### PR TITLE
Improve functionality around Virtual IPs and Internal Load Balancers

### DIFF
--- a/src/SdnDiagnostics.psd1
+++ b/src/SdnDiagnostics.psd1
@@ -65,6 +65,7 @@
         'Get-SdnFabricInfrastructureResult',
         'Get-SdnGateway',
         'Get-SdnInfrastructureInfo',
+        'Get-SdnInternalLoadBalancer',
         'Get-SdnModuleConfiguration',
         'Get-SdnMuxCertificate',
         'Get-SdnMuxDistributedRouterIP',

--- a/src/modules/SdnDiag.NetworkController/private/Connect-SlbManager.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Connect-SlbManager.ps1
@@ -1,12 +1,17 @@
 function Connect-SlbManager {
     [CmdletBinding()]
-    param()
+    param(
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
+    )
 
     $slbClient = Get-SlbClient -ErrorAction Stop
 
     # we need identify the current primary replica for the slbmanager service
     # if the primary replica is on the local node, then we will use the loopback address
-    $slbManagerPrimary = Get-SdnServiceFabricReplica -ServiceTypeName 'SlbManagerService' -Primary -ErrorAction Stop
+    $slbManagerPrimary = Get-SdnServiceFabricReplica -ServiceTypeName 'SlbManagerService' -Primary -Credential $Credential -ErrorAction Stop
     if ($null -ieq $slbManagerPrimary) {
         throw "Unable to return primary replica of SlbManagerService"
     }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnInternalLoadBalancer.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnInternalLoadBalancer.ps1
@@ -1,0 +1,113 @@
+function Get-SdnInternalLoadBalancer {
+    <#
+        .SYNOPSIS
+            Performs lookups and joins between OVSDB resources, load balancers and virtual networks to create internal load balancer object mappings
+        .PARAMETER NcUri
+            Specifies the Network Controller URI to connect to.
+        .PARAMETER Credential
+            Specifies a user account that has permission to the Hyper-V Hosts within the SDN Fabric. The default is the current user.
+        .PARAMETER NcRestCredential
+            Specifies a user account that has permission to query the Network Controller NB API endpoint. The default is the current user.
+        .EXAMPLE
+            Get-SdnInternalLoadBalancer -NcUri https://nc.contoso.com -Credential (Get-Credential)
+    #>
+
+    param (
+        [Parameter(Mandatory = $true)]
+        [Uri]$NcUri,
+
+        [Parameter(Mandatory = $false)]
+        [IPAddress]$IPAddress,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $NcRestCredential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+
+    $array = @()
+    $subnetHash = [System.Collections.Hashtable]::new()
+    $frontendHash = [System.Collections.Hashtable]::new()
+
+    try {
+        $servers = Get-SdnServer -NcUri $NcUri -Credential $NcRestCredential -ManagementAddressOnly
+        $ovsdbAddressMappings = Get-SdnOvsdbAddressMapping -ComputerName $servers -Credential $Credential | Where-Object {$_.mappingType -eq 'learning_disabled'}
+        $loadBalancers = Get-SdnResource -NcUri $NcUri -Credential $NcRestCredential -Resource LoadBalancers
+        $virtualNetworks = Get-SdnResource-NcUri $NcUri -Credential $NcRestCredential -Resource VirtualNetworks
+
+        # if this returns null, this is due to no tenant internal load balancers have been provisioned on the system
+        # in which case all the further processing is not needed
+        if($null -eq $ovsdbAddressMappings){
+            "No tenant Internal Load Balancer references found within OVSDB" | Trace-Output -Level:Verbose
+            return $null
+        }
+
+        "Located {0} address mappings from OVSDB" -f $ovsdbAddressMappings.Count | Trace-Output -Level:Verbose
+        # create a hash table based on the subnet instanceId contained within the virtual networks
+        foreach($group in $virtualNetworks.properties.subnets | Group-Object InstanceID){
+            [void]$subnetHash.Add($group.Name, $group.Group)
+        }
+
+        "Located {0} subnets" -f $subnetHash.Count | Trace-Output -Level:Verbose
+        # create a hash table based on the resourceRef of the frontendIPConfigurations within the load balancers
+        foreach($group in $loadBalancers.properties.frontendIPConfigurations | Group-Object resourceRef){
+            [void]$frontendHash.Add($group.Name, $group.Group)
+        }
+
+        "Located {0} frontendIPConfigurations" -f $frontendHash.Count | Trace-Output -Level:Verbose
+        foreach($ovsdbObject in $ovsdbAddressMappings){
+
+            # leveraging the routing domain ID taken from the OVSDB objects we need to
+            # do a lookup against the virtual network subnets to locate the associated ip configurations
+            # once we have the ipconfiguration, we want to enumerate each load balancer to match on the customer ip address
+            $tenantSubnet = $subnetHash[$ovsdbObject.RoutingDomainID.Guid]
+            if($tenantSubnet){
+                $loadBalancerResourceRef = $tenantSubnet.properties.ipConfigurations | Where-Object {$_.ResourceRef -like "/loadBalancers/*"}
+                if($loadBalancerResourceRef){
+                    foreach($resource in $loadBalancerResourceRef){
+                        $internalLoadBalancer = $frontendHash[$resource.resourceRef]
+
+                        # if the customer ip address does not match between load balancer and ovsdb then skip it as
+                        # this is not the load balancer you are looking for
+                        if($internalLoadBalancer){
+                            if($internalLoadBalancer.properties.privateIPAddress -ne $ovsdbObject.CustomerAddress){
+                                continue
+                            }
+
+                            # create a new object to add to the array list as we now have all the mappings we want
+                            $array += [PSCustomObject]@{
+                                [String]ResourceRef = $internalLoadBalancer.resourceRef
+                                [IPAddress]CustomerAddress = $internalLoadBalancer.properties.privateIPAddress
+                                [IPAddress]ProviderAddress = $ovsdbObject.ProviderAddress
+                            }
+                        }
+                        else {
+                            "Unable to locate Load Balancer Frontend IP Configuration for {0}" -f $resource.resourceRef | Trace-Output -Level:Warning
+                        }
+                    }
+                }
+                else {
+                    "Unable to locate any Load Balancer objects within IP configurations for {0}" -f $tenantSubnet.resourceRef  | Trace-Output -Level:Warning
+                }
+            }
+            else {
+                "Unable to locate Virtual Network Subnet related to Routing Domain ID {0}" -f $ovsdbObject.RoutingDomainID | Trace-Output -Level:Warning
+            }
+        }
+
+        if ($IPAddress) {
+            return ($array | Where-Object {$_.CustomerAddress -eq $IPAddress})
+        }
+
+        return ($array | Sort-Object CustomerAddress -Unique)
+    }
+    catch {
+        $_ | Trace-Exception
+    }
+}

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnSlbStateInformation.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnSlbStateInformation.ps1
@@ -82,7 +82,7 @@ function Get-SdnSlbStateInformation {
         if ($VirtualIPAddress) {
             $tenantDetails = $stateResult.properties.output.datagroups | Where-object { $_.name -eq 'Tenant' }
             $vipDetails = $tenantDetails.dataSections.dataunits | Where-object { $_.name -eq $VirtualIPAddress.IPAddressToString }
-            return $vipDetails
+            return $vipDetails.value
         }
 
         return $stateResult.properties.output

--- a/src/modules/SdnDiag.NetworkController/public/Show-SdnVipState.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Show-SdnVipState.ps1
@@ -5,11 +5,22 @@ function Show-SdnVipState {
         [IPAddress]$VirtualIPAddress,
 
         [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $false)]
         [Switch]$Detailed
     )
 
     try {
-        $slbManager = Connect-SlbManager -ErrorAction Stop
+        if ($PSSenderInfo) {
+            if ($Credential -eq [System.Management.Automation.PSCredential]::Empty -or $null -eq $Credential) {
+                throw New-Object System.NotSupportedException("This operation is not supported in a remote session without supplying -Credential.")
+            }
+        }
+
+        $slbManager = Connect-SlbManager -Credential $Credential -ErrorAction Stop
         if ($slbManager) {
             $consolidatedVipState = $slbManager.GetConsolidatedVipState($VirtualIPAddress, $Detailed)
             return $consolidatedVipState

--- a/src/modules/SdnDiag.Utilities/public/Install-SdnDiagnostics.ps1
+++ b/src/modules/SdnDiag.Utilities/public/Install-SdnDiagnostics.ps1
@@ -80,7 +80,10 @@ function Install-SdnDiagnostics {
         }
         else {
             "Getting current installed version of SdnDiagnostics on {0}" -f ($filteredComputerName -join ', ') | Trace-Output -Level:Verbose
-            $remoteModuleVersion = Invoke-PSRemoteCommand -ComputerName $filteredComputerName -Credential $Credential -ImportModuleOnRemoteSession:$false -ScriptBlock {
+
+            # use Invoke-Command here, as we do not want to create a cached session for the remote computers
+            # as it will impact scenarios where we need to import the module on the remote computer for remote sessions
+            $remoteModuleVersion = Invoke-Command -ComputerName $filteredComputerName -Credential $Credential -ScriptBlock {
                 param ([string]$arg0)
                 try {
                     # Get the latest version of SdnDiagnostics Module installed


### PR DESCRIPTION
# Description
Summary of changes:
- Enable support to execute `Show-SdnVipState` from within a remote PSSession into NC node
- Added new function called `Get-SdnInternalLoadBalancer` which enumerates the internal load balancers configured on a system, in addition to filtering on specific CustomerAddress or ProviderAddress
- Fixed a scenario where PSSessions created and left behind if no node(s) are updated, even though they adhere to `ImportModuleOnRemoteSession:$true`, resulting in functions failing to work if module is in non-default path

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.