### PR TITLE
Add new fabric validation test and misc fixes for Start-SdnDataCollection

### DIFF
--- a/src/modules/SdnDiag.Health/private/Test-EncapOverhead.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-EncapOverhead.ps1
@@ -34,12 +34,12 @@ function Test-EncapOverhead {
                     "[{0}] {1}" -f $object.Name, ($interface | Out-String -Width 4096) | Trace-Output -Level:Verbose
 
                     if($interface.EncapOverheadEnabled -eq $false -or $interface.EncapOverheadValue -lt $encapOverheadExpectedValue){
-                        "EncapOverhead settings for {0} on {1} are disabled or not configured correctly" -f $interface.NetworkInterface, $object.Name | Trace-Output -Level:Warning
+                        "EncapOverhead settings for {0} on {1} are disabled or not configured correctly" -f $interface.NetworkInterface, $object.Name | Trace-Output -Level:Verbose
                         $encapDisabled = $true
                     }
 
                     if($interface.JumboPacketEnabled -eq $false -or $interface.JumboPacketValue -lt $jumboPacketExpectedValue){
-                        "JumboPacket settings for {0} on {1} are disabled or not configured correctly" -f $interface.NetworkInterface, $object.Name | Trace-Output -Level:Warning
+                        "JumboPacket settings for {0} on {1} are disabled or not configured correctly" -f $interface.NetworkInterface, $object.Name | Trace-Output -Level:Verbose
                         $jumboPacketDisabled = $true
                     }
 
@@ -47,6 +47,7 @@ function Test-EncapOverhead {
                     # and as such, environment would experience intermittent packet loss
                     if ($encapDisabled -and $jumboPacketDisabled) {
                         $sdnHealthObject.Result = 'FAIL'
+                        "EncapOverhead and JumboPacket for interface {0} on {1} are disabled or not configured correctly." -f $interface.NetworkInterface, $object.Name  | Trace-Output -Level:Exception
                     }
 
                     $array += $interface

--- a/src/modules/SdnDiag.Health/private/Test-ProviderNetwork.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ProviderNetwork.ps1
@@ -50,7 +50,7 @@ function Test-ProviderNetwork {
                         # if standard MTU was success but jumbo MTU was failure, indication that jumbo packets or encap overhead has not been setup and configured
                         # either on the physical nic or within the physical switches between the provider addresses
                         if($jumboPacketResult.Status -ieq 'Failure' -and $standardPacketResult.Status -ieq 'Success'){
-                            $sdnHealthObject.Remediation = "Ensure physical switch ports and network interfaces support 1660 byte payload using Jumbo Packets or EncapOverhead"
+                            $sdnHealthObject.Remediation = "Ensure physical switches and network interfaces support 1660 byte payload using Jumbo Packets or EncapOverhead"
                             "Cannot send jumbo packets to {0} from {1} ({2})." `
                             -f $destinationAddress[0].DestinationAddress, $computer.Name, $destinationAddress[0].SourceAddress | Trace-Output -Level:Exception
                         }

--- a/src/modules/SdnDiag.Health/private/Test-ScheduledTaskEnabled.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ScheduledTaskEnabled.ps1
@@ -1,0 +1,60 @@
+function Test-ScheduledTaskEnabled {
+    <#
+    .SYNOPSIS
+        Ensures the scheduled task responsible for etl compression is enabled and running
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [SdnFabricHealthObject]$SdnEnvironmentObject,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    $sdnHealthObject = [SdnHealth]::new()
+    $array = @()
+    $serviceStateResults = @()
+
+    $scriptBlock = {
+        try {
+            $result = Get-ScheduledTask -TaskName 'SDN Diagnostics Task' -ErrorAction Stop
+            return [PSCustomObject]@{
+                TaskName = $result.TaskName
+                State = $result.State
+            }
+        }
+        catch {
+            return [PSCustomObject]@{
+                TaskName = 'SDN Diagnostics Task'
+                State = 'Not Available'
+            }
+        }
+    }
+
+    try {
+        $scheduledTaskReady = Invoke-PSRemoteCommand -ComputerName $SdnEnvironmentObject.ComputerName -Credential $Credential -ScriptBlock $scriptBlock -AsJob -PassThru
+        foreach ($result in $scheduledTaskReady) {
+            if ($result.State -ine 'Running') {
+                "SDN Diagnostics Task state is {1} on {1}, which may result in uncontrolled log growth" -f $result.State, $result.PSComputerName | Trace-Output -Level:Warning
+                $sdnHealthObject.Result = 'FAIL'
+
+                $object = [PSCustomObject]@{
+                    State = $result.State
+                    Computer = $result.PSComputerName
+                }
+
+                $array += $object
+            }
+        }
+
+        $sdnHealthObject.Properties = $array
+        return $sdnHealthObject
+    }
+    catch {
+        "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
+    }
+}

--- a/src/modules/SdnDiag.Health/private/Test-ScheduledTaskEnabled.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ScheduledTaskEnabled.ps1
@@ -37,8 +37,8 @@ function Test-ScheduledTaskEnabled {
     try {
         $scheduledTaskReady = Invoke-PSRemoteCommand -ComputerName $SdnEnvironmentObject.ComputerName -Credential $Credential -ScriptBlock $scriptBlock -AsJob -PassThru
         foreach ($result in $scheduledTaskReady) {
-            if ($result.State -ine 'Running') {
-                "SDN Diagnostics Task state is {1} on {1}, which may result in uncontrolled log growth" -f $result.State, $result.PSComputerName | Trace-Output -Level:Warning
+            if ($result.State -ine 'Ready' -or $result.State -ine 'Running') {
+                "SDN Diagnostics Task state is {0} on {1}, which may result in uncontrolled log growth" -f $result.State, $result.PSComputerName | Trace-Output -Level:Exception
                 $sdnHealthObject.Result = 'FAIL'
             }
 

--- a/src/modules/SdnDiag.Health/private/Test-ScheduledTaskEnabled.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ScheduledTaskEnabled.ps1
@@ -23,7 +23,7 @@ function Test-ScheduledTaskEnabled {
             $result = Get-ScheduledTask -TaskName 'SDN Diagnostics Task' -ErrorAction Stop
             return [PSCustomObject]@{
                 TaskName = $result.TaskName
-                State = $result.State
+                State = $result.State.ToString()
             }
         }
         catch {
@@ -37,7 +37,7 @@ function Test-ScheduledTaskEnabled {
     try {
         $scheduledTaskReady = Invoke-PSRemoteCommand -ComputerName $SdnEnvironmentObject.ComputerName -Credential $Credential -ScriptBlock $scriptBlock -AsJob -PassThru
         foreach ($result in $scheduledTaskReady) {
-            if ($result.State -ine 'Ready' -or $result.State -ine 'Running') {
+            if ($result.State -ine 'Ready' -and $result.State -ine 'Running') {
                 "SDN Diagnostics Task state is {0} on {1}, which may result in uncontrolled log growth" -f $result.State, $result.PSComputerName | Trace-Output -Level:Exception
                 $sdnHealthObject.Result = 'FAIL'
             }

--- a/src/modules/SdnDiag.Health/private/Test-ScheduledTaskEnabled.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ScheduledTaskEnabled.ps1
@@ -17,7 +17,6 @@ function Test-ScheduledTaskEnabled {
 
     $sdnHealthObject = [SdnHealth]::new()
     $array = @()
-    $serviceStateResults = @()
 
     $scriptBlock = {
         try {
@@ -41,13 +40,11 @@ function Test-ScheduledTaskEnabled {
             if ($result.State -ine 'Running') {
                 "SDN Diagnostics Task state is {1} on {1}, which may result in uncontrolled log growth" -f $result.State, $result.PSComputerName | Trace-Output -Level:Warning
                 $sdnHealthObject.Result = 'FAIL'
+            }
 
-                $object = [PSCustomObject]@{
-                    State = $result.State
-                    Computer = $result.PSComputerName
-                }
-
-                $array += $object
+            $array += [PSCustomObject]@{
+                State = $result.State
+                Computer = $result.PSComputerName
             }
         }
 

--- a/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
+++ b/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
@@ -112,6 +112,7 @@ function Debug-SdnFabricInfrastructure {
                         Gateway = @(
                             Test-ResourceConfigurationState @restApiParams
                             Test-ServiceState @computerCredParams
+                            Test-ScheduledTaskEnabled @computerCredParams
                         )
                     }
                 }
@@ -121,6 +122,7 @@ function Debug-SdnFabricInfrastructure {
                         LoadBalancerMux = @(
                             Test-ResourceConfigurationState @restApiParams
                             Test-ServiceState @computerCredParams
+                            Test-ScheduledTaskEnabled @computerCredParams
                         )
                     }
                 }
@@ -131,6 +133,7 @@ function Debug-SdnFabricInfrastructure {
                             Test-ServiceState @computerCredParams
                             Test-ServiceFabricPartitionDatabaseSize @computerCredParams
                             Test-NetworkInterfaceAPIDuplicateMacAddress @restApiParams
+                            Test-ScheduledTaskEnabled @computerCredParams
                         )
                     }
                 }
@@ -146,6 +149,7 @@ function Debug-SdnFabricInfrastructure {
                             Test-VfpDuplicatePort @computerCredParams
                             Test-VMNetAdapterDuplicateMacAddress @computerCredParams
                             Test-HostRootStoreNonRootCert @computerCredParams
+                            Test-ScheduledTaskEnabled @computerCredParams
                         )
                     }
                 }


### PR DESCRIPTION
# Description
Summary of changes:
- Added new fabric test to validate the SDN Diagnostics Task is enabled or running to prevent scenarios where logs eat up extensive amount of disk space.
- Collect fabric tests into summary and json as part of `Start-SdnDataCollection`
- Changed logic ordering for some data gathering with `Start-SdnDataCollection` as they were executing multiple times for each role
- Changed output at end of `Start-SdnDataCollection` to highlight more visibly the logs were saved to
- Collect the trace output file as from the node the `Start-SdnDataCollection` is being executed from

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.