### PR TITLE
Remove non-Busy session only to avoid exception

### DIFF
--- a/src/modules/public/utilities.ps1
+++ b/src/modules/public/utilities.ps1
@@ -22,7 +22,7 @@ function Install-SdnDiagnostic {
         }
 
         # ensure that we destroy the current pssessions for the computer to prevent any odd caching issues
-        Get-PSSession -ComputerName $ComputerName | Remove-PSSession
+        Get-PSSession -ComputerName $ComputerName | Where Availability -ne "Busy" | Remove-PSSession
     }
     catch {
         "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error


### PR DESCRIPTION
Checked the busy session, it either not change to available/None or disappeared by itself. Update to not touch the busy session, leave it there as that should not cause problems or just disappeared after. 