### PR TITLE
Fix build version issue 

### DIFF
--- a/.build/generate-version.ps1
+++ b/.build/generate-version.ps1
@@ -3,7 +3,7 @@ $referenceDate = [datetime]"2021-07-15 00:00:00Z"
 $major = [int]((([DateTime]::UtcNow - $referenceDate).Days / 365) +1) # years since reference date
 $minor = [DateTime]::UtcNow.Year.ToString().Substring(2,2) + [DateTime]::UtcNow.Month.ToString().PadLeft(2,"0") # 2002, 2104, etc for current month
 $patch = ([DateTime]::UtcNow - $referenceDate).Days # days since reference date
-$revision = "{0}{1}{2}" -f ([DateTime]::UtcNow.Hour),([DateTime]::UtcNow.Minute),([DateTime]::UtcNow.Second) # creates revision based on hour, minute and second
+$revision = "{0:d2}{1:d2}{2:d2}" -f ([DateTime]::UtcNow.Hour),([DateTime]::UtcNow.Minute),([DateTime]::UtcNow.Second) # creates revision based on hour, minute and second
 $buildNumber = "{0}.{1}.{2}.{3}" -f $major, $minor, $patch, $revision
 
 [Environment]::SetEnvironmentVariable("SdnDiagCustomBuildNumber", $buildNumber)  # This will allow you to use it from env var in later steps of the same phase


### PR DESCRIPTION
Fix build version issue that new revision number can be lower then old version. 

- Added leading zero for hours,minutes,seconds that used to generate revision number this will ensure revision number always increase in the same day. 