### PR TITLE
Restart services post cert rotate and fix scenario where property is not being cast properly

### DIFF
--- a/src/modules/SdnDiag.NetworkController/private/Update-NetworkControllerConfig.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Update-NetworkControllerConfig.ps1
@@ -39,7 +39,7 @@ function Update-NetworkControllerConfig {
 
         if($null -ne $thumbprintProperty){
             "GlobalConfiguration: Property $($thumbprintProperty.Name) will be updated from $($thumbprintProperty.Value) to $nodeCertThumbprint" | Trace-Output
-            Set-SdnServiceFabricClusterConfig -Uri $globalConfigUri -Name $thumbprintProperty.Name -Value $nodeCertThumbprint
+            Set-SdnServiceFabricClusterConfig -Uri $globalConfigUri -Name $thumbprintProperty.Name.ToString() -Value $nodeCertThumbprint
         }
 
         # Cluster Config property name like NodeName.ClusterCertThumbprint
@@ -48,7 +48,7 @@ function Update-NetworkControllerConfig {
         # If NodeName.ClusterCertThumbprint exist (for Server 2022 +), Update
         if($null -ne $thumbprintProperty){
             "ClusterConfiguration: Property $($thumbprintProperty.Name) will be updated from $($thumbprintProperty.Value) to $nodeCertThumbprint" | Trace-Output
-            Set-SdnServiceFabricClusterConfig -Uri $clusterConfigUri -Name $thumbprintProperty.Name -Value $nodeCertThumbprint
+            Set-SdnServiceFabricClusterConfig -Uri $clusterConfigUri -Name $thumbprintProperty.Name.ToString() -Value $nodeCertThumbprint
         }
 
         $certProperty = $clusterConfigs | Where-Object Name -ieq $ncNode.NodeName
@@ -59,7 +59,7 @@ function Update-NetworkControllerConfig {
             } -ArgumentList @('Cert:\LocalMachine\My', $nodeCertThumbprint)
 
             "ClusterConfiguration: Property $($certProperty.Name) will be updated From :`n$($certProperty.Value) `nTo : `n$nodeCert" | Trace-Output
-            Set-SdnServiceFabricClusterConfig -Uri $clusterConfigUri -Name $certProperty.Name -Value $nodeCert.GetRawCertData()
+            Set-SdnServiceFabricClusterConfig -Uri $clusterConfigUri -Name $certProperty.Name.ToString() -Value $nodeCert.GetRawCertData()
         }
     }
 }


### PR DESCRIPTION
# Description
Summary of changes:
- Failover the SlbManagerService and vSwitchService if multiple NC nodes within the cluster, otherwise just stop the associated process to force new TLS connection(s) with the new certificates.
- Fixed an issue where PowerShell is casting the property incorrectly resulting in failure as it cannot convert it to `[string]`.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.