### PR TITLE
Add configuration state error code table and new fabric health tests

### DIFF
--- a/src/SdnDiagnostics.Helper.psm1
+++ b/src/SdnDiagnostics.Helper.psm1
@@ -102,28 +102,3 @@ $serverParamCommands = (
 )
 
 Register-ArgumentCompleter -CommandName $serverParamCommands -ParameterName 'ComputerName' -ScriptBlock $scriptBlocks.ServerNodes
-
-$fabricInfraResultScriptBlock = @{
-    Role = {
-        param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
-        $result = (Get-SdnFabricInfrastructureResult)
-        if ([string]::IsNullOrEmpty($wordToComplete)) {
-            return ($result.Role | Sort-Object -Unique)
-        }
-
-        return $result.Role | Where-Object {$_.Role -like "*$wordToComplete*"} | Sort-Object
-    }
-    Name = {
-        param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
-        $result = (Get-SdnFabricInfrastructureResult).HealthValidation
-        if ([string]::IsNullOrEmpty($wordToComplete)) {
-            return ($result.Name | Sort-Object -Unique)
-        }
-
-        return $result.HealthValidation | Where-Object {$_.Name -like "*$wordToComplete*"} | Sort-Object
-    }
-}
-
-Register-ArgumentCompleter -CommandName 'Get-SdnFabricInfrastructureResult' -ParameterName 'Role' -ScriptBlock $fabricInfraResultScriptBlock.Role
-Register-ArgumentCompleter -CommandName 'Get-SdnFabricInfrastructureResult' -ParameterName 'Name' -ScriptBlock $fabricInfraResultScriptBlock.Name
-

--- a/src/modules/SdnDiag.Health/SdnDiag.Health.Config.psd1
+++ b/src/modules/SdnDiag.Health/SdnDiag.Health.Config.psd1
@@ -109,7 +109,7 @@
         }
         'HostNotConnectedToController' = @{
             Message = 'The Host is not yet connected to the Network Controller'
-            Action = 'Port Profile not applied on the host or the host is not reachable from the Network Controller. Validate that HostID registry key matches the Instance ID of the server resource'
+            Action = 'Validate that Host is online and operational, NCHostAgent service is started and HostID registry key matches the Instance ID of the server resource'
         }
         'MultipleVfpEnabledSwitches' = @{
             Message = 'There are multiple VFp enabled Switches on the host'

--- a/src/modules/SdnDiag.Health/SdnDiag.Health.Config.psd1
+++ b/src/modules/SdnDiag.Health/SdnDiag.Health.Config.psd1
@@ -49,13 +49,13 @@
             PublicDocUrl = "https://learn.microsoft.com/en-us/windows-server/networking/sdn/troubleshoot/troubleshoot-windows-server-software-defined-networking-stack#check-for-corresponding-hostids-and-certificates-between-network-controller-and-each-hyper-v-host"
         }
         'Test-ServiceFabricApplicationHealth' = @{
-            Description = ""
-            Impact = ""
+            Description = "Network Controller application with Service Fabric is not healthy."
+            Impact = "Network Controller services and functionality may be impacted."
             PublicDocUrl = ""
         }
         'Test-ServiceFabricClusterHealth' = @{
-            Description = ""
-            Impact = ""
+            Description = "Service Fabric cluster for Network Controller is not healthy."
+            Impact = "Network Controller services and functionality may be impacted."
             PublicDocUrl = ""
         }
         'Test-ServiceFabricNodeStatus' = @{

--- a/src/modules/SdnDiag.Health/SdnDiag.Health.Config.psd1
+++ b/src/modules/SdnDiag.Health/SdnDiag.Health.Config.psd1
@@ -48,6 +48,21 @@
             Impact = "Mismatch of HostId between Hyper-V host(s) and Network Controller will result in policy configuration failures."
             PublicDocUrl = "https://learn.microsoft.com/en-us/windows-server/networking/sdn/troubleshoot/troubleshoot-windows-server-software-defined-networking-stack#check-for-corresponding-hostids-and-certificates-between-network-controller-and-each-hyper-v-host"
         }
+        'Test-ServiceFabricApplicationHealth' = @{
+            Description = ""
+            Impact = ""
+            PublicDocUrl = ""
+        }
+        'Test-ServiceFabricClusterHealth' = @{
+            Description = ""
+            Impact = ""
+            PublicDocUrl = ""
+        }
+        'Test-ServiceFabricNodeStatus' = @{
+            Description = "Service Fabric node(s) are offline and not participating in the cluster."
+            Impact = "Minimum amount of nodes are required to maintain quorum and cluster availability. Services will be in read-only state if quorum is lost and may result in data loss."
+            PublicDocUrl = "https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-disaster-recovery"
+        }
         'Test-ServiceFabricPartitionDatabaseSize' = @{
             Description = ""
             Impact = ""

--- a/src/modules/SdnDiag.Health/SdnDiag.Health.Config.psd1
+++ b/src/modules/SdnDiag.Health/SdnDiag.Health.Config.psd1
@@ -64,12 +64,12 @@
             PublicDocUrl = "https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-disaster-recovery"
         }
         'Test-ServiceFabricPartitionDatabaseSize' = @{
-            Description = ""
-            Impact = ""
+            Description = "Service Fabric partition database size has exceeded normal size expected."
+            Impact = "Performance of the Service Fabric Services may occur."
             PublicDocUrl = ""
         }
         'Test-ServiceState' = @{
-            Description = "Identified service is not running on the SDN infrastructure node(s)."
+            Description = "Identified service(s) are not running on the SDN infrastructure node(s)."
             Impact = "SDN services and functionality will be impacted without the service running."
             PublicDocUrl = ""
         }
@@ -86,6 +86,11 @@
         'Test-VMNetAdapterDuplicateMacAddress' = @{
             Description = "Duplicate MAC address detected with the data plane on the Hyper-V host(s)."
             Impact = "Policy configuration failures may be reported by Network Controller when applying policies to the Hyper-v host. In addition, network traffic may be impacted for the interfaces that are duplicated."
+            PublicDocUrl = ""
+        }
+        'Test-NcHostAgentConnectionToApiService' = @{
+            Description = "Network Controller Host Agent is not connected to the Network Controller API Service."
+            Impact = "Policy configuration may not be pushed to the Hyper-V host(s) if no southbound connectivity is available."
             PublicDocUrl = ""
         }
     }

--- a/src/modules/SdnDiag.Health/SdnDiag.Health.Config.psd1
+++ b/src/modules/SdnDiag.Health/SdnDiag.Health.Config.psd1
@@ -74,4 +74,82 @@
             PublicDocUrl = ""
         }
     }
+    ConfigurationStateErrorCodes = @{
+        'Unknown' = @{
+            Message = 'Unknown error'
+            Action = 'Collect the logs and contact Microsoft Support'
+        }
+        'HostUnreachable' = @{
+            Message = 'The host machine is not reachable'
+            Action = 'Check the Management network connectivity between Network Controller and Host'
+        }
+        'PAIpAddressExhausted' = @{
+            Message = 'The PA Ip addresses exhausted'
+            Action = 'Increase the HNV Provider logical subnet''s IP Pool Size'
+        }
+        'PAMacAddressExhausted' = @{
+            Message = 'The PA Mac addresses exhausted'
+            Action = 'Increase the Mac Pool Range'
+        }
+        'PAAddressConfigurationFailure' = @{
+            Message = 'Failed to plumb PA addresses to the host'
+            Action = 'Check the management network connectivity between Network Controller and Host.'
+        }
+        'CertificateNotTrusted' = @{
+            Message = 'Certificate is not trusted'
+            Action = 'Fix the certificates used for communication with the host.'
+        }
+        'CertificateNotAuthorized' = @{
+            Message = 'Certificate not authorized'
+            Action = 'Fix the certificates used for communication with the host.'
+        }
+        'PolicyConfigurationFailureOnVfp' = @{
+            Message = 'Failure in configuring VFP policies'
+            Action = 'This is a runtime failure.  No definite workarounds. Collect logs.'
+        }
+        'HostNotConnectedToController' = @{
+            Message = 'The Host is not yet connected to the Network Controller'
+            Action = 'Port Profile not applied on the host or the host is not reachable from the Network Controller. Validate that HostID registry key matches the Instance ID of the server resource'
+        }
+        'MultipleVfpEnabledSwitches' = @{
+            Message = 'There are multiple VFp enabled Switches on the host'
+            Action = 'Delete one of the switches, since Network Controller Host Agent only supports one vSwitch with the VFP extension enabled'
+        }
+        'PolicyConfigurationFailure' = @{
+            Message = 'Failed to push policies (vSwitch, vNet, ACL) for a VmNic due to certificate errors or connectivity errors'
+            Action = 'Check if proper certificates have been deployed (Certificate subject name must match FQDN of host). Also verify the host connectivity with the Network Controller'
+        }
+        'DistributedRouterConfigurationFailure' = @{
+            Message = 'Failed to configure the Distributed router settings on the host vNic'
+            Action = 'TCPIP stack error. May require cleaning up the PA and DR Host vNICs on the server on which this error was reported'
+        }
+        'DhcpAddressAllocationFailure' = @{
+            Message = 'DHCP address allocation failed for a VMNic'
+            Action = 'Check if the static IP address attribute is configured on the NIC resource'
+        }
+        'CertificateNotTrusted CertificateNotAuthorized' = @{
+            Message = 'Failed to connect to Mux due to network or cert errors'
+            Action = 'Check the numeric code provided in the error message code: this corresponds to the winsock error code. Certificate errors are granular (for example, cert cannot be verified, cert not authorized, etc.)'
+        }
+        'PortBlocked' = @{
+            Message = 'The VFP port is blocked, due to lack of VNET / ACL policies'
+            Action = 'Check if there are any other errors, which might cause the policies to be not configured.'
+        }
+        'Overloaded' = @{
+            Message = 'Loadbalancer MUX is overloaded'
+            Action = 'Performance issue with MUX'
+        }
+        'RoutePublicationFailure' = @{
+            Message = 'Loadbalancer MUX is not connected to a BGP router'
+            Action = 'Check if the MUX has connectivity with the BGP routers and that BGP peering is setup correctly'
+        }
+        'VirtualServerUnreachable' = @{
+            Message = 'Loadbalancer MUX is not connected to SLB manager'
+            Action = 'Check connectivity between SLBM and MUX'
+        }
+        'QosConfigurationFailure' = @{
+            Message = 'Failed to configure QOS policies'
+            Action = 'See if sufficient bandwidth is available for all VM''s if QOS reservation is used'
+        }
+    }
 }

--- a/src/modules/SdnDiag.Health/SdnDiag.Health.Helper.psm1
+++ b/src/modules/SdnDiag.Health/SdnDiag.Health.Helper.psm1
@@ -28,3 +28,27 @@ class SdnFabricHealthReport {
     [SdnHealthResult]$Result = 'PASS'
     [Object[]]$HealthValidation
 }
+
+$fabricInfraResultScriptBlock = @{
+    Role = {
+        param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+        $result = (Get-SdnFabricInfrastructureResult)
+        if ([string]::IsNullOrEmpty($wordToComplete)) {
+            return ($result.Role | Sort-Object -Unique)
+        }
+
+        return $result.Role | Where-Object {$_.Role -like "*$wordToComplete*"} | Sort-Object
+    }
+    Name = {
+        param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+        $result = (Get-SdnFabricInfrastructureResult).HealthValidation
+        if ([string]::IsNullOrEmpty($wordToComplete)) {
+            return ($result.Name | Sort-Object -Unique)
+        }
+
+        return $result.HealthValidation | Where-Object {$_.Name -like "*$wordToComplete*"} | Sort-Object
+    }
+}
+
+Register-ArgumentCompleter -CommandName 'Get-SdnFabricInfrastructureResult' -ParameterName 'Role' -ScriptBlock $fabricInfraResultScriptBlock.Role
+Register-ArgumentCompleter -CommandName 'Get-SdnFabricInfrastructureResult' -ParameterName 'Name' -ScriptBlock $fabricInfraResultScriptBlock.Name

--- a/src/modules/SdnDiag.Health/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health/SdnDiag.Health.psm1
@@ -9,9 +9,10 @@ Import-Module $PSScriptRoot\..\SdnDiag.Common\SdnDiag.Common.psm1
 Import-Module $PSScriptRoot\..\SdnDiag.Utilities\SdnDiag.Utilities.psm1
 
 # create local variable to store configuration data
+$configurationData = Import-PowerShellDataFile -Path "$PSScriptRoot\SdnDiag.Health.Config.psd1"
 New-Variable -Name 'SdnDiagnostics_Health' -Scope 'Script' -Force -Value @{
     Cache = @{}
+    Config = $configurationData
 }
-
 
 ##### FUNCTIONS AUTO-POPULATED BELOW THIS LINE DURING BUILD #####

--- a/src/modules/SdnDiag.Health/private/Get-HealthData.ps1
+++ b/src/modules/SdnDiag.Health/private/Get-HealthData.ps1
@@ -1,0 +1,12 @@
+function Get-HealthData {
+    param (
+        [Parameter(Mandatory = $true)]
+        [System.String]$Property,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]$Id
+    )
+
+    $results = $script:SdnDiagnostics_Health.Config[$Property]
+    return ($results[$Id])
+}

--- a/src/modules/SdnDiag.Health/private/Get-HealthValidationDetail.ps1
+++ b/src/modules/SdnDiag.Health/private/Get-HealthValidationDetail.ps1
@@ -1,9 +1,0 @@
-function Get-HealthValidationDetail {
-    param (
-        [Parameter(Mandatory = $true)]
-        [System.String]$Id
-    )
-
-    $configurationData = Import-PowerShellDataFile -Path $PSScriptRoot\SdnDiag.Health.Config.psd1
-    return ($configurationData.HealthValidations[$Id])
-}

--- a/src/modules/SdnDiag.Health/private/Test-NcHostAgentConnectionToApiService.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-NcHostAgentConnectionToApiService.ps1
@@ -1,0 +1,77 @@
+function Test-NcHostAgentConnectionToApiService {
+    <#
+    .SYNOPSIS
+        Validates the TCP connection between Server and primary replica of Api service within Network Controller.
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [SdnFabricEnvObject]$SdnEnvironmentObject,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $NcRestCredential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    $sdnHealthObject = [SdnHealth]::new()
+    $netConnectionExistsScriptBlock = {
+        $tcpConnection = Get-NetTCPConnection -RemotePort 6640 -ErrorAction SilentlyContinue | Where-Object { $_.State -eq "Established" }
+        if ($tcpConnection) {
+            return $true
+        }
+    }
+
+    try {
+        "Validating connectivity between Server and primary replica of API service within Network Controller" | Trace-Output
+        $servers = Get-SdnServer -NcUri $SdnEnvironmentObject.NcUrl.AbsoluteUri -Credential $NcRestCredential
+
+        # if no load balancer muxes configured within the environment, return back the health object to caller
+        if ($null -ieq $servers) {
+            return $sdnHealthObject
+        }
+
+        # get the current primary replica of Network Controller
+        # if we cannot return the primary replica, then something is critically wrong with Network Controller
+        # in which case we should mark this test as failed and return back to the caller with guidance to fix the SlbManagerService
+        $primaryReplicaNode = Get-SdnServiceFabricReplica -NetworkController $SdnEnvironmentObject.EnvironmentInfo.NetworkController -ServiceTypeName 'ApiService' -Credential $NcRestCredential -Primary
+        if ($null -ieq $primaryReplicaNode) {
+            "Unable to return primary replica of ApiService" | Trace-Output -Level:Exception
+            $sdnHealthObject.Result = 'FAIL'
+            $sdnHealthObject.Remediation = "Fix the primary replica of ApiService within Network Controller."
+            return $sdnHealthObject
+        }
+
+        # enumerate through the servers in the environment and validate the TCP connection state
+        # we expect the NCHostAgent to have an active connection to ApiService within Network Controller via port 6640, which informs
+        # Network Controller that the host is operational and ready to receive policy configuration updates
+        foreach ($server in $servers) {
+            [System.Array]$connectionAddress = Get-SdnServer -NcUri $SdnEnvironmentObject.NcUrl.AbsoluteUri -ResourceId $server.resourceId -ManagementAddressOnly -Credential $NcRestCredential
+            $connectionExists = Invoke-PSRemoteCommand -ComputerName $connectionAddress[0] -Credential $Credential -ScriptBlock $netConnectionExistsScriptBlock
+            if (-NOT $connectionExists) {
+                "{0} is not connected to ApiService of Network Controller" -f $server.resourceRef | Trace-Output -Level:Exception
+                $sdnHealthObject.Result = 'FAIL'
+                $sdnHealthObject.Remediation += "Investigate and fix TCP connectivity or x509 authentication between $($primaryReplicaNode.ReplicaAddress) and $($server.resourceRef)."
+
+                $object = [PSCustomObject]@{
+                    Server = $server.resourceRef
+                    ApiPrimaryReplica = $primaryReplicaNode.ReplicaAddress
+                }
+
+                $sdnHealthObject.Properties += $object
+            }
+            else {
+                "{0} is connected to {1}" -f $server.resourceRef, $primaryReplicaNode.ReplicaAddress | Trace-Output -Level:Verbose
+            }
+        }
+    }
+    catch {
+        "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
+    }
+}

--- a/src/modules/SdnDiag.Health/private/Test-NcHostAgentConnectionToApiService.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-NcHostAgentConnectionToApiService.ps1
@@ -57,7 +57,7 @@ function Test-NcHostAgentConnectionToApiService {
             if (-NOT $connectionExists) {
                 "{0} is not connected to ApiService of Network Controller" -f $server.resourceRef | Trace-Output -Level:Exception
                 $sdnHealthObject.Result = 'FAIL'
-                $sdnHealthObject.Remediation += "Investigate and fix TCP connectivity or x509 authentication between $($primaryReplicaNode.ReplicaAddress) and $($server.resourceRef)."
+                $sdnHealthObject.Remediation += "Ensure NCHostAgent service is started. Investigate and fix TCP connectivity or x509 authentication between $($primaryReplicaNode.ReplicaAddress) and $($server.resourceRef)."
 
                 $object = [PSCustomObject]@{
                     Server = $server.resourceRef
@@ -70,6 +70,8 @@ function Test-NcHostAgentConnectionToApiService {
                 "{0} is connected to {1}" -f $server.resourceRef, $primaryReplicaNode.ReplicaAddress | Trace-Output -Level:Verbose
             }
         }
+
+        return $sdnHealthObject
     }
     catch {
         "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error

--- a/src/modules/SdnDiag.Health/private/Test-ResourceConfigurationState.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ResourceConfigurationState.ps1
@@ -41,6 +41,10 @@ function Test-ResourceConfigurationState {
 
                 $sdnHealthObject.Result = 'FAIL'
                 $sdnHealthObject.Remediation += "Examine the Network Controller logs to determine why $($object.resourceRef) provisioning failed."
+
+                # we can continue to the next object at this point
+                # as we do not care about the configurationState at this point if the provisioningState is not success
+                continue
             }
 
             # examine the configuration state of the resources and display errors to the screen

--- a/src/modules/SdnDiag.Health/private/Test-ResourceConfigurationState.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ResourceConfigurationState.ps1
@@ -53,10 +53,18 @@ function Test-ResourceConfigurationState {
                     'Error' {
                         $traceLevel = 'Exception'
                     }
+                    'Uninitialized' {
+                        # in scenarios where state is redundant, we will not fail the test
+                        # as this is expected to be uninitialized
+                        if ($object.properties.state -ieq 'Redundant') {
+                            continue
+                        }
+                        else {
+                            $traceLevel = 'Exception'
+                        }
+                    }
                     default {
-                        # for all other statuses, we will log to verbose
-                        # gateways leverage an Uninitialized for when a gateway is passive and not hosting any virtual gateways, so we will ignore this
-                        continue
+                        $traceLevel = 'Information'
                     }
                 }
 

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricApplicationHealth.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricApplicationHealth.ps1
@@ -16,7 +16,6 @@ function Test-ServiceFabricApplicationHealth {
     )
 
     $sdnHealthObject = [SdnHealth]::new()
-    $array = @()
 
     try {
         "Validating the Service Fabric Application Health for Network Controller" | Trace-Output
@@ -29,9 +28,9 @@ function Test-ServiceFabricApplicationHealth {
         $applicationHealth = Get-SdnServiceFabricApplicationHealth -NetworkController $SdnEnvironmentObject.ComputerName -Credential $Credential
         if ($applicationHealth.AggregatedHealthState -ine 'Ok') {
             $sdnHealthObject.Result = 'FAIL'
+            $sdnHealthObject.Remediation += "Examine the Service Fabric Application Health for Network Controller to determine why the health is not OK."
         }
 
-        $sdnHealthObject.Properties = $array
         return $sdnHealthObject
     }
     catch {

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricApplicationHealth.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricApplicationHealth.ps1
@@ -1,0 +1,40 @@
+function Test-ServiceFabricApplicationHealth {
+    <#
+    .SYNOPSIS
+        Validate the health of the Network Controller application within Service Fabric.
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [SdnFabricEnvObject]$SdnEnvironmentObject,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    $sdnHealthObject = [SdnHealth]::new()
+    $array = @()
+
+    try {
+        "Validating the Service Fabric Application Health for Network Controller" | Trace-Output
+
+        $ncNodes = Get-SdnServiceFabricNode -NetworkController $SdnEnvironmentObject.ComputerName -Credential $credential
+        if($null -eq $ncNodes){
+            throw New-Object System.NullReferenceException("Unable to retrieve service fabric nodes")
+        }
+
+        $applicationHealth = Get-SdnServiceFabricApplicationHealth -NetworkController $SdnEnvironmentObject.ComputerName -Credential $Credential
+        if ($applicationHealth.AggregatedHealthState -ine 'Ok') {
+            $sdnHealthObject.Result = 'FAIL'
+        }
+
+        $sdnHealthObject.Properties = $array
+        return $sdnHealthObject
+    }
+    catch {
+        "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
+    }
+}

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricClusterHealth.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricClusterHealth.ps1
@@ -1,0 +1,40 @@
+function Test-ServiceFabricClusterHealth {
+    <#
+    .SYNOPSIS
+        Validate the health of the Network Controller cluster within Service Fabric.
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [SdnFabricEnvObject]$SdnEnvironmentObject,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    $sdnHealthObject = [SdnHealth]::new()
+    $array = @()
+
+    try {
+        "Validating the Service Fabric Cluster Health for Network Controller" | Trace-Output
+
+        $ncNodes = Get-SdnServiceFabricNode -NetworkController $SdnEnvironmentObject.ComputerName -Credential $credential
+        if($null -eq $ncNodes){
+            throw New-Object System.NullReferenceException("Unable to retrieve service fabric nodes")
+        }
+
+        $clusterHealth = Get-SdnServiceFabricClusterHealth -NetworkController $SdnEnvironmentObject.ComputerName -Credential $Credential
+        if ($clusterHealth.AggregatedHealthState -ine 'Ok') {
+            $sdnHealthObject.Result = 'FAIL'
+        }
+
+        $sdnHealthObject.Properties = $array
+        return $sdnHealthObject
+    }
+    catch {
+        "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
+    }
+}

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricClusterHealth.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricClusterHealth.ps1
@@ -16,7 +16,6 @@ function Test-ServiceFabricClusterHealth {
     )
 
     $sdnHealthObject = [SdnHealth]::new()
-    $array = @()
 
     try {
         "Validating the Service Fabric Cluster Health for Network Controller" | Trace-Output
@@ -29,9 +28,9 @@ function Test-ServiceFabricClusterHealth {
         $clusterHealth = Get-SdnServiceFabricClusterHealth -NetworkController $SdnEnvironmentObject.ComputerName -Credential $Credential
         if ($clusterHealth.AggregatedHealthState -ine 'Ok') {
             $sdnHealthObject.Result = 'FAIL'
+            $sdnHealthObject.Remediation += "Examine the Service Fabric Cluster Health for Network Controller to determine why the health is not OK."
         }
 
-        $sdnHealthObject.Properties = $array
         return $sdnHealthObject
     }
     catch {

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricNodeStatus.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricNodeStatus.ps1
@@ -16,7 +16,6 @@ function Test-ServiceFabricNodeStatus {
     )
 
     $sdnHealthObject = [SdnHealth]::new()
-    $array = @()
 
     try {
         "Validating the Service Fabric Nodes for Network Controller" | Trace-Output
@@ -29,7 +28,7 @@ function Test-ServiceFabricNodeStatus {
         foreach ($node in $ncNodes) {
             if ($node.NodeStatus -ine 'Up') {
                 $sdnHealthObject.Result = 'FAIL'
-                $sdnHealthObject.Remediation = 'Fix the Service Fabric Cluster'
+                $sdnHealthObject.Remediation = 'Examine the Service Fabric Nodes for Network Controller to determine why the node is not Up.'
             }
         }
 

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricNodeStatus.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricNodeStatus.ps1
@@ -1,0 +1,41 @@
+function Test-ServiceFabricNodeStatus {
+    <#
+    .SYNOPSIS
+        Validate the health of the Network Controller nodes within Service Fabric.
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [SdnFabricEnvObject]$SdnEnvironmentObject,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    $sdnHealthObject = [SdnHealth]::new()
+    $array = @()
+
+    try {
+        "Validating the Service Fabric Nodes for Network Controller" | Trace-Output
+
+        $ncNodes = Get-SdnServiceFabricNode -NetworkController $SdnEnvironmentObject.ComputerName -Credential $credential
+        if($null -eq $ncNodes){
+            throw New-Object System.NullReferenceException("Unable to retrieve service fabric nodes")
+        }
+
+        foreach ($node in $ncNodes) {
+            if ($node.NodeStatus -ine 'Up') {
+                $sdnHealthObject.Result = 'FAIL'
+                $sdnHealthObject.Remediation = 'Fix the Service Fabric Cluster'
+            }
+        }
+
+        return $sdnHealthObject
+    }
+    catch {
+        "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
+    }
+}

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricPartitionDatabaseSize.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricPartitionDatabaseSize.ps1
@@ -63,7 +63,8 @@ function Test-ServiceFabricPartitionDatabaseSize {
                     }
 
                     # if the imos database file exceeds 4GB, want to indicate failure as it should not grow to be larger than this size
-                    if([float]$formatedByteSize.GB -gt 4){
+                    # need to perform InvariantCulture to ensure that the decimal separator is a period
+                    if([float]::Parse($formatedByteSize.GB, [System.Globalization.NumberStyles]::Float, [System.Globalization.CultureInfo]::InvariantCulture) -gt 4){
                         "[{0}] Service {1} is reporting {2} GB in size" -f $node.NodeName, $ncService.ServiceName, $formatedByteSize.GB | Trace-Output -Level:Warning
 
                         $sdnHealthObject.Result = 'FAIL'

--- a/src/modules/SdnDiag.Health/private/Test-SlbManagerConnectionToMux.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-SlbManagerConnectionToMux.ps1
@@ -55,19 +55,19 @@ function Test-SlbManagerConnectionToMux {
             $virtualServerConnection = $virtualServer.properties.connections[0].managementAddresses
             $connectionExists = Invoke-PSRemoteCommand -ComputerName $virtualServerConnection -Credential $Credential -ScriptBlock $netConnectionExistsScriptBlock
             if (-NOT $connectionExists) {
-                "{0} is not connected to SlbManager of Network Controller" -f $virtualServerConnection | Trace-Output -Level:Exception
+                "{0} is not connected to SlbManager of Network Controller" -f $mux.resourceRef | Trace-Output -Level:Exception
                 $sdnHealthObject.Result = 'FAIL'
-                $sdnHealthObject.Remediation += "Fix connectivity between $($primaryReplicaNode.ReplicaAddress) and $($virtualServerConnection)."
+                $sdnHealthObject.Remediation += "Investigate and fix TCP connectivity or x509 authentication between $($primaryReplicaNode.ReplicaAddress) and $($mux.resourceRef)."
 
                 $object = [PSCustomObject]@{
-                    LoadBalancerMux = $virtualServerConnection
+                    LoadBalancerMux = $mux.resourceRef
                     SlbManagerPrimaryReplica = $primaryReplicaNode.ReplicaAddress
                 }
 
                 $sdnHealthObject.Properties += $object
             }
             else {
-                "{0} is connected to {1}" -f $virtualServerConnection, $primaryReplicaNode.ReplicaAddress | Trace-Output -Level:Verbose
+                "{0} is connected to {1}" -f $mux.resourceRef, $primaryReplicaNode.ReplicaAddress | Trace-Output -Level:Verbose
             }
         }
     }

--- a/src/modules/SdnDiag.Health/private/Write-HealthValidationInfo.ps1
+++ b/src/modules/SdnDiag.Health/private/Write-HealthValidationInfo.ps1
@@ -11,7 +11,7 @@ function Write-HealthValidationInfo {
         [String[]]$Remediation
     )
 
-    $details = Get-HealthValidationDetail -Id $Name
+    $details = Get-HealthData -Property 'HealthValidations' -Id $Name
 
     $outputString = "[$Role] $Name"
     $outputString += "`r`n`r`n"
@@ -20,7 +20,7 @@ function Write-HealthValidationInfo {
     $outputString += "Impact:`t`t`t$($details.Impact)`r`n"
 
     if (-NOT [string]::IsNullOrEmpty($Remediation)) {
-        $outputString += "Remediation:`r`n`t -$($Remediation -join "`r`n`t -")`r`n"
+        $outputString += "Remediation:`r`n`t -`t$($Remediation -join "`r`n`t -`t")`r`n"
     }
 
     if (-NOT [string]::IsNullOrEmpty($details.PublicDocUrl)) {

--- a/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
+++ b/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
@@ -111,6 +111,9 @@ function Debug-SdnFabricInfrastructure {
                 Credential              = $Credential
             }
 
+            # before proceeding with tests, ensure that the computer objects we are testing against are running the latest version of SdnDiagnostics
+            Install-SdnDiagnostics -ComputerName $sdnFabricDetails.ComputerName -Credential $Credential
+
             # perform the health validations for the appropriate roles that were specified directly
             # or determined via which ComputerNames were defined
             switch ($object) {

--- a/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
+++ b/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
@@ -136,6 +136,9 @@ function Debug-SdnFabricInfrastructure {
                     $roleHealthReport.HealthValidation += @(
                         Test-ServiceState @computerCredParams
                         Test-ServiceFabricPartitionDatabaseSize @computerCredParams
+                        Test-ServiceFabricClusterHealth @computerCredParams
+                        Test-ServiceFabricApplicationHealth @computerCredParams
+                        Test-ServiceFabricNodeStatus @computerCredParams
                         Test-NetworkInterfaceAPIDuplicateMacAddress @restApiParams
                         Test-ScheduledTaskEnabled @computerCredParams
                         Test-NetworkControllerCertCredential @computerCredAndRestApiParams

--- a/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
+++ b/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
@@ -153,6 +153,7 @@ function Debug-SdnFabricInfrastructure {
                         Test-VMNetAdapterDuplicateMacAddress @computerCredParams
                         Test-HostRootStoreNonRootCert @computerCredParams
                         Test-ScheduledTaskEnabled @computerCredParams
+                        Test-NcHostAgentConnectionToApiService @computerCredAndRestApiParams
                     )
                 }
             }

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnVirtualServer.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnVirtualServer.ps1
@@ -36,11 +36,15 @@ function Get-SdnVirtualServer {
         }
 
         if ($ManagementAddressOnly) {
+            $managementAddress = @()
+            foreach ($address in $result.properties.connections.managementAddresses) {
+                $managementAddress += $address
+            }
+
             # there might be multiple connection endpoints to each node so we will want to only return the unique results
             # this does not handle if some duplicate connections are listed as IPAddress with another record saved as NetBIOS or FQDN
             # further processing may be required by the calling function to handle that
-
-            return ($result.properties.connections.managementAddresses | Sort-Object -Unique)
+            return ($managementAddress | Sort-Object -Unique)
         }
         else {
             return $result

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
@@ -4,28 +4,74 @@ function Get-SdnGateway {
         Returns a list of gateways from network controller.
     .PARAMETER NcUri
         Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
+    .PARAMETER ResourceId
+        Specifies the unique identifier for the resource.
+    .PARAMETER ResourceRef
+        Specifies the resource reference for the resource.
 	.PARAMETER Credential
 		Specifies a user account that has permission to perform this action. The default is the current user.
     .PARAMETER ManagementAddressOnly
         Optional parameter to only return back the Management Address value.
+    .EXAMPLE
+        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -Credential (Get-Credential)
+    .EXAMPLE
+        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ManagementAddressOnly
+    .EXAMPLE
+        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceId 'f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e'
+    .EXAMPLE
+        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceRef 'gateways/f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e'
+    .EXAMPLE
+        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceId 'f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e' -ManagementAddressOnly
+    .EXAMPLE
+        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceRef 'gateways/f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e' -ManagementAddressOnly
     #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceRef')]
         [Uri]$NcUri,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
+        [String]$ResourceId,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
+        [String]$ResourceRef,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [switch]$ManagementAddressOnly
     )
 
+    $params = @{
+        NcUri = $NcUri
+        Resource = 'Servers'
+        Credential = $Credential
+    }
+
+    switch ($PSCmdlet.ParameterSetName()) {
+        'ResourceId' {
+            $params.Add('ResourceId', $ResourceId)
+        }
+        'ResourceRef' {
+            $params.Add('ResourceRef', $ResourceRef)
+        }
+        default {
+            # do nothing
+        }
+    }
+
     try {
-        $result = Get-SdnResource -NcUri $NcUri.AbsoluteUri -Resource:Gateways -Credential $Credential
+        $result = Get-SdnResource @params
         if ($result) {
             foreach($obj in $result){
                 if($obj.properties.provisioningState -ne 'Succeeded'){

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
@@ -33,10 +33,10 @@ function Get-SdnGateway {
         [Parameter(Mandatory = $true, ParameterSetName = 'ResourceRef')]
         [Uri]$NcUri,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId')]
         [String]$ResourceId,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceRef')]
         [String]$ResourceRef,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
@@ -54,19 +54,19 @@ function Get-SdnGateway {
 
     $params = @{
         NcUri = $NcUri
-        Resource = 'Servers'
         Credential = $Credential
     }
 
-    switch ($PSCmdlet.ParameterSetName()) {
+    switch ($PSCmdlet.ParameterSetName) {
         'ResourceId' {
+            $params.Add('Resource', 'Gateways')
             $params.Add('ResourceId', $ResourceId)
         }
         'ResourceRef' {
             $params.Add('ResourceRef', $ResourceRef)
         }
         default {
-            # do nothing
+            $params.Add('Resource', 'Gateways')
         }
     }
 

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
@@ -34,12 +34,13 @@ function Get-SdnGateway {
             }
 
             if($ManagementAddressOnly){
-                $managementAddresses = [System.Collections.ArrayList]::new()
+                $managementAddress = @()
                 foreach ($resource in $result) {
                     $virtualServerMgmtAddress = Get-SdnVirtualServer -NcUri $NcUri.AbsoluteUri -ResourceRef $resource.properties.virtualserver.ResourceRef -ManagementAddressOnly -Credential $Credential
-                    [void]$managementAddresses.Add($virtualServerMgmtAddress)
+                    $managementAddress += $virtualServerMgmtAddress
                 }
-                return $managementAddresses
+
+                return ($managementAddress | Sort-Object -Unique)
             }
             else{
                 return $result

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnLoadBalancerMux.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnLoadBalancerMux.ps1
@@ -4,28 +4,74 @@ function Get-SdnLoadBalancerMux {
         Returns a list of load balancer muxes from network controller
     .PARAMETER NcUri
         Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
+    .PARAMETER ResourceId
+        Specifies the unique identifier for the resource.
+    .PARAMETER ResourceRef
+        Specifies the resource reference for the resource.
 	.PARAMETER Credential
 		Specifies a user account that has permission to perform this action. The default is the current user.
     .PARAMETER ManagementAddressOnly
         Optional parameter to only return back the Management Address value.
+    .EXAMPLE
+        PS> Get-SdnLoadBalancerMux -NcUri 'https://NC.FQDN' -Credential (Get-Credential)
+    .EXAMPLE
+        PS> Get-SdnLoadBalancerMux -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ManagementAddressOnly
+    .EXAMPLE
+        PS> Get-SdnLoadBalancerMux -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceId 'f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e'
+    .EXAMPLE
+        PS> Get-SdnLoadBalancerMux -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceRef '/LoadBalancerMuxes/f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e'
+    .EXAMPLE
+        PS> Get-SdnLoadBalancerMux -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceId 'f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e' -ManagementAddressOnly
+    .EXAMPLE
+        PS> Get-SdnLoadBalancerMux -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceRef '/LoadBalancerMuxes/f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e' -ManagementAddressOnly
     #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceRef')]
         [Uri]$NcUri,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
+        [String]$ResourceId,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
+        [String]$ResourceRef,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [switch]$ManagementAddressOnly
     )
 
+    $params = @{
+        NcUri = $NcUri
+        Resource = 'Servers'
+        Credential = $Credential
+    }
+
+    switch ($PSCmdlet.ParameterSetName()) {
+        'ResourceId' {
+            $params.Add('ResourceId', $ResourceId)
+        }
+        'ResourceRef' {
+            $params.Add('ResourceRef', $ResourceRef)
+        }
+        default {
+            # do nothing
+        }
+    }
+
     try {
-        $result = Get-SdnResource -NcUri $NcUri.AbsoluteUri -Resource:LoadBalancerMuxes -Credential $Credential
+        $result = Get-SdnResource @params
         if ($result) {
             foreach($obj in $result){
                 if($obj.properties.provisioningState -ne 'Succeeded'){

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnLoadBalancerMux.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnLoadBalancerMux.ps1
@@ -34,14 +34,15 @@ function Get-SdnLoadBalancerMux {
             }
 
             if($ManagementAddressOnly){
-                $managementAddresses = [System.Collections.ArrayList]::new()
+                $managementAddress = @()
                 foreach ($resource in $result) {
                     $virtualServerMgmtAddress = Get-SdnVirtualServer -NcUri $NcUri.AbsoluteUri -ResourceRef $resource.properties.virtualserver.ResourceRef -ManagementAddressOnly -Credential $Credential
-                    [void]$managementAddresses.Add($virtualServerMgmtAddress)
+                    $managementAddress += $virtualServerMgmtAddress
                 }
-                return $managementAddresses
+
+                return ($managementAddress | Sort-Object -Unique)
             }
-            else {
+            else{
                 return $result
             }
         }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnLoadBalancerMux.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnLoadBalancerMux.ps1
@@ -33,10 +33,10 @@ function Get-SdnLoadBalancerMux {
         [Parameter(Mandatory = $true, ParameterSetName = 'ResourceRef')]
         [Uri]$NcUri,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId')]
         [String]$ResourceId,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceRef')]
         [String]$ResourceRef,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
@@ -54,19 +54,19 @@ function Get-SdnLoadBalancerMux {
 
     $params = @{
         NcUri = $NcUri
-        Resource = 'Servers'
         Credential = $Credential
     }
 
-    switch ($PSCmdlet.ParameterSetName()) {
+    switch ($PSCmdlet.ParameterSetName) {
         'ResourceId' {
+            $params.Add('Resource', 'LoadBalancerMuxes')
             $params.Add('ResourceId', $ResourceId)
         }
         'ResourceRef' {
             $params.Add('ResourceRef', $ResourceRef)
         }
         default {
-            # do nothing
+            $params.Add('Resource', 'LoadBalancerMuxes')
         }
     }
 

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
@@ -4,6 +4,8 @@ function Get-SdnServer {
         Returns a list of servers from network controller.
     .PARAMETER NcUri
         Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
+    .PARAMETER ResourceId
+        Specifies the unique identifier of the resource. If this parameter is not specified, all resources are returned.
 	.PARAMETER Credential
 		Specifies a user account that has permission to perform this action. The default is the current user.
     .PARAMETER ManagementAddressOnly
@@ -16,6 +18,9 @@ function Get-SdnServer {
         [Uri]$NcUri,
 
         [Parameter(Mandatory = $false)]
+        [String]$ResourceId,
+
+        [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
@@ -24,8 +29,18 @@ function Get-SdnServer {
         [switch]$ManagementAddressOnly
     )
 
+    $params = @{
+        NcUri = $NcUri
+        Resource = 'Servers'
+        Credential = $Credential
+    }
+
+    if ($PSBoundParameters.ContainsKey('ResourceId')) {
+        [void]$params.Add('ResourceId', $ResourceId)
+    }
+
     try {
-        $result = Get-SdnResource -NcUri $NcUri.AbsoluteUri -Resource:Servers -Credential $Credential
+        $result = Get-SdnResource @params
         if ($result) {
             foreach($obj in $result){
                 if($obj.properties.provisioningState -ne 'Succeeded'){
@@ -34,10 +49,15 @@ function Get-SdnServer {
             }
 
             if($ManagementAddressOnly){
+                $managementAddress = @()
+                foreach ($address in $result.properties.connections.managementAddresses) {
+                    $managementAddress += $address
+                }
+
                 # there might be multiple connection endpoints to each node so we will want to only return the unique results
                 # this does not handle if some duplicate connections are listed as IPAddress with another record saved as NetBIOS or FQDN
                 # further processing may be required by the calling function to handle that
-                return ($result.properties.connections.managementAddresses | Sort-Object -Unique)
+                return ($managementAddress | Sort-Object -Unique)
             }
             else{
                 return $result

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
@@ -33,10 +33,10 @@ function Get-SdnServer {
         [Parameter(Mandatory = $true, ParameterSetName = 'ResourceRef')]
         [Uri]$NcUri,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId')]
         [String]$ResourceId,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceRef')]
         [String]$ResourceRef,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
@@ -54,19 +54,19 @@ function Get-SdnServer {
 
     $params = @{
         NcUri = $NcUri
-        Resource = 'Servers'
         Credential = $Credential
     }
 
-    switch ($PSCmdlet.ParameterSetName()) {
+    switch ($PSCmdlet.ParameterSetName) {
         'ResourceId' {
+            $params.Add('Resource', 'Servers')
             $params.Add('ResourceId', $ResourceId)
         }
         'ResourceRef' {
             $params.Add('ResourceRef', $ResourceRef)
         }
         default {
-            # do nothing
+            $params.Add('Resource', 'Servers')
         }
     }
 

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
@@ -5,27 +5,50 @@ function Get-SdnServer {
     .PARAMETER NcUri
         Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
     .PARAMETER ResourceId
-        Specifies the unique identifier of the resource. If this parameter is not specified, all resources are returned.
+        Specifies the unique identifier for the resource.
+    .PARAMETER ResourceRef
+        Specifies the resource reference for the resource.
 	.PARAMETER Credential
 		Specifies a user account that has permission to perform this action. The default is the current user.
     .PARAMETER ManagementAddressOnly
         Optional parameter to only return back the Management Address value.
+    .EXAMPLE
+        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -Credential (Get-Credential)
+    .EXAMPLE
+        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ManagementAddressOnly
+    .EXAMPLE
+        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceId 'f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e'
+    .EXAMPLE
+        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceRef 'Servers/f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e'
+    .EXAMPLE
+        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceId 'f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e' -ManagementAddressOnly
+    .EXAMPLE
+        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceRef 'Servers/f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e' -ManagementAddressOnly
     #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceRef')]
         [Uri]$NcUri,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
         [String]$ResourceId,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
+        [String]$ResourceRef,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [switch]$ManagementAddressOnly
     )
 
@@ -35,8 +58,16 @@ function Get-SdnServer {
         Credential = $Credential
     }
 
-    if ($PSBoundParameters.ContainsKey('ResourceId')) {
-        [void]$params.Add('ResourceId', $ResourceId)
+    switch ($PSCmdlet.ParameterSetName()) {
+        'ResourceId' {
+            $params.Add('ResourceId', $ResourceId)
+        }
+        'ResourceRef' {
+            $params.Add('ResourceRef', $ResourceRef)
+        }
+        default {
+            # do nothing
+        }
     }
 
     try {


### PR DESCRIPTION
# Description
Summary of changes:
- Expand configurationState tests to provide more informative information if issue detected
     ![image](https://github.com/microsoft/SdnDiagnostics/assets/18577812/bee55216-9d9f-42b1-9a5c-33f6b8658f89)
- Added the following new tests:
     - Check to ensure NCHostAgent has connectivity to SDN API endpoint
     - Check to ensure that the SF nodes are Up
     - Check to ensure that SF Cluster Health is OK
     - Check to ensure that SF Application Health is OK
- Fixed test for SF partition size to handle different cultures that using comma (,) rather than period (.) for decimal seperator.
- Changed placement of where the argument completers for Sdn.Health are stored
- Expanded functionality of `Get-SdnServer`, `Get-SdnLoadBalancerMux` and `Get-SdnGateway` to allow querying based on the `-ResourceId` and `-ResourceRef` properties.

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.