### PR TITLE
Convert reference date to UTC

### DIFF
--- a/.build/generate-version.ps1
+++ b/.build/generate-version.ps1
@@ -1,4 +1,4 @@
-$referenceDate = [datetime]"2021-07-15 00:00:00Z"
+$referenceDate = ([datetime]"2021-07-15 00:00:00Z").ToUniversalTime()
 
 $major = [int]((([DateTime]::UtcNow - $referenceDate).Days / 365) +1) # years since reference date
 $minor = [DateTime]::UtcNow.Year.ToString().Substring(2,2) + [DateTime]::UtcNow.Month.ToString().PadLeft(2,"0") # 2002, 2104, etc for current month


### PR DESCRIPTION
- The current $referenceDate is generated from UTC time of 2021-07-15 00:00:00 when convert to datetime. the datatime object generated is with current machine time zone. 
- When compare the current time with that $referenceDate to generate patch day
`$patch = ([DateTime]::UtcNow - $referenceDate).Days`
The two object can be different time zone cause cause incorrect result of day offset since reference day. 
- As a result, the build number generated is not always increasing. 