### PR TITLE
Fix issue of Infra Info Fabric Nodes include null element

### DIFF
--- a/src/modules/NetworkController/public/Get-SdnInfrastructureInfo.ps1
+++ b/src/modules/NetworkController/public/Get-SdnInfrastructureInfo.ps1
@@ -110,10 +110,19 @@ function Get-SdnInfrastructureInfo {
         # populate the global cache that contains the names of the nodes for the roles defined above
         $fabricNodes = @()
         $fabricNodes += $global:SdnDiagnostics.EnvironmentInfo.NetworkController
-        $fabricNodes += $Global:SdnDiagnostics.EnvironmentInfo.Server
-        $fabricNodes += $Global:SdnDiagnostics.EnvironmentInfo.Gateway
-        $fabricNodes += $global:SdnDiagnostics.EnvironmentInfo.SoftwareLoadBalancer
 
+        if($null -ne $Global:SdnDiagnostics.EnvironmentInfo.Server){
+            $fabricNodes += $Global:SdnDiagnostics.EnvironmentInfo.Server
+        }
+
+        if($null -ne $Global:SdnDiagnostics.EnvironmentInfo.Gateway){
+            $fabricNodes += $Global:SdnDiagnostics.EnvironmentInfo.Gateway
+        }
+
+        if($null -ne $Global:SdnDiagnostics.EnvironmentInfo.SoftwareLoadBalancer){
+            $fabricNodes += $Global:SdnDiagnostics.EnvironmentInfo.SoftwareLoadBalancer
+        }
+        
         $Global:SdnDiagnostics.EnvironmentInfo.FabricNodes = $fabricNodes
 
         return $Global:SdnDiagnostics.EnvironmentInfo


### PR DESCRIPTION
# Description
Summary of changes:
The  `Get-SdnInfrastructureInfo` returned FabricNodes might include `$null` elements for deployment with no SLB, Gateway etc. 
- changes

Removed `$null` element in FabricNodes

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.