### PR TITLE
Change vendorId string format to fix invalid parameter issue when set port profile

### DIFF
--- a/src/modules/Server/private/Set-VMNetworkAdapterPortProfile.ps1
+++ b/src/modules/Server/private/Set-VMNetworkAdapterPortProfile.ps1
@@ -64,7 +64,7 @@ function Set-VMNetworkAdapterPortProfile {
 
             $currentProfile.SettingData.ProfileId = $ProfileId.ToString("B")
             $currentProfile.SettingData.ProfileData = $ProfileData
-            $currentProfile.SettingData.VendorId = $vendorId
+            $currentProfile.SettingData.VendorId = $vendorId.ToString("B")
 
             Set-VMSwitchExtensionPortFeature -VMSwitchExtensionFeature $currentProfile -VMNetworkAdapter $vmNic
         }


### PR DESCRIPTION
# Description
Set-SdnVmNetworkAdapterPortProfile reported error about invalid parameter as we passed vendorid string with incorrect format. 
- changes
Changed the format vendorid with correct format.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.