### PR TITLE
Fix issue with VendorId format with `Set-SdnVMNetworkAdapterPortProfile`

### DIFF
--- a/src/modules/Server/private/Set-VMNetworkAdapterPortProfile.ps1
+++ b/src/modules/Server/private/Set-VMNetworkAdapterPortProfile.ps1
@@ -44,6 +44,8 @@ function Set-VMNetworkAdapterPortProfile {
             return
         }
 
+        # this is taking the default system switch extension port feature settings
+        # and modifying to our purposes so that we can then apply directly to network adapter
         $portProfileDefaultSetting = Get-VMSystemSwitchExtensionPortFeature -FeatureId $portProfileFeatureId -ErrorAction Stop
         $portProfileDefaultSetting.SettingData.ProfileId = $ProfileId.ToString("B")
         $portProfileDefaultSetting.SettingData.NetCfgInstanceId = "{56785678-a0e5-4a26-bc9b-c0cba27311a3}"
@@ -54,6 +56,9 @@ function Set-VMNetworkAdapterPortProfile {
         $portProfileDefaultSetting.SettingData.VendorName = "NetworkController"
         $portProfileDefaultSetting.SettingData.ProfileData = $ProfileData
 
+        # get the current port feature associated with the vm network adapter
+        # if we don't return anything, then it has not been set and we need to add the port feature to network adapter
+        # else if already set, then modify a few settings to match what we provided and set the port feature properties
         $currentProfile = Get-VMSwitchExtensionPortFeature -FeatureId $portProfileFeatureId -VMNetworkAdapter $vmNic
         if ($null -eq $currentProfile) {
             "Port profile not previously configured" | Trace-Output
@@ -64,7 +69,7 @@ function Set-VMNetworkAdapterPortProfile {
 
             $currentProfile.SettingData.ProfileId = $ProfileId.ToString("B")
             $currentProfile.SettingData.ProfileData = $ProfileData
-            $currentProfile.SettingData.VendorId = $vendorId
+            $currentProfile.SettingData.VendorId = $vendorId.ToString("B")
 
             Set-VMSwitchExtensionPortFeature -VMSwitchExtensionFeature $currentProfile -VMNetworkAdapter $vmNic
         }


### PR DESCRIPTION
# Description
Summary of changes:
- Fixed typo in `Set-SdnVMNetworkAdapterPortProfile` where the `VendorId` is in the wrong format

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.