### PR TITLE
Data Collection bug fix

### DIFF
--- a/src/SdnDiagnostics.psd1
+++ b/src/SdnDiagnostics.psd1
@@ -81,7 +81,8 @@
         'Invoke-SdnServiceFabricCommand',
         'Move-SdnServiceFabricReplica',
         'Start-EtwTraceCapture',
-        'Start-NetshTrace'
+        'Start-SdnDataCollection',
+        'Start-NetshTrace',
         'Stop-EtwTraceCapture',
         'Stop-NetshTrace',
         'Test-SdnKINetworkInterfaceAPIDuplicateMacAddress',

--- a/src/modules/NetworkController/public/Get-SdnNetworkControllerState.ps1
+++ b/src/modules/NetworkController/public/Get-SdnNetworkControllerState.ps1
@@ -15,7 +15,7 @@ function Get-SdnNetworkControllerState {
 		Specifies a user account that has permission to access the northbound NC API interface. The default is the current user.
     .PARAMETER ExecutionTimeout
         Specify the execution timeout (seconds) on how long you want to wait for operation to complete before cancelling operation. If omitted, defaults to 300 seconds.
-    .EXAMPLE 
+    .EXAMPLE
         PS> Get-SdnNcImosDumpFiles -NcUri "https://nc.contoso.com" -NetworkController $NetworkControllers -OutputDirectory "C:\Temp\CSS_SDN"
     #>
 
@@ -54,7 +54,7 @@ function Get-SdnNetworkControllerState {
                 if (Test-Path -Path $using:netControllerStatePath.FullName -PathType Container) {
                     Get-Item -Path $using:netControllerStatePath.FullName | Remove-Item -Recurse -Confirm:$false -Force -ErrorAction SilentlyContinue
                 }
-    
+
                 $null = New-Item -Path $using:netControllerStatePath.FullName -ItemType Container -Force
             }
             catch {
@@ -64,16 +64,16 @@ function Get-SdnNetworkControllerState {
 
         $infraInfo = Get-SdnInfrastructureInfo -NetworkController $NetworkController -Credential $Credential -NcRestCredential $NcRestCredential
         # invoke scriptblock to clean up any stale NetworkControllerState files
-        Invoke-PSRemoteCommand -ComputerName $infraInfo.NC -ScriptBlock $scriptBlock -Credential $Credential
+        Invoke-PSRemoteCommand -ComputerName $infraInfo.NetworkController -ScriptBlock $scriptBlock -Credential $Credential
 
         # invoke the call to generate the files
         # once the operation completes and returns true, then enumerate through the Network Controllers defined to collect the files
         $result = Invoke-SdnNetworkControllerStateDump -NcUri $infraInfo.NcUrl -Credential $NcRestCredential -ExecutionTimeOut $ExecutionTimeOut
         if ($result) {
-            foreach ($ncVM in $infraInfo.NC) {
+            foreach ($ncVM in $infraInfo.NetworkController) {
                 Copy-FileFromRemoteComputer -Path "$($config.properties.netControllerStatePath)\*" -ComputerName $ncVM -Destination $outputDir.FullName
             }
-        }        
+        }
     }
     catch {
         "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error


### PR DESCRIPTION
# Description
Summary of changes:
- Exported function Start-SdnDataCollection.
- Changed log dir to c:\Temp\CSS_SDN during log collection on remote nodes and copy files from that location to local log collection after finished.
- Saved SlbState to SlbState.json file
- Moved function `Get-SdnProviderAddress`, `Get-SdnVfpVmSwitchPort`, `Get-SdnVMNetworkAdapter` to server role as other role might get empty ServerNodes
- Bug fix of Get-SdnNetworkControllerState due to change of global environment info.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.