### PR TITLE
Disable Correlation for Netsh traces

### DIFF
--- a/src/modules/SdnDiag.Common/private/Start-NetshTrace.ps1
+++ b/src/modules/SdnDiag.Common/private/Start-NetshTrace.ps1
@@ -13,7 +13,7 @@ function Start-NetshTrace {
     .PARAMETER Overwrite
         Optional. Specifies whether this instance of the trace conversion command overwrites files that were rendered from previous trace conversions. If unspecified, the default is Yes.
     .PARAMETER Correlation
-        Optional. Specifies whether related events will be correlated and grouped together. If unspecified, the default is No.
+        Optional. Specifies whether related events will be correlated and grouped together. If unspecified, the default is disabled.
     .PARAMETER Report
         Optional. Specifies whether a complementing report will be generated in addition to the trace file report. If unspecified, the default is disabled.
     .EXAMPLE
@@ -47,12 +47,12 @@ function Start-NetshTrace {
         [System.String]$Overwrite = 'Yes',
 
         [Parameter(Mandatory = $false)]
-        [ValidateSet('Enabled', 'Disabled')]
+        [ValidateSet('Yes', 'No', 'Disabled')]
         [System.String]$Report = 'Disabled',
 
         [Parameter(Mandatory = $false)]
-        [ValidateSet('Yes', 'No')]
-        [System.String]$Correlation = 'No'
+        [ValidateSet('Yes', 'No', 'Disabled')]
+        [System.String]$Correlation = 'Disabled'
     )
 
     try {

--- a/src/modules/SdnDiag.Common/public/Start-SdnNetshTrace.ps1
+++ b/src/modules/SdnDiag.Common/public/Start-SdnNetshTrace.ps1
@@ -18,7 +18,7 @@ function Start-SdnNetshTrace {
     .PARAMETER Overwrite
         Optional. Specifies whether this instance of the trace conversion command overwrites files that were rendered from previous trace conversions. If unspecified, the default is Yes.
     .PARAMETER Correlation
-        Optional. Specifies whether related events will be correlated and grouped together. If unspecified, the default is No.
+        Optional. Specifies whether related events will be correlated and grouped together. If unspecified, the default is Disabled.
     .PARAMETER Report
         Optional. Specifies whether a complementing report will be generated in addition to the trace file report. If unspecified, the default is disabled.
     .EXAMPLE
@@ -54,12 +54,12 @@ function Start-SdnNetshTrace {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Local')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Remote')]
-        [ValidateSet('Yes', 'No')]
-        [System.String]$Correlation = 'No',
+        [ValidateSet('Yes', 'No', 'Disabled')]
+        [System.String]$Correlation = 'Disabled',
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Local')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Remote')]
-        [ValidateSet('Enabled', 'Disabled')]
+        [ValidateSet('Yes', 'No', 'Disabled')]
         [System.String]$Report = 'Disabled',
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Local')]


### PR DESCRIPTION
# Description
Summary of changes:
- Configure `correlation=disabled` for netsh trace to prevent issue where vm workload traffic disconnects when enabling tracing on vSwitch

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.