### PR TITLE
Fix ArgumentCompleters for Service Fabric Services and Debug

### DIFF
--- a/src/modules/SdnDiag.Health/SdnDiag.Health.Helper.psm1
+++ b/src/modules/SdnDiag.Health/SdnDiag.Health.Helper.psm1
@@ -46,7 +46,7 @@ $fabricInfraResultScriptBlock = @{
             return ($result.Name | Sort-Object -Unique)
         }
 
-        return $result.HealthValidation | Where-Object {$_.Name -like "*$wordToComplete*"} | Sort-Object
+        return $result.Name | Where-Object {$_.Name -like "*$wordToComplete*"} | Sort-Object
     }
 }
 

--- a/src/modules/SdnDiag.NetworkController/SdnDiag.NetworkController.Helper.psm1
+++ b/src/modules/SdnDiag.NetworkController/SdnDiag.NetworkController.Helper.psm1
@@ -69,7 +69,7 @@ $scriptBlocks = @{
             return ($serviceName | Sort-Object)
         }
 
-        return $serviceName | Where-Object {$_.ServiceName -like "*$wordToComplete*"} | Sort-Object
+        return $serviceName | Where-Object {$_ -ilike "*$wordToComplete*"} | Sort-Object
     }
 
     ServiceFabricServiceTypeName = {
@@ -92,7 +92,7 @@ $scriptBlocks = @{
             return ($serviceTypeName | Sort-Object)
         }
 
-        return $serviceTypeName | Where-Object {$_.ServiceTypeName -like "*$wordToComplete*"} | Sort-Object
+        return $serviceTypeName | Where-Object {$_ -ilike "*$wordToComplete*"} | Sort-Object
     }
 }
 


### PR DESCRIPTION
# Description
Summary of changes:
- Fixed an issue with Argument Completers where tab complete was not working if you had already started typing the property value.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.