### PR TITLE
Improve handling of session creation for IP Addresses

### DIFF
--- a/src/modules/Utilities/private/New-PSRemotingSession.ps1
+++ b/src/modules/Utilities/private/New-PSRemotingSession.ps1
@@ -5,7 +5,7 @@ function New-PSRemotingSession {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [string[]]$ComputerName,
+        [System.String[]]$ComputerName,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
@@ -13,17 +13,15 @@ function New-PSRemotingSession {
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Parameter(Mandatory = $false)]
-        [switch]$Force
+        [Switch]$Force
     )
 
     try {
-
-        if((Get-Service -Name WinRM).Status -ine 'Running'){
-            $service = Start-Service -Name WinRM -PassThru
-            if($service.Status -ine 'Running'){
-                $msg = "Unable to start WinRM service`n`t{0}" -f $_
-                throw New-Object System.Exception($msg)
-            }
+        # ensure that WinRM service is running on the local machine
+        $serviceState = Get-Service -Name 'WinRm'
+        if($serviceState.Status -ine 'Running'){
+            $msg = "WinRM Service is currently {0}. Ensure that service is running and try again." -f $serviceState.Status
+            throw New-Object System.Exception($msg)
         }
 
         $remoteSessions = [System.Collections.ArrayList]::new()
@@ -33,15 +31,14 @@ function New-PSRemotingSession {
         # without having to wait for existing sessions to move from Busy -> Available
         $currentActiveSessions = Get-PSSession -Name "SdnDiag-*" | Where-Object {$_.State -ieq 'Opened' -and $_.Availability -ieq 'Available'}
 
-        $remoteSessions = [System.Collections.ArrayList]::new()
         foreach($obj in $ComputerName){
-
             $session = $null
 
             # determine if an IP address was passed for the destination
             # if using IP address it needs to be added to the trusted hosts
             $isIpAddress = ($obj -as [IPAddress]) -as [Bool]
             if($isIpAddress){
+                "{0} is an ip address" -f $obj | Trace-Output -Level:Verbose
                 $trustedHosts = Get-Item -Path "WSMan:\localhost\client\TrustedHosts"
                 if($trustedHosts.Value -notlike "*$obj*" -and $trustedHosts.Value -ne "*") {
                     "Adding {0} to {1}" -f $obj, $trustedHosts.PSPath | Trace-Output
@@ -62,6 +59,13 @@ function New-PSRemotingSession {
                         $session = New-PSSession -Name "SdnDiag-$(Get-Random)" -ComputerName $obj -Credential $Credential -SessionOption (New-PSSessionOption -Culture en-US -UICulture en-US) -ErrorAction Stop
                     }
                     else {
+                        # if we need to create a new remote session, need to check to ensure that if using an IP Address that credentials are specified
+                        # which is a requirement from a WinRM perspective. Will throw a warning and skip session creation for this computer.
+                        if ($isIpAddress -and $Credential -eq [System.Management.Automation.PSCredential]::Empty) {
+                            "Unable to create PSSession to {0}. Credential parameter is required when using an IP Address" -f $obj | Trace-Output -Level:Warning
+                            continue
+                        }
+
                         "PSRemotingSession use default credential" | Trace-Output -Level:Verbose
                         $session = New-PSSession -Name "SdnDiag-$(Get-Random)" -ComputerName $obj -SessionOption (New-PSSessionOption -Culture en-US -UICulture en-US) -ErrorAction Stop
                     }

--- a/src/modules/Utilities/private/New-PSRemotingSession.ps1
+++ b/src/modules/Utilities/private/New-PSRemotingSession.ps1
@@ -62,7 +62,7 @@ function New-PSRemotingSession {
                         # if we need to create a new remote session, need to check to ensure that if using an IP Address that credentials are specified
                         # which is a requirement from a WinRM perspective. Will throw a warning and skip session creation for this computer.
                         if ($isIpAddress -and $Credential -eq [System.Management.Automation.PSCredential]::Empty) {
-                            "Unable to create PSSession to {0}. Credential parameter is required when using an IP Address" -f $obj | Trace-Output -Level:Warning
+                            "Unable to create PSSession to {0}. The Credential parameter is required when using an IP Address." -f $obj | Trace-Output -Level:Warning
                             continue
                         }
 


### PR DESCRIPTION
# Description
Summary of changes:
- Improved logging to better detect if using IP address
- Throw terminating exception if WinRM not running vs trying to start service w/o user consent
- Skip session creation if using an IP address and credentials are not specified (non-terminating)

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.