### PR TITLE
Disable correlation for netsh tracing by default

### DIFF
--- a/src/modules/SdnDiag.Common/private/Start-NetshTrace.ps1
+++ b/src/modules/SdnDiag.Common/private/Start-NetshTrace.ps1
@@ -12,6 +12,8 @@ function Start-NetshTrace {
         Optional. Specifies whether packet capture is enabled in addition to trace events. If unspecified, the default is No.
     .PARAMETER Overwrite
         Optional. Specifies whether this instance of the trace conversion command overwrites files that were rendered from previous trace conversions. If unspecified, the default is Yes.
+    .PARAMETER Correlation
+        Optional. Specifies whether related events will be correlated and grouped together. If unspecified, the default is No.
     .PARAMETER Report
         Optional. Specifies whether a complementing report will be generated in addition to the trace file report. If unspecified, the default is disabled.
     .EXAMPLE
@@ -46,7 +48,11 @@ function Start-NetshTrace {
 
         [Parameter(Mandatory = $false)]
         [ValidateSet('Enabled', 'Disabled')]
-        [System.String]$Report = 'Disabled'
+        [System.String]$Report = 'Disabled',
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Yes', 'No')]
+        [System.String]$Correlation = 'No'
     )
 
     try {
@@ -64,12 +70,12 @@ function Start-NetshTrace {
 
         # enable the network trace
         if ($TraceProviderString) {
-            $cmd = "netsh trace start capture={0} {1} tracefile={2} maxsize={3} overwrite={4} report={5}" `
-                -f $Capture, $TraceProviderString, $traceFile, $MaxTraceSize, $Overwrite, $Report
+            $cmd = "netsh trace start capture={0} {1} tracefile={2} maxsize={3} overwrite={4} report={5} correlation={6}" `
+                -f $Capture, $TraceProviderString, $traceFile, $MaxTraceSize, $Overwrite, $Report, $Correlation
         }
         else {
-            $cmd = "netsh trace start capture={0} tracefile={1} maxsize={2} overwrite={3} report={4}" `
-                -f $Capture, $traceFile, $MaxTraceSize, $Overwrite, $Report
+            $cmd = "netsh trace start capture={0} tracefile={1} maxsize={2} overwrite={3} report={4}, correlation={5}" `
+                -f $Capture, $traceFile, $MaxTraceSize, $Overwrite, $Report, $Correlation
         }
 
         "Starting netsh trace" | Trace-Output

--- a/src/modules/SdnDiag.Common/public/Start-SdnNetshTrace.ps1
+++ b/src/modules/SdnDiag.Common/public/Start-SdnNetshTrace.ps1
@@ -17,6 +17,8 @@ function Start-SdnNetshTrace {
         Optional. Specifies whether packet capture is enabled in addition to trace events. If unspecified, the default is No.
     .PARAMETER Overwrite
         Optional. Specifies whether this instance of the trace conversion command overwrites files that were rendered from previous trace conversions. If unspecified, the default is Yes.
+    .PARAMETER Correlation
+        Optional. Specifies whether related events will be correlated and grouped together. If unspecified, the default is No.
     .PARAMETER Report
         Optional. Specifies whether a complementing report will be generated in addition to the trace file report. If unspecified, the default is disabled.
     .EXAMPLE
@@ -51,6 +53,11 @@ function Start-SdnNetshTrace {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Local')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Remote')]
+        [ValidateSet('Yes', 'No')]
+        [System.String]$Correlation = 'No',
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Local')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Remote')]
         [ValidateSet('Enabled', 'Disabled')]
         [System.String]$Report = 'Disabled',
 
@@ -74,6 +81,7 @@ function Start-SdnNetshTrace {
         Capture = $Capture
         Overwrite = $Overwrite
         Report = $Report
+        Correlation = $Correlation
     }
 
     $scriptBlock = {
@@ -84,17 +92,18 @@ function Start-SdnNetshTrace {
             [Parameter(Position = 3)][String]$Capture,
             [Parameter(Position = 4)][String]$Overwrite,
             [Parameter(Position = 5)][String]$Report,
-            [Parameter(Position = 6)][String]$Providers
+            [Parameter(Position = 6)][String]$Correlation,
+            [Parameter(Position = 7)][String]$Providers
         )
 
         Start-SdnNetshTrace -Role $Role.ToString() -OutputDirectory $OutputDirectory `
-        -MaxTraceSize $MaxTraceSize -Capture $Capture -Overwrite $Overwrite -Report $Report -Providers $Providers
+        -MaxTraceSize $MaxTraceSize -Capture $Capture -Overwrite $Overwrite -Report $Report -Correlation $Correlation -Providers $Providers
     }
 
     try {
         if ($PSCmdlet.ParameterSetName -eq 'Remote') {
             Invoke-PSRemoteCommand -ComputerName $ComputerName -Credential $Credential -ScriptBlock $scriptBlock `
-            -ArgumentList @($Role.ToString(), $params.OutputDirectory, $params.MaxTraceSize, $params.Capture, $params.Overwrite, $params.Report, $Providers)
+            -ArgumentList @($Role.ToString(), $params.OutputDirectory, $params.MaxTraceSize, $params.Capture, $params.Overwrite, $params.Report, $params.Correlation, $Providers)
         }
         else {
             $traceProviderString = Get-TraceProviders -Role $Role.ToString() -Providers $Providers -AsString


### PR DESCRIPTION
# Description
Summary of changes:
- Add new parameter support for `correlation` for `start netsh trace`
- Set `correlation` to disabled by default

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.