### PR TITLE
Add ability to configure between RestName and RestIPAddress

### DIFF
--- a/src/SdnDiagnostics.psd1
+++ b/src/SdnDiagnostics.psd1
@@ -133,6 +133,7 @@
         'Remove-SdnExpressBgpHost',
         'Repair-SdnDiagnosticsScheduledTask',
         'Set-SdnCertificateAcl',
+        'Set-SdnNetworkController',
         'Set-SdnServiceFabricClusterConfig',
         'Set-SdnVMNetworkAdapterPortProfile',
         'Show-SdnVfpPortConfig',

--- a/src/modules/SdnDiag.Health/SdnDiag.Health.Config.psd1
+++ b/src/modules/SdnDiag.Health/SdnDiag.Health.Config.psd1
@@ -93,6 +93,11 @@
             Impact = "Policy configuration may not be pushed to the Hyper-V host(s) if no southbound connectivity is available."
             PublicDocUrl = ""
         }
+        'Test-NcUrlNameResolution' = @{
+            Description = "Network Controller URL is not resolvable."
+            Impact = "Calls to Network Controller NB API will fail resulting in policy configuration failures and unable to manage SDN resources."
+            PublicDocUrl = ""
+        }
     }
     ConfigurationStateErrorCodes = @{
         'Unknown' = @{

--- a/src/modules/SdnDiag.Health/private/Test-NcUrlNameResolution.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-NcUrlNameResolution.ps1
@@ -1,0 +1,61 @@
+function Test-NcUrlNameResolution {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [SdnFabricEnvObject]$SdnEnvironmentObject,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $NcRestCredential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    $sdnHealthObject = [SdnHealth]::new()
+
+    try {
+        $ncApiReplicaPrimary = Get-SdnServiceFabricReplica -NetworkController $SdnEnvironmentObject.ComputerName -Credential $credential -ServiceTypeName 'ApiService' -Primary
+        if ($null -eq $ncApiReplicaPrimary) {
+            "Unable to find the primary replica for the ApiService" | Trace-Output -Level:Warning
+            return $sdnHealthObject
+        }
+
+        $nbApiName = $SdnEnvironmentObject.NcUrl.AbsoluteUri.Split('/')[2]
+        $ncNodeName = $ncApiReplicaPrimary.ReplicaAddress.Split(':')[0]
+
+        if ($ncNodeName -is [System.Net.IPAddress]) {
+            $ncNodeIp = $ncNodeName.ToString()
+        }
+        else {
+            $ncNodeIp = Resolve-DnsName -Name $ncNodeName -NoHostsFile -ErrorAction SilentlyContinue
+            if ($null -ieq $ncNodeIp) {
+                "Unable to resolve IP address for {0}" -f $ncNodeName | Trace-Output -Level:Warning
+                return $sdnHealthObject
+            }
+        }
+
+        "ApiService replica primary is hosted on {0} with an IP address of {1}" -f $ncApiReplicaPrimary.ReplicaAddress, $ncNodeIp | Trace-Output
+        $dnsResult = Resolve-DnsName -Name $nbApiName -NoHostsFile -ErrorAction SilentlyContinue
+        if ($null -ieq $dnsResult) {
+            $sdnHealthObject.Result = 'FAIL'
+
+            "Unable to resolve DNS name for {0}" -f $nbApiName | Trace-Output -Level:Warning
+            return $sdnHealthObject
+        }
+        elseif ($dnsResult[0].IPAddress -ine $ncNodeIp) {
+            $sdnHealthObject.Result = 'FAIL'
+            $sdnHealthObject.Remediation = 'Ensure that the DNS name for the Network Controller NB API URL resolves to the correct IP address.'
+
+            "DNS name for {0} resolves to {1} instead of {2}" -f $nbApiName, $dnsResult[0].IPAddress, $ncNodeIp | Trace-Output -Level:Warning
+            return $sdnHealthObject
+        }
+    }
+    catch {
+        "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
+    }
+}

--- a/src/modules/SdnDiag.Health/private/Test-NcUrlNameResolution.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-NcUrlNameResolution.ps1
@@ -27,7 +27,7 @@ function Test-NcUrlNameResolution {
             return $sdnHealthObject
         }
 
-        $networkController = Get-SdnNetworkController -NetworkController $SdnEnvironmentObject.ComputerName -Credential $Credential
+        $networkController = Get-SdnNetworkController -NetworkController $SdnEnvironmentObject.ComputerName[0] -Credential $Credential
         if ($null -eq $networkController) {
             "Unable to retrieve results from Get-SdnNetworkController" | Trace-Output -Level:Warning
             return $sdnHealthObject
@@ -73,6 +73,8 @@ function Test-NcUrlNameResolution {
             "DNS name for {0} resolves to {1} instead of {2}" -f $nbApiName, $dnsResult[0].IPAddress, $expectedIPAddress | Trace-Output -Level:Warning
             return $sdnHealthObject
         }
+
+        return $sdnHealthObject
     }
     catch {
         "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error

--- a/src/modules/SdnDiag.Health/private/Test-NcUrlNameResolution.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-NcUrlNameResolution.ps1
@@ -39,7 +39,7 @@ function Test-NcUrlNameResolution {
             }
         }
 
-        "ApiService replica primary is hosted on {0} with an IP address of {1}" -f $ncApiReplicaPrimary.ReplicaAddress, $ncNodeIp | Trace-Output
+        "ApiService replica primary is hosted on {0} with an IP address of {1}" -f $ncApiReplicaPrimary.ReplicaAddress, $ncNodeIp.IPAddress | Trace-Output -Level:Verbose
         $dnsResult = Resolve-DnsName -Name $nbApiName -NoHostsFile -ErrorAction SilentlyContinue
         if ($null -ieq $dnsResult) {
             $sdnHealthObject.Result = 'FAIL'
@@ -47,11 +47,11 @@ function Test-NcUrlNameResolution {
             "Unable to resolve DNS name for {0}" -f $nbApiName | Trace-Output -Level:Warning
             return $sdnHealthObject
         }
-        elseif ($dnsResult[0].IPAddress -ine $ncNodeIp) {
+        elseif ($dnsResult[0].IPAddress -ine $ncNodeIp.IPAddress) {
             $sdnHealthObject.Result = 'FAIL'
             $sdnHealthObject.Remediation = 'Ensure that the DNS name for the Network Controller NB API URL resolves to the correct IP address.'
 
-            "DNS name for {0} resolves to {1} instead of {2}" -f $nbApiName, $dnsResult[0].IPAddress, $ncNodeIp | Trace-Output -Level:Warning
+            "DNS name for {0} resolves to {1} instead of {2}" -f $nbApiName, $dnsResult[0].IPAddress, $ncNodeIp.IPAddress | Trace-Output -Level:Warning
             return $sdnHealthObject
         }
     }

--- a/src/modules/SdnDiag.Health/private/Write-HealthValidationInfo.ps1
+++ b/src/modules/SdnDiag.Health/private/Write-HealthValidationInfo.ps1
@@ -17,7 +17,7 @@ function Write-HealthValidationInfo {
     $outputString += "`r`n`r`n"
     $outputString += "--------------------------`r`n"
     $outputString += "Description:`t$($details.Description)`r`n"
-    $outputString += "Impact:`t`t`t$($details.Impact)`r`n"
+    $outputString += "Impact:`t`t$($details.Impact)`r`n"
 
     if (-NOT [string]::IsNullOrEmpty($Remediation)) {
         $outputString += "Remediation:`r`n`t -`t$($Remediation -join "`r`n`t -`t")`r`n"

--- a/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
+++ b/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
@@ -146,6 +146,7 @@ function Debug-SdnFabricInfrastructure {
 
                 'NetworkController' {
                     $roleHealthReport.HealthValidation += @(
+                        Test-NcUrlNameResolution @computerCredAndRestApiParams
                         Test-ServiceState @computerCredParams
                         Test-ServiceFabricPartitionDatabaseSize @computerCredParams
                         Test-ServiceFabricClusterHealth @computerCredParams

--- a/src/modules/SdnDiag.NetworkController/public/Set-SdnNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Set-SdnNetworkController.ps1
@@ -39,6 +39,12 @@ function Set-SdnNetworkController {
         $params.Add('Credential', $Credential)
     }
 
+    # we do not support this operation being executed from remote session
+    # unless we have explicitly specified the Credential parameter
+    if ($PSSenderInfo -and $null -eq $Credential) {
+        throw New-Object System.NotSupportedException("This operation is not supported in a remote session without supplying -Credential.")
+    }
+
     # ensure that the module is running as local administrator
     $elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     if (-NOT $elevated) {
@@ -46,7 +52,7 @@ function Set-SdnNetworkController {
     }
 
     # add disclaimer that this feature is currently under preview
-    "This feature is currently under preview. Please report any issues to https://github.com/microsoft/SdnDiagnostics/issues so we can accurately track any issues." | Trace-Output -Level:Warning
+    "This feature is currently under preview. Please report any issues to https://github.com/microsoft/SdnDiagnostics/issues." | Trace-Output -Level:Warning
     $confirm = Confirm-UserInput -Message "Do you want to proceed with operation? [Y/N]:"
     if (-NOT $confirm) {
         "User has opted to abort the operation. Terminating operation" | Trace-Output -Level:Warning
@@ -121,7 +127,7 @@ function Set-SdnNetworkController {
                 # if we changing from RestName to RestIPAddress, then we need to remove the RestURL property and add the RestIPAddress property
                 # once we remove the RestUrl property, we need to insert a dummy CIDR value to ensure that the Set-NetworkController operation does not fail
                 else {
-                    "RestIPAddress is not configured. Operation will set RestIPAddress to {0}." -f $RestIpAddress | Trace-Output -Level:Warning
+                    "Operation will set RestIPAddress to {0}." -f $RestIpAddress | Trace-Output -Level:Warning
                     $confirm = Confirm-UserInput -Message "Do you want to proceed with operation? [Y/N]:"
                     if ($confirm) {
                         "Deleting the current RestURL property and inserting temporary RestIPAddress" | Trace-Output

--- a/src/modules/SdnDiag.NetworkController/public/Set-SdnNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Set-SdnNetworkController.ps1
@@ -136,4 +136,9 @@ function Set-SdnNetworkController {
     catch {
         "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
     }
+    finally {
+        if ($client) {
+            $client.Dispose()
+        }
+    }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Set-SdnNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Set-SdnNetworkController.ps1
@@ -41,8 +41,10 @@ function Set-SdnNetworkController {
 
     # we do not support this operation being executed from remote session
     # unless we have explicitly specified the Credential parameter
-    if ($PSSenderInfo -and $null -eq $Credential) {
-        throw New-Object System.NotSupportedException("This operation is not supported in a remote session without supplying -Credential.")
+    if ($PSSenderInfo) {
+        if ($Credential -eq [System.Management.Automation.PSCredential]::Empty -or $null -eq $Credential) {
+            throw New-Object System.NotSupportedException("This operation is not supported in a remote session without supplying -Credential.")
+        }
     }
 
     # ensure that the module is running as local administrator

--- a/src/modules/SdnDiag.NetworkController/public/Set-SdnNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Set-SdnNetworkController.ps1
@@ -151,7 +151,5 @@ function Set-SdnNetworkController {
         if ($client) {
             $client.Dispose()
         }
-
-        throw $_
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Set-SdnNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Set-SdnNetworkController.ps1
@@ -1,0 +1,139 @@
+function Set-SdnNetworkController {
+    <#
+    .SYNOPSIS
+        Sets network controller application settings.
+    .PARAMETER RestIPAddress
+        Specifies the IP address on which network controller nodes communicate with the REST clients. This IP address must not be an existing IP address on any of the network controller nodes.
+    .PARAMETER RestName
+        Specifies the DNS name of the Network Controller cluster. This must be specified if the Network Controller nodes are in different subnets. In this case, you must also enable dynamic registration of the RestName on the DNS servers.
+    .PARAMETER Credential
+        Specifies a user credential that has permission to perform this action. The default is the current user.
+        Specify this parameter only if you run this cmdlet on a computer that is not part of the network controller cluster.
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestIPAddress')]
+        [ValidateScript({
+            $split = $_.split('/')
+            if ($split.count -ne 2) { throw "RestIpAddress must be in CIDR format."}
+            if (!($split[0] -as [ipaddress] -as [bool])) { throw "Invalid IP address specified in RestIpAddress."}
+            if (($split[1] -le 0) -or ($split[1] -gt 32)) { throw "Invalid subnet bits specified in RestIpAddress."}
+            return $true
+        })]
+        [System.String]$RestIpAddress,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestName')]
+        [System.String]$RestName,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestIPAddress')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestName')]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential
+    )
+
+    # ensure that the module is running as local administrator
+    $elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    if (-NOT $elevated) {
+        throw New-Object System.Exception("This function requires elevated permissions. Run PowerShell as an Administrator and import the module again.")
+    }
+
+    # add disclaimer that this feature is currently under preview
+    "This feature is currently under preview. Please report any issues to https://github.com/microsoft/SdnDiagnostics/issues so we can accurately track any issues." | Trace-Output -Level:Warning
+    $confirm = Confirm-UserInput -Message "Do you want to proceed with operation? [Y/N]:"
+    if (-NOT $confirm) {
+        "User has opted to abort the operation. Terminating operation" | Trace-Output -Level:Warning
+        return
+    }
+
+    try {
+        $getNetworkController = Get-SdnNetworkController
+        if ($null -eq $getNetworkController) {
+            throw New-Object System.Exception("Unable to retrieve network controller information.")
+        }
+
+        Connect-ServiceFabricCluster | Out-Null
+        $param = Get-ServiceFabricApplication -ApplicationName 'fabric:/NetworkController' -ErrorAction Stop
+        $version = $param.ApplicationParameters["SDNAPIConfigVersion"].Value
+        $client=[System.Fabric.FabricClient]::new()
+
+        switch ($PSBoundParameters.ParameterSetName) {
+            'RestName' {
+                if ($getNetworkController.RestName) {
+                    $currentRestName = $getNetworkController.ServerCertificate.Thumbprint.Split('=')[1].Trim()
+                    if ($currentRestName -ieq $RestName) {
+                        "RestName is already set to {0}. Aborting operation." -f $currentRestName | Trace-Output -Level:Warning
+                        return
+                    }
+                    else {
+                        "Set-SdnNetworkController does not support changing RestName. Please use Set-NetworkController instead to update the RestName." | Trace-Output -Level:Warning
+                        return
+                    }
+                }
+
+                # if we changing from RestIPAddress to RestName, then we need to remove the RestIPAddress property and add the RestName property
+                else {
+                    "RestName is not configured. Configuring RestName to {0}. Operation will take several minutes." -f $RestName | Trace-Output -Level:Warning
+                    $confirm = Confirm-UserInput -Message "Do you want to proceed with operation? [Y/N]:"
+                    if ($confirm) {
+                        $client.PropertyManager.DeletePropertyAsync("fabric:/NetworkController/GlobalConfiguration", "SDNAPI.$version.RestIPAddress")
+
+                        Start-Sleep -Seconds 30 # wait for the property to be deleted
+                        Set-NetworkController @PSBoundParameters
+                    }
+                    else {
+                        "User has opted to abort the operation. Terminating operation" | Trace-Output
+                        return
+                    }
+                }
+            }
+
+            'RestIPAddress' {
+                # check to see if the RestIPAddress is already configured, if so, then cross-compare the value currently configured with the new value
+                # if we are just changing from one IP to another, then we can just update the value using Set-NetworkController
+                if ($getNetworkController.RestIPAddress) {
+                    if ($getNetworkController.RestIPAddress -ieq $RestIpAddress) {
+                        "RestIPAddress is already set to {0}. Aborting operation." -f $getNetworkController.RestIPAddress | Trace-Output -Level:Warning
+                        return
+                    }
+                    else {
+                        "RestIPAddress is currently set to {0}. Changing to {1}." -f $getNetworkController.RestIPAddress, $RestIpAddress | Trace-Output -Level:Warning
+                        $confirm = Confirm-UserInput -Message "Do you want to proceed with operation? [Y/N]:"
+                        if ($confirm) {
+                            "Configuring RestIPAddress to {0}. Operation will take several minutes." -f $RestIpAddress | Trace-Output -Level:Verbose
+                            Set-NetworkController @PSBoundParameters
+                        }
+                        else {
+                            "User has opted to abort the operation. Terminating operation" | Trace-Output
+                            return
+                        }
+                    }
+                }
+
+                # if we changing from RestName to RestIPAddress, then we need to remove the RestName property and add the RestIPAddress property
+                # once we remove the RestUrl property, we need to insert a dummy CIDR value to ensure that the Set-NetworkController operation does not fail
+                else {
+                    "RestIPAddress is not configured. Configuring RestIPAddress to {0}. Operation will take several minutes." -f $RestIpAddress | Trace-Output -Level:Warning
+                    $confirm = Confirm-UserInput -Message "Do you want to proceed with operation? [Y/N]:"
+                    if ($confirm) {
+                        $client.PropertyManager.DeletePropertyAsync("fabric:/NetworkController/GlobalConfiguration", "SDNAPI.$version.RestURL")
+                        $client.PropertyManager.PutPropertyAsync("fabric:/NetworkController/GlobalConfiguration", "SDNAPI.$version.RestIPAddress", "10.65.15.117/27")
+
+                        Start-Sleep -Seconds 30 # wait for the property to be deleted
+                        Set-NetworkController @PSBoundParameters
+                    }
+                    else {
+                        "User has opted to abort the operation. Terminating operation" | Trace-Output
+                        return
+                    }
+                }
+            }
+        }
+
+        return (Get-SdnNetworkController)
+    }
+    catch {
+        "{0}`n{1}" -f $_.Exception, $_.ScriptStackTrace | Trace-Output -Level:Error
+    }
+}


### PR DESCRIPTION
# Description
Summary of changes:
- Added `Set-SdnNetworkController` to enable ability to more easily switch between RestName and RestIPAddress
- Added new fabric health test to ensure that DNS returned for NB API matches the IP address of the ApiService primary replica for scenarios when using RestName
    ![image](https://github.com/microsoft/SdnDiagnostics/assets/18577812/6c64a54a-5816-4f7c-b349-691fe7d6b7a7)


# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [ ] I have tested and validated my code changes.