### PR TITLE
User/arudell/argument completers

### DIFF
--- a/.build/validate-functions.ps1
+++ b/.build/validate-functions.ps1
@@ -1,21 +1,19 @@
-$files = Get-ChildItem -Path "$PSScriptRoot\..\src\*" -Include "*.ps1" -Exclude "settings.ps1" -Recurse
-foreach($file in $files){
-    # skip .ps1 files contained within the enum directory
-    if($file.FullName -ilike "*\src\enum\*.ps1"){
-        continue
-    }
-    
+$files = Get-ChildItem -Path "$PSScriptRoot\..\src\*" -Include "*.ps1" -Recurse
+foreach ($file in $files) {
     $code = Get-Content -Path $file.FullName -Raw
+    $functionName = [Management.Automation.Language.Parser]::ParseInput($code, [ref]$null, [ref]$null).EndBlock.Statements.FindAll([Func[Management.Automation.Language.Ast,bool]]{$args[0] `
+        -is [Management.Automation.Language.FunctionDefinitionAst]}, $false) | Select-Object -ExpandProperty Name
 
-    $functionName = [Management.Automation.Language.Parser]::ParseInput($code, [ref]$null, [ref]$null).EndBlock.Statements.FindAll([Func[Management.Automation.Language.Ast,bool]]{$args[0] -is [Management.Automation.Language.FunctionDefinitionAst]}, $false) `
-        | Select-Object -ExpandProperty Name
+    # if functions identified within the file, enumerate them to ensure we have a single function per file
+    # and that the function name matches the file name for consistency with the module
+    if ($functionName) {
+        if ($functionName.Count -gt 1) {
+            "{0} contains {1} functions. Please look to split these functions into their own individual files." -f $file.FullName, $functionName.Count | Write-Host -ForegroundColor:Yellow
+            continue
+        }
 
-    if($functionName.Count -gt 1){
-        "{0} contains {1} functions. Please look to split these functions into their own individual files." -f $file.FullName, $functionName.Count | Write-Host -ForegroundColor:Yellow
-        continue
-    }
-
-    if($file.BaseName -ine $functionName){
-        "{0} does not match function name {1}" -f $file.FullName, $functionName | Write-Host -ForegroundColor:Yellow
+        if ($file.BaseName -ine $functionName) {
+            "{0} does not match function name {1}" -f $file.FullName, $functionName | Write-Host -ForegroundColor:Yellow
+        }
     }
 }

--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -22,5 +22,6 @@ foreach($item in Get-ChildItem -Path "$PSScriptRoot\knownIssues" -Recurse -Inclu
 }
 
 . "$PSScriptRoot\config\settings.ps1"
+. "$PSScriptRoot\config\ArgumentCompleters.ps1"
 
 $ErrorActionPreference = 'Continue'

--- a/src/config/ArgumentCompleters.ps1
+++ b/src/config/ArgumentCompleters.ps1
@@ -1,0 +1,90 @@
+$scriptBlocks = @{
+    AllFabricNodes = {
+        param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+        $computerName = $Global:SdnDiagnostics.EnvironmentInfo.FabricNodes
+
+        if ([string]::IsNullOrEmpty($wordToComplete)) {
+            return ($computerName | Sort-Object)
+        }
+
+        return $computerName | Where-Object {$_ -like "*$wordToComplete*"} | Sort-Object
+    }
+
+    GatewayNodes = {
+        param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+        $computerName = $Global:SdnDiagnostics.EnvironmentInfo.Gateway
+
+        if ([string]::IsNullOrEmpty($wordToComplete)) {
+            return ($computerName | Sort-Object)
+        }
+
+        return $computerName | Where-Object {$_ -like "*$wordToComplete*"} | Sort-Object
+    }
+
+    NetworkControllerNodes = {
+        param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+        $computerName = $Global:SdnDiagnostics.EnvironmentInfo.NetworkController
+
+        if ([string]::IsNullOrEmpty($wordToComplete)) {
+            return ($computerName | Sort-Object)
+        }
+
+        return $computerName | Where-Object {$_ -like "*$wordToComplete*"} | Sort-Object
+    }
+
+    ServerNodes = {
+        param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+        $computerName = $Global:SdnDiagnostics.EnvironmentInfo.Server
+
+        if ([string]::IsNullOrEmpty($wordToComplete)) {
+            return ($computerName | Sort-Object)
+        }
+
+        return $computerName | Where-Object {$_ -like "*$wordToComplete*"} | Sort-Object
+    }
+
+    SoftwareLoadBalancerNodes = {
+        param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+        $computerName = $Global:SdnDiagnostics.EnvironmentInfo.SoftwareLoadBalancer
+
+        if ([string]::IsNullOrEmpty($wordToComplete)) {
+            return ($computerName | Sort-Object)
+        }
+
+        return $computerName | Where-Object {$_ -like "*$wordToComplete*"} | Sort-Object
+    }
+}
+
+Register-ArgumentCompleter -CommandName Invoke-Command -ParameterName 'ComputerName' -ScriptBlock $scriptBlocks.AllFabricNodes
+
+$networkControllerParamCommands = (
+    'Debug-SdnFabricInfrastructure',
+    'Test-SdnKnownIssue',
+    'Start-SdnDataCollection',
+    'Get-SdnNetworkController',
+    'Get-SdnNetworkControllerClusterInfo',
+    'Get-SdnNetworkControllerState',
+    'Get-SdnServiceFabricApplicationHealth',
+    'Get-SdnServiceFabricClusterHealth',
+    'Get-SdnServiceFabricClusterManifest',
+    'Get-SdnServiceFabricNode',
+    'Get-SdnServiceFabricReplica',
+    'Get-SdnServiceFabricService',
+    'Invoke-SdnServiceFabricCommand',
+    'Move-SdnServiceFabricReplica'
+)
+
+Register-ArgumentCompleter -CommandName $networkControllerParamCommands -ParameterName 'NetworkController' -ScriptBlock $scriptBlocks.NetworkControllerNodes
+
+$serverParamCommands = (
+    'Get-SdnOvsdbAddressMapping',
+    'Get-SdnOvsdbFirewallRuleTable',
+    'Get-SdnOvsdbGlobalTable',
+    'Get-SdnOvsdbPhysicalPortTable',
+    'Get-SdnOvsdbUcastMacRemoteTable',
+    'Get-SdnProviderAddress',
+    'Get-SdnVfpVmSwitchPort',
+    'Get-SdnVMNetworkAdapter'
+)
+
+Register-ArgumentCompleter -CommandName $serverParamCommands -ParameterName 'ComputerName' -ScriptBlock $scriptBlocks.ServerNodes


### PR DESCRIPTION
# Description
Summary of changes:
- Added Argument Completers to allow tab-completion of `ComputerName` and `NetworkController` if the `$Global:SdnDiagnostics.EnvironmentInfo` cache has been populated
- Updated build pipeline to only do function name validation of ps1 files that contain a function

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.