### PR TITLE
Fix missing positional parameter and ensure parent directory for file copy ops

### DIFF
--- a/src/modules/SdnDiag.NetworkController/private/Copy-ServiceFabricManifestToNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Copy-ServiceFabricManifestToNetworkController.ps1
@@ -53,11 +53,10 @@ function Copy-ServiceFabricManifestToNetworkController {
             $settingsFile = Join-Path -Path $fabricConfigDir -ChildPath "Settings.xml"
 
             Invoke-PSRemoteCommand -ComputerName $_.IpAddressOrFQDN -Credential $Credential -ScriptBlock {
-                param([Parameter(Position = 0)][String]$param1)
+                param([Parameter(Position = 0)][String]$param1, [Parameter(Position = 1)][String]$param2)
                 Set-ItemProperty -Path (Join-Path -Path $param1 -ChildPath "ClusterManifest.current.xml") -Name IsReadOnly -Value $false | Out-Null
                 Set-ItemProperty -Path (Join-Path -Path $param1 -ChildPath "Fabric.Data\InfrastructureManifest.xml") -Name IsReadOnly -Value $false | Out-Null
                 Set-ItemProperty -Path $param2 -Name IsReadOnly -Value $false | Out-Null
-
             } -ArgumentList @($fabricFolder, $settingsFile)
 
             Copy-FileToRemoteComputer -Path "$ManifestFolder\ClusterManifest.current.xml" -Destination "$fabricFolder\ClusterManifest.current.xml" -ComputerName $_.IpAddressOrFQDN -Credential $Credential

--- a/src/modules/SdnDiag.Utilities/private/Copy-FileFromRemoteComputerSMB.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Copy-FileFromRemoteComputerSMB.ps1
@@ -62,6 +62,21 @@ function Copy-FileFromRemoteComputerSMB {
     }
 
     process {
+        # ensure that the destination directory already exists
+        # we want to check to see if destination is meant to be a folder or file
+        # if its a file, then we want the parent directory of the file
+        if ($Destination.Extension) {
+            $destinationRootDir = Split-Path -Path $params.Destination -Parent
+        }
+        else {
+            $destinationRootDir = $params.Destination
+        }
+
+        # create the parent directory first to prevent copy file operation failures
+        if (-NOT (Test-Path -Path $destinationRootDir -PathType Container)) {
+            $null = New-Item -Path $destinationRootDir -ItemType Directory
+        }
+
         foreach ($subPath in $Path) {
             $remotePath = Convert-FileSystemPathToUNC -ComputerName $ComputerName -Path $subPath
             if (-NOT (Test-Path -Path $remotePath)) {

--- a/src/modules/SdnDiag.Utilities/private/Copy-FileFromRemoteComputerWinRM.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Copy-FileFromRemoteComputerWinRM.ps1
@@ -43,6 +43,21 @@ function Copy-FileFromRemoteComputerWinRM {
 
     $session = New-PSRemotingSession -ComputerName $ComputerName -Credential $Credential
     if ($session) {
+        # ensure that the destination directory already exists
+        # we want to check to see if destination is meant to be a folder or file
+        # if its a file, then we want the parent directory of the file
+        if ($Destination.Extension) {
+            $destinationRootDir = Split-Path -Path $Destination.FullName -Parent
+        }
+        else {
+            $destinationRootDir = $Destination.FullName
+        }
+
+        # create the parent directory first to prevent copy file operation failures
+        if (-NOT (Test-Path -Path $destinationRootDir -PathType Container)) {
+            $null = New-Item -Path $destinationRootDir -ItemType Directory
+        }
+
         foreach ($subPath in $Path) {
             "Copying {0} to {1} using WinRM Session {2}" -f $subPath, $Destination.FullName, $session.Name | Trace-Output
             Copy-Item -Path $subPath -Destination $Destination.FullName -FromSession $session -Force:($Force.IsPresent) -Recurse:($Recurse.IsPresent) -ErrorAction:Continue


### PR DESCRIPTION
# Description
- Fixed a missing positional parameter for setting the settings.xml read-only:$false
- Added defensive coding for file copy operations to ensure parent directory exists

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.