### PR TITLE
User/arudell/enable auto conversion of etw logs

### DIFF
--- a/src/modules/Common/public/Get-SdnDiagnosticLog.ps1
+++ b/src/modules/Common/public/Get-SdnDiagnosticLog.ps1
@@ -48,7 +48,7 @@ function Get-SdnDiagnosticLog {
         Copy-Item -Path $logFiles.FullName -Destination $OutputDirectory.FullName -Force
 
         # convert the trace file into human readable format without requirement of additional parsing tools
-        foreach ($file in (Get-ChildItem -Path $OutputDirectory.FullName -Include '*.etl')) {
+        foreach ($file in (Get-ChildItem -Path "$($OutputDirectory.FullName)\*" -Include '*.etl')) {
             $null = Convert-SdnEtwTraceToTxt -FileName $file.FullName -Overwrite 'Yes'
         }
 

--- a/src/modules/Common/public/Get-SdnDiagnosticLog.ps1
+++ b/src/modules/Common/public/Get-SdnDiagnosticLog.ps1
@@ -47,8 +47,9 @@ function Get-SdnDiagnosticLog {
         "Copying {0} files to {1}" -f $logFiles.Count, $OutputDirectory.FullName | Trace-Output -Level:Verbose
         Copy-Item -Path $logFiles.FullName -Destination $OutputDirectory.FullName -Force
 
-        # convert the trace file into human readable format without requirement of additional parsing tools
-        foreach ($file in (Get-ChildItem -Path "$($OutputDirectory.FullName)\*" -Include '*.etl')) {
+        # convert the most recent etl trace file into human readable format without requirement of additional parsing tools
+        $convertFile = Get-Item -Path "$($OutputDirectory.FullName)\*" -Include '*.etl' | Sort-Object -Property LastWriteTime | Select-Object -Last 1
+        if ($convertFile) {
             $null = Convert-SdnEtwTraceToTxt -FileName $file.FullName -Overwrite 'Yes'
         }
 

--- a/src/modules/Common/public/Get-SdnDiagnosticLog.ps1
+++ b/src/modules/Common/public/Get-SdnDiagnosticLog.ps1
@@ -47,6 +47,11 @@ function Get-SdnDiagnosticLog {
         "Copying {0} files to {1}" -f $logFiles.Count, $OutputDirectory.FullName | Trace-Output -Level:Verbose
         Copy-Item -Path $logFiles.FullName -Destination $OutputDirectory.FullName -Force
 
+        # convert the trace file into human readable format without requirement of additional parsing tools
+        foreach ($file in (Get-ChildItem -Path $OutputDirectory.FullName -Include '*.etl')) {
+            $null = Convert-SdnEtwTraceToTxt -FileName $file.FullName -Overwrite 'Yes'
+        }
+
         # once we have copied the files to the new location we want to compress them to reduce disk space
         # if confirmed we have a .zip file, then remove the staging folder
         "Compressing results to {0}" -f "$($OutputDirectory.FullName).zip" | Trace-Output -Level:Verbose

--- a/src/modules/Common/public/Start-SdnDataCollection.ps1
+++ b/src/modules/Common/public/Start-SdnDataCollection.ps1
@@ -244,8 +244,9 @@ function Start-SdnDataCollection {
                 [System.IO.FileInfo]$networkTraceDir = "$($using:workingDirectory)\NetworkTraces"
                 if (Test-Path -Path $networkTraceDir.FullName -PathType Container) {
 
-                    # convert the trace file into human readable format without requirement of additional parsing tools
-                    foreach ($file in (Get-ChildItem -Path "$($networkTraceDir.FullName)\*" -Include '*.etl')) {
+                    # convert the most recent etl trace file into human readable format without requirement of additional parsing tools
+                    $convertFile = Get-Item -Path "$($networkTraceDir.FullName)\*" -Include '*.etl' | Sort-Object -Property LastWriteTime | Select-Object -Last 1
+                    if ($convertFile) {
                         $null = Convert-SdnEtwTraceToTxt -FileName $file.FullName -Overwrite 'Yes'
                     }
 

--- a/src/modules/Gateway/public/Get-SdnGatewayConfigurationState.ps1
+++ b/src/modules/Gateway/public/Get-SdnGatewayConfigurationState.ps1
@@ -46,6 +46,10 @@ function Get-SdnGatewayConfigurationState {
             Get-BgpPeer -RoutingDomain $routingDomain.RoutingDomain | Export-ObjectToFile -FilePath $routingDomainPath.FullName -Name 'Get-BgpPeer' -FileType txt -Format List
             Get-BgprouteInformation -RoutingDomain $routingDomain.RoutingDomain | Export-ObjectToFile -FilePath $routingDomainPath.FullName -Name 'Get-BgprouteInformation' -FileType txt -Format List
             Get-BgpCustomRoute -RoutingDomain $routingDomain.RoutingDomain | Export-ObjectToFile -FilePath $routingDomainPath.FullName -Name 'Get-BgpCustomRoute' -FileType txt -Format List
+            Get-BgpStatistics -RoutingDomain $routingDomain.RoutingDomain | Export-ObjectToFile -FilePath $routingDomainPath.FullName -Name 'Get-BgpStatistics' -FileType txt -Format List
+            Get-BgpRoutingPolicy -RoutingDomain $routingDomain.RoutingDomain | Export-ObjectToFile -FilePath $routingDomainPath.FullName -Name 'Get-BgpRoutingPolicy' -FileType txt -Format List
+            Get-BgpRouteFlapDampening -RoutingDomain $routingDomain.RoutingDomain | Export-ObjectToFile -FilePath $routingDomainPath.FullName -Name 'Get-BgpRouteFlapDampening' -FileType txt -Format List
+            Get-BgpRouteAggregate -RoutingDomain $routingDomain.RoutingDomain | Export-ObjectToFile -FilePath $routingDomainPath.FullName -Name 'Get-BgpRouteAggregate' -FileType txt -Format List
         }
 
         # for ipsec fast path, there is a new service w/ new cmdlets to get the tunnels and routing domains

--- a/src/modules/Utilities/private/Copy-FileFromRemoteComputer.ps1
+++ b/src/modules/Utilities/private/Copy-FileFromRemoteComputer.ps1
@@ -61,7 +61,7 @@ function Copy-FileFromRemoteComputer {
             else {
                 # try SMB Copy first and fallback to WinRM
                 try {
-                    Copy-FileFromRemoteComputerSMB -Path $Path -ComputerName $object -Destination $Destination -Force:($Force.IsPresent) -Recurse:($Recurse.IsPresent)
+                    Copy-FileFromRemoteComputerSMB -Path $Path -ComputerName $object -Destination $Destination -Force:($Force.IsPresent) -Recurse:($Recurse.IsPresent) -ErrorAction Stop
                 }
                 catch {
                     "{0}. Attempting to copy files using WinRM" -f $_ | Trace-Output -Level:Warning

--- a/src/modules/Utilities/private/Copy-FileToRemoteComputer.ps1
+++ b/src/modules/Utilities/private/Copy-FileToRemoteComputer.ps1
@@ -61,7 +61,7 @@ function Copy-FileToRemoteComputer {
             else {
                 # try SMB Copy first and fallback to WinRM
                 try {
-                    Copy-FileToRemoteComputerSMB -Path $Path -ComputerName $object -Destination $Destination -Force:($Force.IsPresent) -Recurse:($Recurse.IsPresent)
+                    Copy-FileToRemoteComputerSMB -Path $Path -ComputerName $object -Destination $Destination -Force:($Force.IsPresent) -Recurse:($Recurse.IsPresent) -ErrorAction Stop
                 }
                 catch {
                     "{0}. Attempting to copy files using WinRM" -f $_ | Trace-Output -Level:Warning

--- a/src/modules/Utilities/private/Export-ObjectToFile.ps1
+++ b/src/modules/Utilities/private/Export-ObjectToFile.ps1
@@ -9,7 +9,7 @@ function Export-ObjectToFile {
 
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory = $false, ValueFromPipeline = $true)]
         [Object[]]$Object,
 
         [Parameter(Mandatory = $true)]
@@ -32,6 +32,11 @@ function Export-ObjectToFile {
 
     begin {
         $arrayList = [System.Collections.ArrayList]::new()
+
+        # if object is null, then exit
+        if ($null -eq $Object) {
+            return
+        }
     }
     process {
         foreach ($obj in $Object) {


### PR DESCRIPTION
# Description
Summary of changes:
- Enable automatic conversion of .etl into .txt format
- Collect more details related to BGP configuration for gateways
- Fixed scenario where Test-Path would fail when testing network share path, but would fail with non-terminating exception indicating `Access Denied`, however was not critical and would not fallback to using WinRM method for copy operations
- Fixed `Convert-SdnEtwTraceToTxt` function

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.