### PR TITLE
Fix issue that Get-SdnInfrastructureInfo test use incorrect credential

### DIFF
--- a/tests/online/waveAll/Role.NetworkController.Tests.ps1
+++ b/tests/online/waveAll/Role.NetworkController.Tests.ps1
@@ -1,24 +1,24 @@
 # Pester tests
 Describe 'Get-SdnInfrastructureInfo test' { 
   It "Able to retreive NCUrl" {
-      $infraInfo = Get-SdnInfrastructureInfo -NetworkController $Global:PesterOnlineTests.configdata.NcVM -NcRestCredential $Global:PesterOfflineTests.NcRestCredential
+      $infraInfo = Get-SdnInfrastructureInfo -NetworkController $Global:PesterOnlineTests.configdata.NcVM -NcRestCredential $Global:PesterOnlineTests.NcRestCredential
       $infraInfo.NCUrl | Should -not -BeNullOrEmpty
   }
   It "All NC retrieved" {
-    $infraInfo = Get-SdnInfrastructureInfo -NetworkController $Global:PesterOnlineTests.configdata.NcVM -NcRestCredential $Global:PesterOfflineTests.NcRestCredential
+    $infraInfo = Get-SdnInfrastructureInfo -NetworkController $Global:PesterOnlineTests.configdata.NcVM -NcRestCredential $Global:PesterOnlineTests.NcRestCredential
     $infraInfo.NC.Count | Should -Be $Global:PesterOnlineTests.ConfigData.NumberOfNc
   }
   It "All MUX retrieved" {
-    $infraInfo = Get-SdnInfrastructureInfo -NetworkController $Global:PesterOnlineTests.configdata.NcVM -NcRestCredential $Global:PesterOfflineTests.NcRestCredential
+    $infraInfo = Get-SdnInfrastructureInfo -NetworkController $Global:PesterOnlineTests.configdata.NcVM -NcRestCredential $Global:PesterOnlineTests.NcRestCredential
     $infraInfo.Mux.Count | Should -Be $Global:PesterOnlineTests.ConfigData.NumberOfMux
   }
   It "All Gateway retrieved" {
-    $infraInfo = Get-SdnInfrastructureInfo -NetworkController $Global:PesterOnlineTests.configdata.NcVM -NcRestCredential $Global:PesterOfflineTests.NcRestCredential
+    $infraInfo = Get-SdnInfrastructureInfo -NetworkController $Global:PesterOnlineTests.configdata.NcVM -NcRestCredential $Global:PesterOnlineTests.NcRestCredential
     $infraInfo.Gateway.Count | Should -Be $Global:PesterOnlineTests.ConfigData.NumberOfGateway
   }
 
   It "All Server retrieved" {
-    $infraInfo = Get-SdnInfrastructureInfo -NetworkController $Global:PesterOnlineTests.configdata.NcVM -NcRestCredential $Global:PesterOfflineTests.NcRestCredential
+    $infraInfo = Get-SdnInfrastructureInfo -NetworkController $Global:PesterOnlineTests.configdata.NcVM -NcRestCredential $Global:PesterOnlineTests.NcRestCredential
     $infraInfo.Host.Count | Should -Be $Global:PesterOnlineTests.ConfigData.NumberOfServer
   }
 }


### PR DESCRIPTION

# Description
Summary of changes:
- Pester Online Test for Get-SdnInfrastructureInfo incorrectly used NcRestCredential 

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.