### PR TITLE
Convert VMState enum to string when compare the VM state

### DIFF
--- a/src/modules/Server/public/Get-SdnVMNetworkAdapter.ps1
+++ b/src/modules/Server/public/Get-SdnVMNetworkAdapter.ps1
@@ -51,7 +51,7 @@ function Get-SdnVMNetworkAdapter {
 
     try {
         $scriptBlock = {
-            $virtualMachines = Get-VM | Where-Object { $_.State -eq $using:VmState }
+            $virtualMachines = Get-VM | Where-Object { $_.State -eq [String]$using:VmState }
             $virtualMachines | Get-VMNetworkAdapter
         }
 


### PR DESCRIPTION
# Description
Summary of changes:
- Convert VMState enum to string when compare the VM state. To fix issue that Get-SdnVMNetworkAdapter returned nothing due to incorrect VM State detected.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.