### PR TITLE
Remove creating parent directory for SMB copy operation

### DIFF
--- a/src/modules/SdnDiag.Utilities/private/Copy-FileFromRemoteComputerSMB.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Copy-FileFromRemoteComputerSMB.ps1
@@ -62,21 +62,6 @@ function Copy-FileFromRemoteComputerSMB {
     }
 
     process {
-        # ensure that the destination directory already exists
-        # we want to check to see if destination is meant to be a folder or file
-        # if its a file, then we want the parent directory of the file
-        if ($Destination.Extension) {
-            $destinationRootDir = Split-Path -Path $params.Destination -Parent
-        }
-        else {
-            $destinationRootDir = $params.Destination
-        }
-
-        # create the parent directory first to prevent copy file operation failures
-        if (-NOT (Test-Path -Path $destinationRootDir -PathType Container)) {
-            $null = New-Item -Path $destinationRootDir -ItemType Directory
-        }
-
         foreach ($subPath in $Path) {
             $remotePath = Convert-FileSystemPathToUNC -ComputerName $ComputerName -Path $subPath
             if (-NOT (Test-Path -Path $remotePath)) {

--- a/src/modules/SdnDiag.Utilities/private/Copy-FileFromRemoteComputerWinRM.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Copy-FileFromRemoteComputerWinRM.ps1
@@ -43,21 +43,6 @@ function Copy-FileFromRemoteComputerWinRM {
 
     $session = New-PSRemotingSession -ComputerName $ComputerName -Credential $Credential
     if ($session) {
-        # ensure that the destination directory already exists
-        # we want to check to see if destination is meant to be a folder or file
-        # if its a file, then we want the parent directory of the file
-        if ($Destination.Extension) {
-            $destinationRootDir = Split-Path -Path $Destination.FullName -Parent
-        }
-        else {
-            $destinationRootDir = $Destination.FullName
-        }
-
-        # create the parent directory first to prevent copy file operation failures
-        if (-NOT (Test-Path -Path $destinationRootDir -PathType Container)) {
-            $null = New-Item -Path $destinationRootDir -ItemType Directory
-        }
-
         foreach ($subPath in $Path) {
             "Copying {0} to {1} using WinRM Session {2}" -f $subPath, $Destination.FullName, $session.Name | Trace-Output
             Copy-Item -Path $subPath -Destination $Destination.FullName -FromSession $session -Force:($Force.IsPresent) -Recurse:($Recurse.IsPresent) -ErrorAction:Continue

--- a/src/modules/SdnDiag.Utilities/private/Copy-FileToRemoteComputerSMB.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Copy-FileToRemoteComputerSMB.ps1
@@ -66,21 +66,6 @@ function Copy-FileToRemoteComputerSMB {
         $params.Destination = $remotePath.FullName
     }
     process {
-
-        # ensure that the destination directory already exists
-        # we want to check to see if destination is meant to be a folder or file
-        # if its a file, then we want the parent directory of the file
-        if ($remotePath.Extension) {
-            $destinationRootDir = Split-Path -Path $params.Destination -Parent
-        }
-        else {
-            $destinationRootDir = $params.Destination
-        }
-
-        if (-NOT (Test-Path -Path $destinationRootDir -PathType Container)) {
-            $null = New-Item -Path $destinationRootDir -ItemType Directory
-        }
-
         foreach ($subPath in $Path) {
             $params.Path = $subPath
 

--- a/src/modules/SdnDiag.Utilities/private/Copy-FileToRemoteComputerWinRM.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Copy-FileToRemoteComputerWinRM.ps1
@@ -43,25 +43,6 @@ function Copy-FileToRemoteComputerWinRM {
 
     $session = New-PSRemotingSession -ComputerName $ComputerName -Credential $Credential
     if ($session) {
-
-        # ensure that the destination directory already exists
-        # we want to check to see if destination is meant to be a folder or file
-        # if its a file, then we want the parent directory of the file
-        if ($Destination.Extension) {
-            $destinationRootDir = Split-Path -Path $Destination.FullName -Parent
-        }
-        else {
-            $destinationRootDir = $Destination.FullName
-        }
-
-        # create the parent directory first to prevent copy file operation failures
-        Invoke-PSRemoteCommand -ComputerName $session.ComputerName -Credential $Credential -ScriptBlock {
-            param([Parameter(Position = 0)][String]$param1)
-            if (-NOT (Test-Path -Path $param1 -PathType Container)) {
-                $null = New-Item -Path $param1 -ItemType Directory
-            }
-        } -ArgumentList $destinationRootDir
-
         # copy the files to the destination using WinRM
         foreach ($subPath in $Path) {
             "Copying {0} to {1} using WinRM Session {2}" -f $subPath, $Destination.FullName, $session.Name | Trace-Output


### PR DESCRIPTION
# Description
Summary of changes:
- Remove creating parent directory for SMB copy operation. Appears that when using normal Copy-Item operation and using SMB, it will automatically create the parent directory. Creating the parent folder appears to only be required for Copy-Item when using WinRM operation.
     - Validated that folder structure appears correct in environment where mix of SMB/WinRM copy is being leveraged for remote copy (Install-SdnDiagnostics) and copy to computer (Start-SdnDataCollection)

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.