### PR TITLE
Created new sdn2019 workflow for PR, updated old sdn2019 flow for Push

### DIFF
--- a/.github/workflows/server2019-sdntest-pr.yml
+++ b/.github/workflows/server2019-sdntest-pr.yml
@@ -1,11 +1,11 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Server2019SDN
+name: Server2019SDNPullRequest
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push request events but only for the main branch
-  push:
+  # Triggers the workflow on pull request events but only for the main branch
+  pull_request:
     branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout SdnDiagnostics repo
         uses: actions/checkout@v2
         with: 
-          ref: main
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Runs a single command using the runners shell
       - name: Build SdnDiagnostics module


### PR DESCRIPTION
# Description
Summary of changes:
- The current SDN2019 workflow run on PR event but use main branch hash not use the PR commit hash. Create a new SDN2019 workflow to be triggered only when PR and use PR commit hash
- Current SDN2019 workflow is updated to run only on Push event

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [x] Other

# Checklist:
- [ ] My code follows the style and contribution guidelines of this project.
- [ ] I have tested and validated my code changes.