### PR TITLE
Add exception handling around HnvDiagnostics commands

### DIFF
--- a/src/modules/SdnDiag.Common/private/Get-CommonConfigState.ps1
+++ b/src/modules/SdnDiag.Common/private/Get-CommonConfigState.ps1
@@ -17,7 +17,7 @@ function Get-CommonConfigState {
     try {
         [System.IO.FileInfo]$OutputDirectory = Join-Path -Path $OutputDirectory.FullName -ChildPath "Common"
 
-        "Collect general configuration state details" | Trace-Output
+        "Collect general configuration state details" | Trace-Output -Level:Verbose
         if (-NOT (Initialize-DataCollection -FilePath $OutputDirectory.FullName -MinimumMB 100)) {
             "Unable to initialize environment for data collection" | Trace-Output -Level:Error
             return

--- a/src/modules/SdnDiag.Common/public/Get-SdnDiagnosticLogFile.ps1
+++ b/src/modules/SdnDiag.Common/public/Get-SdnDiagnosticLogFile.ps1
@@ -47,7 +47,7 @@ function Get-SdnDiagnosticLogFile {
         $commonConfig = Get-SdnModuleConfiguration -Role 'Common'
         # enumerate the log files in the log directory and filter based on the from and to date
         if (-NOT (Test-Path -Path $LogDir)) {
-            "{0} does not exist" -f $LogDir | Trace-Output
+            "{0} does not exist" -f $LogDir | Trace-Output -Level:Verbose
             return
         }
 


### PR DESCRIPTION
# Description
Summary of changes:
- When collecting data leveraging HnvDiagnostics module, add fault tolerance as these cmdlets do not have [CmdletBinding()] associated with them, resulting in any errors being logged as terminating

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.