### PR TITLE
Updated several command to support run from NC directly

### DIFF
--- a/src/health/Debug-SdnFabricInfrastructure.ps1
+++ b/src/health/Debug-SdnFabricInfrastructure.ps1
@@ -51,6 +51,15 @@ function Debug-SdnFabricInfrastructure {
             $Global:SdnDiagnostics.NcRestCredential = $NcRestCredential
         }
 
+        if (-NOT ($PSBoundParameters.ContainsKey('NetworkController'))) {
+            $config = Get-SdnRoleConfiguration -Role 'NetworkController'
+            $confirmFeatures = Confirm-RequiredFeaturesInstalled -Name $config.windowsFeature
+            if (-NOT ($confirmFeatures)) {
+                "The current machine is not a NetworkController, run this on NetworkController or use -NetworkController parameter to specify one" | Trace-Output -Level:Warning
+                return # don't throw exception, since this is a controlled scenario and we do not need stack exception tracing
+            }
+        }
+
         $environmentInfo = Get-SdnInfrastructureInfo -NetworkController $NetworkController -Credential $Credential -NcRestCredential $NcRestCredential
         if($null -eq $environmentInfo){
             throw New-Object System.NullReferenceException("Unable to retrieve environment details")

--- a/src/health/Debug-SdnFabricInfrastructure.ps1
+++ b/src/health/Debug-SdnFabricInfrastructure.ps1
@@ -6,7 +6,7 @@ function Debug-SdnFabricInfrastructure {
     .SYNOPSIS
         Executes a series of fabric validation tests to validate the state and health of the underlying components within the SDN fabric.
     .PARAMETER NetworkController
-        Specifies the name or IP address of the network controller node on which this cmdlet operates.
+        Specifies the name or IP address of the network controller node on which this cmdlet operates. The parameter is optional if running on network controller node.
 	.PARAMETER Credential
 		Specifies a user account that has permission to perform this action. The default is the current user.
 	.PARAMETER NcRestCredential
@@ -19,8 +19,8 @@ function Debug-SdnFabricInfrastructure {
 
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
-        [System.String]$NetworkController,
+        [Parameter(Mandatory = $false)]
+        [System.String]$NetworkController = $(HostName),
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]

--- a/src/knownIssues/Test-SdnKnownIssue.ps1
+++ b/src/knownIssues/Test-SdnKnownIssue.ps1
@@ -6,21 +6,21 @@ function Test-SdnKnownIssue {
     .SYNOPSIS
         Executes a series of detection scripts to isolate well known issues that may cause impact to workloads running on the SDN fabric.
     .PARAMETER NetworkController
-        Specifies the name or IP address of the network controller node on which this cmdlet operates.
+        Specifies the name or IP address of the network controller node on which this cmdlet operates. The parameter is optional if running on network controller node.
 	.PARAMETER Credential
 		Specifies a user account that has permission to perform this action. The default is the current user.
 	.PARAMETER NcRestCredential
 		Specifies a user account that has permission to access the northbound NC API interface. The default is the current user.
     .EXAMPLE
-        PS> Debug-SdnFabricInfrastructure
+        PS> Test-SdnKnownIssue
     .EXAMPLE
-        PS> Debug-SdnFabricInfrastructure -NetworkController 'NC01' -Credential (Get-Credential) -NcRestCredential (Get-Credential)
+        PS> Test-SdnKnownIssue -NetworkController 'NC01' -Credential (Get-Credential) -NcRestCredential (Get-Credential)
     #>
 
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
-        [System.String]$NetworkController,
+        [Parameter(Mandatory = $false)]
+        [System.String]$NetworkController = $(HostName),
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]

--- a/src/knownIssues/Test-SdnKnownIssue.ps1
+++ b/src/knownIssues/Test-SdnKnownIssue.ps1
@@ -51,6 +51,15 @@ function Test-SdnKnownIssue {
             $Global:SdnDiagnostics.NcRestCredential = $NcRestCredential
         }
 
+        if (-NOT ($PSBoundParameters.ContainsKey('NetworkController'))) {
+            $config = Get-SdnRoleConfiguration -Role 'NetworkController'
+            $confirmFeatures = Confirm-RequiredFeaturesInstalled -Name $config.windowsFeature
+            if (-NOT ($confirmFeatures)) {
+                "The current machine is not a NetworkController, run this on NetworkController or use -NetworkController parameter to specify one" | Trace-Output -Level:Warning
+                return # don't throw exception, since this is a controlled scenario and we do not need stack exception tracing
+            }
+        }
+
         $environmentInfo = Get-SdnInfrastructureInfo -NetworkController $NetworkController -Credential $Credential -NcRestCredential $NcRestCredential
         if ($null -eq $environmentInfo) {
             throw New-Object System.NullReferenceException("Unable to retrieve environment details")

--- a/src/modules/Common/public/Start-SdnDataCollection.ps1
+++ b/src/modules/Common/public/Start-SdnDataCollection.ps1
@@ -7,7 +7,7 @@ function Start-SdnDataCollection {
     .SYNOPSIS
         Automated data collection script to pull the current configuration state in conjuction with diagnostic logs and other data points used for debugging.
     .PARAMETER NetworkController
-        Specifies the name or IP address of the network controller node on which this cmdlet operates.
+        Specifies the name or IP address of the network controller node on which this cmdlet operates. The parameter is optional if running on network controller node.
     .PARAMETER NcUri
         Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
     .PARAMETER Role
@@ -40,9 +40,9 @@ function Start-SdnDataCollection {
 
     [CmdletBinding(DefaultParameterSetName = 'Role')]
     param (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Role')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'Computer')]
-        [System.String]$NetworkController,
+        [Parameter(Mandatory = $false, ParameterSetName = 'Role')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Computer')]
+        [System.String]$NetworkController = $(HostName),
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Role')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Computer')]

--- a/src/modules/Common/public/Start-SdnDataCollection.ps1
+++ b/src/modules/Common/public/Start-SdnDataCollection.ps1
@@ -93,6 +93,15 @@ function Start-SdnDataCollection {
     )
 
     try {
+        if (-NOT ($PSBoundParameters.ContainsKey('NetworkController'))) {
+            $config = Get-SdnRoleConfiguration -Role 'NetworkController'
+            $confirmFeatures = Confirm-RequiredFeaturesInstalled -Name $config.windowsFeature
+            if (-NOT ($confirmFeatures)) {
+                "The current machine is not a NetworkController, run this on NetworkController or use -NetworkController parameter to specify one" | Trace-Output -Level:Warning
+                return # don't throw exception, since this is a controlled scenario and we do not need stack exception tracing
+            }
+        }
+
         [System.IO.FileInfo]$OutputDirectory = Join-Path -Path $OutputDirectory.FullName -ChildPath (Get-FormattedDateTimeUTC)
         [System.IO.FileInfo]$workingDirectory = (Get-WorkingDirectory)
         [System.IO.FileInfo]$tempDirectory = "$(Get-WorkingDirectory)\Temp"

--- a/src/modules/NetworkController/public/Get-SdnInfrastructureInfo.ps1
+++ b/src/modules/NetworkController/public/Get-SdnInfrastructureInfo.ps1
@@ -50,6 +50,14 @@ function Get-SdnInfrastructureInfo {
     )
 
     try {
+        if (-NOT ($PSBoundParameters.ContainsKey('NetworkController'))) {
+            $config = Get-SdnRoleConfiguration -Role 'NetworkController'
+            $confirmFeatures = Confirm-RequiredFeaturesInstalled -Name $config.windowsFeature
+            if (-NOT ($confirmFeatures)) {
+                "The current machine is not a NetworkController, run this on NetworkController or use -NetworkController parameter to specify one" | Trace-Output -Level:Warning
+                return # don't throw exception, since this is a controlled scenario and we do not need stack exception tracing
+            }
+        }
 
         # if force is defined, purge the cache to force a refresh on the objects
         if ($PSBoundParameters.ContainsKey('Force')) {

--- a/src/modules/NetworkController/public/Get-SdnInfrastructureInfo.ps1
+++ b/src/modules/NetworkController/public/Get-SdnInfrastructureInfo.ps1
@@ -6,7 +6,7 @@ function Get-SdnInfrastructureInfo {
     .SYNOPSIS
         Get the SDN infrastructure information from network controller. The function will update the $Global:SdnDiagnostics.EnvironmentInfo variable.
     .PARAMETER NetworkController
-        Specifies the name or IP address of the network controller node on which this cmdlet operates.
+        Specifies the name or IP address of the network controller node on which this cmdlet operates. The parameter is optional if running on network controller node.
     .PARAMETER NcUri
         Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
     .PARAMETER Credential
@@ -23,8 +23,8 @@ function Get-SdnInfrastructureInfo {
 
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
-        [String]$NetworkController,
+        [Parameter(Mandatory = $false)]
+        [String]$NetworkController = $(HostName),
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]

--- a/src/modules/NetworkController/public/Get-SdnNetworkController.ps1
+++ b/src/modules/NetworkController/public/Get-SdnNetworkController.ps1
@@ -30,6 +30,15 @@ function Get-SdnNetworkController {
     )
 
     try {
+        if (-NOT ($PSBoundParameters.ContainsKey('NetworkController'))) {
+            $config = Get-SdnRoleConfiguration -Role 'NetworkController'
+            $confirmFeatures = Confirm-RequiredFeaturesInstalled -Name $config.windowsFeature
+            if (-NOT ($confirmFeatures)) {
+                "The current machine is not a NetworkController, run this on NetworkController or use -NetworkController parameter to specify one" | Trace-Output -Level:Warning
+                return # don't throw exception, since this is a controlled scenario and we do not need stack exception tracing
+            }
+        }
+
         $result = Invoke-PSRemoteCommand -ComputerName $NetworkController -ScriptBlock {Get-NetworkControllerNode} -Credential $Credential
         foreach($obj in $result){
             if($obj.Status -ine 'Up'){

--- a/src/modules/NetworkController/public/Get-SdnNetworkController.ps1
+++ b/src/modules/NetworkController/public/Get-SdnNetworkController.ps1
@@ -6,7 +6,7 @@ function Get-SdnNetworkController {
     .SYNOPSIS
         Returns a list of servers from network controller.
     .PARAMETER NetworkController
-        Specifies the name or IP address of the network controller node on which this cmdlet operates.
+        Specifies the name or IP address of the network controller node on which this cmdlet operates. The parameter is optional if running on network controller node.
 	.PARAMETER Credential
 		Specifies a user account that has permission to perform this action. The default is the current user.
     .EXAMPLE
@@ -17,8 +17,8 @@ function Get-SdnNetworkController {
 
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
-        [System.String]$NetworkController,
+        [Parameter(Mandatory = $false)]
+        [System.String]$NetworkController = $(HostName),
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]


### PR DESCRIPTION
# Description
Summary of changes:
Now below cmdlet support run on NC directly without specify -NetworkController parameters:

- `Debug-SdnFabricInfrastructure`
- `Test-SdnKnownIssue`
- `Start-SdnDataCollection`
- `Get-SdnInfrastructureInfo`
- `Get-SdnNetworkController`

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [x] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.