### PR TITLE
Implement Get-SdnVirtualServer to be used by Get-SdnLoadBalancerMuxes 

### DIFF
--- a/src/modules/private/role/networkController.ps1
+++ b/src/modules/private/role/networkController.ps1
@@ -74,3 +74,56 @@ function Invoke-SdnNetworkControllerStateDump {
         "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
     }
 }
+
+function Get-SdnVirtualServer {
+    <#
+    .SYNOPSIS
+        Returns virtual server of a particular resource Id from network controller.
+    .PARAMETER NcUri
+        Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
+
+    .PARAMETER ResourceRef
+        Specifies Resource Ref of virtual server.
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [Uri]$NcUri,
+
+        [Parameter(Mandatory = $true)]
+        [String]$ResourceRef,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$ManagementAddressOnly,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    try {
+        $result = Get-SdnResource -NcUri $NcUri.AbsoluteUri -ResourceRef $ResourceRef -Credential $Credential
+
+        foreach($obj in $result){
+            if($obj.properties.provisioningState -ne 'Succeeded'){
+                "{0} is reporting provisioningState: {1}" -f $obj.resourceId, $obj.properties.provisioningState | Trace-Output -Level:Warning
+            }
+        }
+
+        if($ManagementAddressOnly){
+            # there might be multiple connection endpoints to each node so we will want to only return the unique results
+            # this does not handle if some duplicate connections are listed as IPAddress with another record saved as NetBIOS or FQDN
+            # further processing may be required by the calling function to handle that
+            return ($result.properties.connections.managementAddresses | Sort-Object -Unique)
+        }
+        else{
+            return $result
+        }
+    } 
+    catch {
+        "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
+    }
+}
+

--- a/src/modules/public/role/networkController.ps1
+++ b/src/modules/public/role/networkController.ps1
@@ -189,13 +189,11 @@ function Get-SdnLoadBalancerMuxes {
             }
         }
 
-        if($ResourceIdOnly){
-            return $result.resourceId
-        }elseif($ManagementAddressOnly)
-        {
-            $managementAddresses = @()
+        if($ManagementAddressOnly){
+            $managementAddresses = [System.Collections.ArrayList]::new()
             foreach ($resource in $result) {
-                $managementAddresses += Get-SdnVirtualServer -NcUri $NcUri.AbsoluteUri -ResourceRef $resource.properties.virtualserver.ResourceRef -ManagementAddressOnly -Credential $Credential
+                $virtualServerMgmtAddress = Get-SdnVirtualServer -NcUri $NcUri.AbsoluteUri -ResourceRef $resource.properties.virtualserver.ResourceRef -ManagementAddressOnly -Credential $Credential
+                [void]$managementAddresses.Add($virtualServerMgmtAddress)
             }
             return $managementAddresses
         }
@@ -238,12 +236,11 @@ function Get-SdnGateways {
             }
         }
 
-        if($ResourceIdOnly){
-            return $result.resourceId
-        }elseif($ManagementAddressOnly){
-            $managementAddresses = @()
+        if($ManagementAddressOnly){
+            $managementAddresses = [System.Collections.ArrayList]::new()
             foreach ($resource in $result) {
-                $managementAddresses += Get-SdnVirtualServer -NcUri $NcUri.AbsoluteUri -ResourceRef $resource.properties.virtualserver.ResourceRef -ManagementAddressOnly -Credential $Credential
+                $virtualServerMgmtAddress = Get-SdnVirtualServer -NcUri $NcUri.AbsoluteUri -ResourceRef $resource.properties.virtualserver.ResourceRef -ManagementAddressOnly -Credential $Credential
+                [void]$managementAddresses.Add($virtualServerMgmtAddress)
             }
             return $managementAddresses
         }
@@ -255,59 +252,6 @@ function Get-SdnGateways {
         "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
     }
 }
-
-function Get-SdnVirtualServer {
-    <#
-    .SYNOPSIS
-        Returns virtual server of a particular resource Id from network controller.
-    .PARAMETER NcUri
-        Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
-
-    .PARAMETER ResourceRef
-        Specifies Resource Ref of virtual server.
-    #>
-
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [Uri]$NcUri,
-
-        [Parameter(Mandatory = $true)]
-        [String]$ResourceRef,
-
-        [Parameter(Mandatory = $false)]
-        [switch]$ManagementAddressOnly,
-
-        [Parameter(Mandatory = $false)]
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
-    )
-
-    try {
-        $result = Get-SdnResource -NcUri $NcUri.AbsoluteUri -ResourceRef $ResourceRef -Credential $Credential
-
-        foreach($obj in $result){
-            if($obj.properties.provisioningState -ne 'Succeeded'){
-                "{0} is reporting provisioningState: {1}" -f $obj.resourceId, $obj.properties.provisioningState | Trace-Output -Level:Warning
-            }
-        }
-
-        if($ManagementAddressOnly){
-            # there might be multiple connection endpoints to each node so we will want to only return the unique results
-            # this does not handle if some duplicate connections are listed as IPAddress with another record saved as NetBIOS or FQDN
-            # further processing may be required by the calling function to handle that
-            return ($result.properties.connections.managementAddresses | Sort-Object -Unique)
-        }
-        else{
-            return $result
-        }
-    } 
-    catch {
-        "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
-    }
-}
-
 
 function Get-SdnInfrastructureInfo {
     <#
@@ -358,12 +302,12 @@ function Get-SdnInfrastructureInfo {
 
         if([System.String]::IsNullOrEmpty($Global:SdnDiagnostics.MUX))
         {
-            $Global:SdnDiagnostics.MUX = Get-SdnLoadBalancerMuxes -NcUri $($Global:SdnDiagnostics.NcUrl) -ResourceIdOnly -Credential $NcRestCredential
+            $Global:SdnDiagnostics.MUX = Get-SdnLoadBalancerMuxes -NcUri $($Global:SdnDiagnostics.NcUrl) -ManagementAddressOnly -Credential $NcRestCredential
         }
 
         if([System.String]::IsNullOrEmpty($Global:SdnDiagnostics.Gateway))
         {
-            $Global:SdnDiagnostics.Gateway = Get-SdnGateways -NcUri $($Global:SdnDiagnostics.NcUrl) -ResourceIdOnly -Credential $NcRestCredential
+            $Global:SdnDiagnostics.Gateway = Get-SdnGateways -NcUri $($Global:SdnDiagnostics.NcUrl) -ManagementAddressOnly -Credential $NcRestCredential
         }
 
         if([System.String]::IsNullOrEmpty($Global:SdnDiagnostics.Host))
@@ -374,7 +318,7 @@ function Get-SdnInfrastructureInfo {
 
 
         $SdnInfraInfo = [PSCustomObject]@{
-            RestName = $Global:SdnDiagnostics.NcUrl
+            NcUrl = $Global:SdnDiagnostics.NcUrl
             NC = $Global:SdnDiagnostics.NC
             MUX = $Global:SdnDiagnostics.MUX
             Gateway = $Global:SdnDiagnostics.Gateway


### PR DESCRIPTION
- Implemented Get-SdnVirtualServer under Private folder to return ManagementAddressess of VirtualServer
- Updated Get-SdnLoadbalancerMuxes and Get-SdnGateways to accept -ManagementAddressOnly switch to return LB MUX and Gateway VM Management IP align with Get-SdnServers
- Updated Get-SdnInfrastrucureInfo to use new -ManagementAddressOnly option for LB MUX and Gateway