### PR TITLE
Fix NcUri usage for Get-SdnAuditLog call

### DIFF
--- a/src/modules/Common/public/Start-SdnDataCollection.ps1
+++ b/src/modules/Common/public/Start-SdnDataCollection.ps1
@@ -278,7 +278,7 @@ function Start-SdnDataCollection {
                 }
 
                 if ($group.Name -ieq 'Server') {
-                    Get-SdnAuditLog -NcUri $NcUri.AbsoluteUri -NcRestCredential $NcRestCredential -OutputDirectory "$($OutputDirectory.FullName)\AuditLogs" `
+                    Get-SdnAuditLog -NcUri $sdnFabricDetails.NcUrl -NcRestCredential $NcRestCredential -OutputDirectory "$($OutputDirectory.FullName)\AuditLogs" `
                     -ComputerName $dataNodes -Credential $Credential
                 }
 


### PR DESCRIPTION
# Description

Get-SdnAuditLog currently use NcUri which should be from fabric details.
```
System.Management.Automation.ParameterBindingValidationException: Cannot bind argument to parameter 'NcUri' because it is null.
   at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
at Start-SdnDataCollection, C:\Program Files\WindowsPowerShell\Modules\SDNDiagnostics\3.2302.568.30905\modules\Common\public\Start-SdnDataCollection.ps1: line 281
```

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [ ] I have tested and validated my code changes.