### PR TITLE
Added ArgumentList support for Invoke-PsRemoteCommand

### DIFF
--- a/src/modules/Utilities/private/Invoke-PSRemoteCommand.ps1
+++ b/src/modules/Utilities/private/Invoke-PSRemoteCommand.ps1
@@ -15,6 +15,9 @@ function Invoke-PSRemoteCommand {
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
+        [Parameter(Mandatory = $false)]
+        [Object[]]$ArgumentList = $null,
+
         [Parameter(Mandatory = $false, ParameterSetName = 'AsJob')]
         [Switch]$AsJob,
 
@@ -33,7 +36,7 @@ function Invoke-PSRemoteCommand {
         "ComputerName: {0}, ScriptBlock: {1}" -f ($session.ComputerName -join ', '), $ScriptBlock.ToString() | Trace-Output -Level:Verbose
 
         if ($AsJob) {
-            $result = Invoke-Command -Session $session -ScriptBlock $ScriptBlock -AsJob -JobName $([guid]::NewGuid().Guid)
+            $result = Invoke-Command -Session $session -ScriptBlock $ScriptBlock -AsJob -JobName $([guid]::NewGuid().Guid) -ArgumentList $ArgumentList
             if ($PassThru) {
                 if ($Activity) {
                     $result = Wait-PSJob -Name $result.Name -ExecutionTimeOut $ExecutionTimeout -Activity $Activity
@@ -46,7 +49,7 @@ function Invoke-PSRemoteCommand {
             return $result
         }
         else {
-            return (Invoke-Command -Session $session -ScriptBlock $ScriptBlock)
+            return (Invoke-Command -Session $session -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList)
         }
     }
 }


### PR DESCRIPTION
# Description

`New-SdnCertificateRotationConfig` reported failure after convert `Invoke-Command` to `Invoke-PsRemoteCommand` as `-ArgumentList` not supported
- changes
Added ArgumentList support for `Invoke-PsRemoteCommand`. The `ArgumentList` parameter is mandatory and default to NULL so should not affect existing callers.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.