### PR TITLE
Remove the output in PS Remote for Test-SdnKINetworkControllerCertCredential 

### DIFF
--- a/src/knownIssues/Test-SdnKINetworkControllerCertCredential.ps1
+++ b/src/knownIssues/Test-SdnKINetworkControllerCertCredential.ps1
@@ -88,7 +88,6 @@ function Test-SdnKINetworkControllerCertCredential {
                 $thumbPrint = $credObj.properties.value
                 $scriptBlock = {
                     if (-NOT (Test-Path -Path Cert:\LocalMachine\My\$using:thumbPrint)) {
-                        "Certificate with thumbprint $using:thumbPrint not found" | Trace-Output -Level:Warning
                         return $false
                     }
                     else {


### PR DESCRIPTION
# Description
Remove the output in PS Remote for Test-SdnKINetworkControllerCertCredential. 

- changes
Save all results into KI return instead of output on the screen. 

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.