### PR TITLE
Add Get-VfpPortState function

### DIFF
--- a/src/SdnDiagnostics.psd1
+++ b/src/SdnDiagnostics.psd1
@@ -76,6 +76,7 @@
         'Get-VfpPortGroup',
         'Get-VfpPortLayer',
         'Get-VfpPortRule',
+        'Get-VfpPortState',
         'Get-VMNetworkAdapterPortProfile',
         'Install-SdnDiagnostics',
         'Invoke-SdnGetNetView',

--- a/src/modules/Server/public/Get-SdnServerConfigurationState.ps1
+++ b/src/modules/Server/public/Get-SdnServerConfigurationState.ps1
@@ -47,12 +47,15 @@ function Get-SdnServerConfigurationState {
                     vfpctrl /get-port-flow-stats /port $($port.Name) | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix 'PortFlowStats' -Name $port.Name -FileType txt
                     vfpctrl /get-flow-stats /port $($port.Name) | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix 'FlowStats' -Name $port.Name -FileType txt
                     vfpctrl /get-port-state /port $($port.Name) | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix 'PortState' -Name $port.Name -FileType txt
+
+                    Get-VfpPortState -PortId $($port.Name) | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix 'PortState' -Name $port.Name -FileType json
                 }
             }
         }
 
         vfpctrl /list-vmswitch-port | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'vfpctrl_list-vmswitch-port' -FileType json
         Get-SdnVfpVmSwitchPort | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-SdnVfpVmSwitchPort' -FileType csv
+        Get-SdnVfpVmSwitchPort | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-SdnVfpVmSwitchPort' -FileType json
 
         # Gather OVSDB databases
         "Gathering ovsdb database output" | Trace-Output -Level:Verbose

--- a/src/modules/Server/public/Get-SdnServerConfigurationState.ps1
+++ b/src/modules/Server/public/Get-SdnServerConfigurationState.ps1
@@ -46,6 +46,7 @@ function Get-SdnServerConfigurationState {
                     vfpctrl /get-port-flow-settings /port $($port.Name) | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix 'PortFlowSettings' -Name $port.Name -FileType txt
                     vfpctrl /get-port-flow-stats /port $($port.Name) | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix 'PortFlowStats' -Name $port.Name -FileType txt
                     vfpctrl /get-flow-stats /port $($port.Name) | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix 'FlowStats' -Name $port.Name -FileType txt
+                    vfpctrl /get-port-state /port $($port.Name) | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix 'PortState' -Name $port.Name -FileType txt
                 }
             }
         }

--- a/src/modules/Server/public/Get-VfpPortState.ps1
+++ b/src/modules/Server/public/Get-VfpPortState.ps1
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function Get-VfpPortState {
+    <#
+    .SYNOPSIS
+        Returns the current VFP port state for a particular port Id.
+    .DESCRIPTION
+        Executes 'vfpctrl.exe /get-port-state /port $PortId' to return back the current state of the port specified.
+    .PARAMETER PortId
+        The Port ID GUID for the network interface.
+    .EXAMPLE
+        PS> Get-VfpPortState -PortId 3DC59D2B-9BFE-4996-AEB6-2589BD20B559
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [GUID]$PortId,
+    )
+
+    try {
+        $object = New-Object -TypeName PSObject
+
+        $vfpPortState = vfpctrl.exe /get-port-state /port $PortId
+        if ($null -eq $vfpPortState) {
+            $msg = "Unable to locate port ID {0} from vfpctrl`n{1}" -f $PortId, $_
+            throw New-Object System.NullReferenceException($msg)
+        }
+
+        foreach ($line in $vfpPortState) {
+            $trimmedLine = $line.Replace(':','').Trim()
+
+            # since we are explicitly looking for true/false in this statement, we will convert the value to boolean when adding to the object
+            if ($trimmedLine -match '(.*)\s+(True|False)') {
+                $object | Add-Member -MemberType NoteProperty -Name $Matches.1 -Value ([System.Convert]::ToBoolean($Matches.2))
+                continue
+            }
+
+            # look for enabled/disabled and then seperate out the key/value pairs
+            if ($trimmedLine -match '(.*)\s+(Enabled|Disabled)') {
+                $object | Add-Member -MemberType NoteProperty -Name $Matches.1 -Value $Matches.2
+                continue
+            }
+        }
+    }
+    catch {
+        "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
+    }
+}

--- a/src/modules/Server/public/Get-VfpPortState.ps1
+++ b/src/modules/Server/public/Get-VfpPortState.ps1
@@ -16,7 +16,7 @@ function Get-VfpPortState {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [GUID]$PortId,
+        [GUID]$PortId
     )
 
     try {

--- a/src/modules/Server/public/Get-VfpPortState.ps1
+++ b/src/modules/Server/public/Get-VfpPortState.ps1
@@ -31,7 +31,8 @@ function Get-VfpPortState {
         foreach ($line in $vfpPortState) {
             $trimmedLine = $line.Replace(':','').Trim()
 
-            # since we are explicitly looking for true/false in this statement, we will convert the value to boolean when adding to the object
+            # look for true/false and then seperate out the key/value pairs
+            # we will convert the true/false values to boolean when adding to the object
             if ($trimmedLine -match '(.*)\s+(True|False)') {
                 $object | Add-Member -MemberType NoteProperty -Name $Matches.1 -Value ([System.Convert]::ToBoolean($Matches.2))
                 continue


### PR DESCRIPTION
# Description
Summary of changes:
- Add a new exported function to server module called `Get-VfpPortState` which can be leveraged to query the port state from VFP and return PSObject that can be consumed by other functions.
- Updated the `Get-SdnServerConfigurationState` function to leverage the new function as well as add a few other minor changes to collect more data

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.