### PR TITLE
Add function to handle removing PSSessions

### DIFF
--- a/src/modules/private/utilities.ps1
+++ b/src/modules/private/utilities.ps1
@@ -141,15 +141,15 @@ function Confirm-UserInput {
 function New-PSRemotingSession {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $false, ParameterSetName = 'ComputerName')]
+        [Parameter(Mandatory = $true)]
         [string[]]$ComputerName,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'ComputerName')]
+        [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'ComputerName')]
+        [Parameter(Mandatory = $false)]
         [switch]$Force
     )
 
@@ -679,6 +679,54 @@ function Copy-FileToPSRemoteSession {
         }
     }
     catch {
+        "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
+    }
+}
+
+function Remove-PSRemotingSession {
+    <#
+    .SYNOPSIS
+        Gracefully removes any existing PSSessions
+    .PARAMETER ComputerName
+        The computer name(s) that should have any existing PSSessions removed
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [System.String[]]$ComputerName
+    )
+
+    try {
+        [int]$timeOut = 120
+        $stopWatch =  [System.Diagnostics.Stopwatch]::StartNew()
+
+        $sessions = Get-PSSession -ComputerName $ComputerName
+        while($sessions){
+            if($stopWatch.Elapsed.TotalSeconds -gt $timeOut){
+                throw New-Object System.TimeoutException("Unable to drain PSSessions")
+            }
+
+            foreach($session in $sessions){
+                if($session.Availability -ieq 'Busy'){
+                    "{0} is currently {1}. Waiting for PSSession.. {2} seconds" -f $session.Name, $session.Availability, $stopWatch.Elapsed.TotalSeconds | Trace-Output
+                    Start-Sleep -Seconds 5
+                    continue
+                }
+                else {
+                    "Removing PSSession {0}" -f $session.Name | Trace-Output -Level:Verbose
+                    $session | Remove-PSSession -ErrorAction Continue
+                }
+            }
+
+            $sessions = Get-PSSession -ComputerName $ComputerName
+        }
+
+        $stopWatch.Stop()
+        "Successfully drained PSSessions for {0}" -f ($ComputerName -join ', ') | Trace-Output
+    }
+    catch {
+        $stopWatch.Stop()
         "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
     }
 }

--- a/src/modules/public/utilities.ps1
+++ b/src/modules/public/utilities.ps1
@@ -22,7 +22,7 @@ function Install-SdnDiagnostic {
         }
 
         # ensure that we destroy the current pssessions for the computer to prevent any odd caching issues
-        Get-PSSession -ComputerName $ComputerName | Where Availability -ne "Busy" | Remove-PSSession
+        Remove-PSRemotingSession -ComputerName $ComputerName
     }
     catch {
         "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error


### PR DESCRIPTION
- Added new private function called Remove-PSRemotingSession to be leveraged when tearing down existing sessions
- Built in timeout of 120 seconds (2 minutes) to ensure that we can bail out within a timely fashion and are not stalled


![image](https://user-images.githubusercontent.com/18577812/127350449-f4204d76-8713-4302-b021-60432dac03e8.png)

