### PR TITLE
Certificate rotate fails because variable is passed as string rather than boolean

### DIFF
--- a/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
@@ -58,6 +58,11 @@ function Start-SdnCertificateRotation {
         [switch]$Force
     )
 
+    # we do not support this operation being executed from remote session
+    if ($PSSenderInfo) {
+        throw New-Object System.NotSupportedException("This operation is not supported in a remote session. Please run this operation locally on Network Controller.")
+    }
+
     # ensure that the module is running as local administrator
     $elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     if (-NOT $elevated) {

--- a/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
@@ -100,6 +100,9 @@ function Start-SdnCertificateRotation {
         if ($NcInfraInfo.ClusterCredentialType -ieq 'X509') {
             $rotateNCNodeCerts = $true
         }
+        else {
+            $rotateNCNodeCerts = $false
+        }
 
         # Get the current rest certificate to determine if it is expired scenario or not.
         $currentRestCert = Get-SdnNetworkControllerRestCertificate
@@ -200,7 +203,7 @@ function Start-SdnCertificateRotation {
         if ($PSCmdlet.ParameterSetName -ieq 'Pfx') {
             "== STAGE: Install PFX Certificates to Fabric ==" | Trace-Output
             $pfxCertificates = Copy-UserProvidedCertificateToFabric -CertPath $CertPath -CertPassword $CertPassword -FabricDetails $sdnFabricDetails `
-            -NetworkControllerHealthy:$ncHealthy -Credential $Credential -RotateNodeCerts:$rotateNCNodeCerts
+            -NetworkControllerHealthy $ncHealthy -Credential $Credential -RotateNodeCerts $rotateNCNodeCerts
 
             $pfxCertificates | ForEach-Object {
                 if ($_.CertificateType -ieq 'NetworkControllerRest' ) {


### PR DESCRIPTION
# Description
Summary of changes:
- Fix an issue where PowerShell is passing variable as string rather than boolean

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.