### PR TITLE
Switch to using Name rather than ID to detect VFP extension

### DIFF
--- a/src/modules/SdnDiag.Server/public/Get-SdnNetAdapterEncapOverheadConfig.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnNetAdapterEncapOverheadConfig.ps1
@@ -11,9 +11,9 @@ function Get-SdnNetAdapterEncapOverheadConfig {
 
         # filter to only look at vSwitches where the Microsoft Azure VFP Switch Extension is installed
         # once we have the vSwitches, then need to then filter and only look at switches where VFP is enabled
-        $vfpSwitch = Get-VMSwitch | Where-Object {$_.Extensions.Id -ieq 'F74F241B-440F-4433-BB28-00F89EAD20D8'}
+        $vfpSwitch = Get-VMSwitch | Where-Object {$_.Extensions.Name -ieq 'Microsoft Azure VFP Switch Extension'}
         foreach ($switch in $vfpSwitch) {
-            $vfpExtension = $switch.Extensions | Where-Object {$_.Id -ieq 'F74F241B-440F-4433-BB28-00F89EAD20D8'}
+            $vfpExtension = $switch.Extensions | Where-Object {$_.Name -ieq 'Microsoft Azure VFP Switch Extension'}
             if ($vfpExtension.Enabled -ieq $false) {
                 continue
             }


### PR DESCRIPTION
# Description
Summary of changes:
- In some environments, `Test-EncapOverhead` returns back a false positive that an issue was found. This is because `Get-SdnNetAdapterEncapOverheadConfig` is returning `$null` when executed against a hyper-v host. Debugging, found that the VFP ID is not the same across build(s) due to certain reasons. Updated to instead filter based on Name, as should be sufficient for our purposes.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.