### PR TITLE
Fix of issue #10

### DIFF
--- a/src/modules/public/utilities.ps1
+++ b/src/modules/public/utilities.ps1
@@ -30,7 +30,7 @@ function Install-SdnDiagnostic {
             Copy-Item -Path $modulePath.FullName -Destination 'C:\Program Files\WindowsPowerShell\Modules' -Recurse -ToSession $session -Force
 
             # ensure that we destroy the current pssessions for the computer to prevent any odd caching issues
-            Get-PSSession -ComputerName $session.ComputerName | Remove-PSSession
+            $session | Remove-PSSession
         }
     }
     catch {


### PR DESCRIPTION
```
PS D:\Temp\SdnDiagnostics> Install-SdnDiagnostic -ComputerName $infra.Host -Verbose
VERBOSE: TraceFile: C:\Windows\Tracing\SdnDataCollection\SdnDiagnostics_TraceOutput_20210727.csv
VERBOSE: SdnDiagnostics module found at D:\Temp\SdnDiagnostics\
VERBOSE: Located existing powershell session WinRM6
Copying D:\Temp\SdnDiagnostics\ to SDNEXP1.Corp.contoso.com via WinRM

 Id Name            ComputerName    ComputerType    State         ConfigurationName     Availability
 -- ----            ------------    ------------    -----         -----------------     ------------
  8 WinRM1          SDNEXP1.Corp... RemoteMachine   Disconnected  Microsoft.PowerShell          Busy
  6 WinRM6          SDNEXP1.Corp... RemoteMachine   Opened        Microsoft.PowerShell     Available


System.Management.Automation.PSInvalidOperationException: Cannot connect the PSSession because the session is not in the Disconnected state, or is not available for connection.
   at System.Management.Automation.RemoteRunspace.Connect()
   at Microsoft.PowerShell.Commands.RemovePSSessionCommand.ProcessRecord()
   at System.Management.Automation.CommandProcessor.ProcessRecord()
at Install-SdnDiagnostic, D:\Temp\SdnDiagnostics\src\modules\public\utilities.ps1: line 35
at <ScriptBlock>, <No file>: line 1
```

There is a strange PSSession generated and ended up with Busy state not able to remove. Proposal is to remove newly get/created PSSession instead of remove all sessions for that computer. 