### PR TITLE
fix issue for test encap failed when jumbo packet disabled

### DIFF
--- a/src/modules/public/role/server.ps1
+++ b/src/modules/public/role/server.ps1
@@ -937,7 +937,7 @@ function Get-NetworkInterfaceEncapOverheadSetting {
                 }
                 else {
                     $supportsJumboPacket = $true
-                    [int]$jumboPacketValue = $jumboPacket.DisplayValue
+                    [int]$jumboPacketValue = $jumboPacket.RegistryValue[0]
                 }
 
                 $object = [PSCustomObject]@{


### PR DESCRIPTION
- The jumbo packet DisplayValue will show as disabled and indicate default value as 1514 at RegistryValue. Fix is to return RegistryValue instead of DisplayValue