### PR TITLE
Fix issue where default Depth for JSON is not sufficient to show all properties

### DIFF
--- a/src/modules/SdnDiag.Common/private/Get-GeneralConfigurationState.ps1
+++ b/src/modules/SdnDiag.Common/private/Get-GeneralConfigurationState.ps1
@@ -46,9 +46,9 @@ function Get-GeneralConfigurationState {
         $outputDir = New-Item -Path (Join-Path -Path $OutputDirectory.FullName -ChildPath 'NetAdapter') -ItemType Directory -Force
         foreach($adapter in Get-NetAdapter){
             Get-NetAdapter -Name $adapter.Name | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix $adapter.Name -Name 'Get-NetAdapter' -FileType txt -Format List
-            Get-NetAdapterSriov -Name $adapter.Name | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix $adapter.Name -Name 'Get-NetAdapterSriov' -FileType txt -Format List
+            Get-NetAdapterSriov -Name $adapter.Name -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix $adapter.Name -Name 'Get-NetAdapterSriov' -FileType txt -Format List
             Get-NetAdapterRsc -Name $adapter.Name | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix $adapter.Name -Name 'Get-NetAdapterRsc' -FileType txt -Format List
-            Get-NetAdapterHardwareInfo -Name $adapter.Name | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix $adapter.Name -Name 'Get-NetAdapterHardwareInfo' -FileType txt -Format List
+            Get-NetAdapterHardwareInfo -Name $adapter.Name -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix $adapter.Name -Name 'Get-NetAdapterHardwareInfo' -FileType txt -Format List
             Get-NetAdapterAdvancedProperty -Name $adapter.Name `
                 | Export-ObjectToFile -FilePath $outputDir.FullName -Prefix $adapter.Name -Name 'Get-NetAdapterAdvancedProperty' -FileType txt -Format List
         }

--- a/src/modules/SdnDiag.Common/public/Enable-SdnVipTrace.ps1
+++ b/src/modules/SdnDiag.Common/public/Enable-SdnVipTrace.ps1
@@ -146,7 +146,7 @@ function Enable-SdnVipTrace {
         $null = Stop-SdnNetshTrace -ComputerName $networkTraceNodes -Credential $Credential
 
         "Tracing has been disabled on the SDN infrastructure. Saving configuration details to {0}\{1}_TraceMapping.json" -f (Get-WorkingDirectory), $VirtualIP | Trace-Output
-        $Script:SdnDiagnostics_Common.Cache['TraceMapping'] | Export-ObjectToFile -FilePath (Get-WorkingDirectory) -Prefix $VirtualIP -Name 'TraceMapping' -FileType 'json'
+        $Script:SdnDiagnostics_Common.Cache['TraceMapping'] | Export-ObjectToFile -FilePath (Get-WorkingDirectory) -Prefix $VirtualIP -Name 'TraceMapping' -FileType json -Depth 3
 
         $traceFileInfo = @()
         foreach ($obj in $traceInfo) {

--- a/src/modules/SdnDiag.Common/public/Start-SdnDataCollection.ps1
+++ b/src/modules/SdnDiag.Common/public/Start-SdnDataCollection.ps1
@@ -215,7 +215,7 @@ function Start-SdnDataCollection {
         $debugInfraHealthResults = Get-SdnFabricInfrastructureResult
         if ($debugInfraHealthResults) {
             $debugInfraHealthResults.Values | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-SdnFabricInfrastructureResult_Summary' -FileType 'txt' -Format 'table'
-            $debugInfraHealthResults | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-SdnFabricInfrastructureResult' -FileType 'json'
+            $debugInfraHealthResults | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-SdnFabricInfrastructureResult' -FileType json -Depth 5
         }
 
         # enumerate through each role and collect appropriate data

--- a/src/modules/SdnDiag.Common/public/Start-SdnDataCollection.ps1
+++ b/src/modules/SdnDiag.Common/public/Start-SdnDataCollection.ps1
@@ -346,7 +346,7 @@ function Start-SdnDataCollection {
 
         $stopwatch.Stop()
         $dataCollectionObject.DurationInMinutes = $stopWatch.Elapsed.TotalMinutes
-        $dataCollectionObject | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'SdnDataCollection_Summary' -FileType json
+        $dataCollectionObject | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'SdnDataCollection_Summary' -FileType json -Depth 4
         "`Data collection completed. Logs have been saved to {0}" -f $OutputDirectory.FullName | Trace-Output -Level:Success
         Copy-Item -Path (Get-TraceOutputFile) -Destination $OutputDirectory.FullName
 

--- a/src/modules/SdnDiag.NetworkController/public/Invoke-SdnResourceDump.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Invoke-SdnResourceDump.ps1
@@ -54,7 +54,7 @@ function Invoke-SdnResourceDump {
             if ($minVersionInt -le $apiVersionInt) {
                 $sdnResource = Get-SdnResource -NcUri $NcUri.AbsoluteUri -ResourceRef $value.uri -Credential $Credential
                 if ($sdnResource) {
-                    $sdnResource | Export-ObjectToFile -FilePath $outputDir.FullName -Name $key -FileType json
+                    $sdnResource | Export-ObjectToFile -FilePath $outputDir.FullName -Name $key -FileType json -Depth 10
                 }
             }
         }

--- a/src/modules/SdnDiag.Server/public/Get-SdnServerConfigurationState.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnServerConfigurationState.ps1
@@ -55,7 +55,7 @@ function Get-SdnServerConfigurationState {
         }
 
         vfpctrl /list-vmswitch-port | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'vfpctrl_list-vmswitch-port' -FileType txt
-        Get-SdnVfpVmSwitchPort | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-SdnVfpVmSwitchPort' -FileType json
+        Get-SdnVfpVmSwitchPort | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-SdnVfpVmSwitchPort' -FileType json -Depth 3
 
         # Gather OVSDB databases
         "Gathering ovsdb database output" | Trace-Output -Level:Verbose


### PR DESCRIPTION
# Description
Summary of changes:
- For several properties we are dumping, need to add -Depth to bypass the default limit to ensure all the properties we need are displayed
- Fixed an issue where some cmdlets do not support $ErrorActionPreference by default, so need to explicitely declare `-ErrorAction $ErrorActionPreference` where it's already defined to `SilentlyContinue`

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.