### PR TITLE
Implemented Get-SdnInfrastructureInfo to populate global SDN infra in…

### DIFF
--- a/SDNDiagnostics.psd1
+++ b/SDNDiagnostics.psd1
@@ -70,7 +70,8 @@
         'Get-SdnApiResources',
         'Get-SdnNetworkControllerStateFiles',
         'Get-VMNetAdapters',
-        'Start-SdnDataCollection'
+        'Start-SdnDataCollection',
+        'Get-SdnInfrastructureInfo'
     )
 
     # Variables to export from this module


### PR DESCRIPTION
Implemented Get-SdnInfrastructureInfo to populate global SDN infra info and return. 

Plan to use this as single point to populate SDN Infra info for future use. The data collection use NCVM as the only parameter to get all needed data. Other validation function can consume this info when needed to avoid duplicate effort. 