### PR TITLE
Fix of issue invalid info cached due to exception

### DIFF
--- a/src/modules/public/role/networkController.ps1
+++ b/src/modules/public/role/networkController.ps1
@@ -323,6 +323,12 @@ function Get-SdnInfrastructureInfo {
         return $Global:SdnDiagnostics.EnvironmentInfo
     } 
     catch {
+        # Remove any cached info in case of exception as the cached info might be incorrect
+        $Global:SdnDiagnostics.EnvironmentInfo.NcUrl = $null
+        $Global:SdnDiagnostics.EnvironmentInfo.NC = $null
+        $Global:SdnDiagnostics.EnvironmentInfo.MUX = $null
+        $Global:SdnDiagnostics.EnvironmentInfo.Gateway = $null
+        $Global:SdnDiagnostics.EnvironmentInfo.Host = $null
         "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
     }
 }


### PR DESCRIPTION
The cached info at $Global:SdnDiagnostics.EnvironmentInfo need to be removed in case of any exception cached