### PR TITLE
Fix logging and fault tolerance for numerous functions

### DIFF
--- a/src/modules/SdnDiag.Common/private/Export-RegistryKeyConfigDetails.ps1
+++ b/src/modules/SdnDiag.Common/private/Export-RegistryKeyConfigDetails.ps1
@@ -46,6 +46,5 @@ function Export-RegistryKeyConfigDetails {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/private/Export-RegistryKeyConfigDetails.ps1
+++ b/src/modules/SdnDiag.Common/private/Export-RegistryKeyConfigDetails.ps1
@@ -46,5 +46,6 @@ function Export-RegistryKeyConfigDetails {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/private/Get-CommonConfigState.ps1
+++ b/src/modules/SdnDiag.Common/private/Get-CommonConfigState.ps1
@@ -76,6 +76,7 @@ function Get-CommonConfigState {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 
     $ProgressPreference = 'Continue'

--- a/src/modules/SdnDiag.Common/private/Get-CommonConfigState.ps1
+++ b/src/modules/SdnDiag.Common/private/Get-CommonConfigState.ps1
@@ -76,7 +76,6 @@ function Get-CommonConfigState {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 
     $ProgressPreference = 'Continue'

--- a/src/modules/SdnDiag.Common/private/Get-TraceProviders.ps1
+++ b/src/modules/SdnDiag.Common/private/Get-TraceProviders.ps1
@@ -75,5 +75,6 @@ function Get-TraceProviders {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/private/Get-TraceProviders.ps1
+++ b/src/modules/SdnDiag.Common/private/Get-TraceProviders.ps1
@@ -75,6 +75,5 @@ function Get-TraceProviders {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/private/Start-EtwTraceSession.ps1
+++ b/src/modules/SdnDiag.Common/private/Start-EtwTraceSession.ps1
@@ -54,5 +54,6 @@ function Start-EtwTraceSession {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/private/Start-EtwTraceSession.ps1
+++ b/src/modules/SdnDiag.Common/private/Start-EtwTraceSession.ps1
@@ -54,6 +54,5 @@ function Start-EtwTraceSession {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/private/Start-NetshTrace.ps1
+++ b/src/modules/SdnDiag.Common/private/Start-NetshTrace.ps1
@@ -109,6 +109,5 @@ function Start-NetshTrace {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/private/Start-NetshTrace.ps1
+++ b/src/modules/SdnDiag.Common/private/Start-NetshTrace.ps1
@@ -109,5 +109,6 @@ function Start-NetshTrace {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/private/Stop-EtwTraceSession.ps1
+++ b/src/modules/SdnDiag.Common/private/Stop-EtwTraceSession.ps1
@@ -27,6 +27,5 @@ function Stop-EtwTraceSession {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/private/Stop-EtwTraceSession.ps1
+++ b/src/modules/SdnDiag.Common/private/Stop-EtwTraceSession.ps1
@@ -27,5 +27,6 @@ function Stop-EtwTraceSession {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/private/Stop-NetshTrace.ps1
+++ b/src/modules/SdnDiag.Common/private/Stop-NetshTrace.ps1
@@ -36,5 +36,6 @@ function Stop-NetshTrace {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/private/Stop-NetshTrace.ps1
+++ b/src/modules/SdnDiag.Common/private/Stop-NetshTrace.ps1
@@ -36,6 +36,5 @@ function Stop-NetshTrace {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Convert-SdnEtwTraceToTxt.ps1
+++ b/src/modules/SdnDiag.Common/public/Convert-SdnEtwTraceToTxt.ps1
@@ -81,5 +81,6 @@ function Convert-SdnEtwTraceToTxt {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Convert-SdnEtwTraceToTxt.ps1
+++ b/src/modules/SdnDiag.Common/public/Convert-SdnEtwTraceToTxt.ps1
@@ -81,6 +81,5 @@ function Convert-SdnEtwTraceToTxt {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Enable-SdnVipTrace.ps1
+++ b/src/modules/SdnDiag.Common/public/Enable-SdnVipTrace.ps1
@@ -165,6 +165,5 @@ function Enable-SdnVipTrace {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Enable-SdnVipTrace.ps1
+++ b/src/modules/SdnDiag.Common/public/Enable-SdnVipTrace.ps1
@@ -165,5 +165,6 @@ function Enable-SdnVipTrace {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Get-SdnCertificate.ps1
+++ b/src/modules/SdnDiag.Common/public/Get-SdnCertificate.ps1
@@ -60,6 +60,5 @@ function Get-SdnCertificate {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Get-SdnCertificate.ps1
+++ b/src/modules/SdnDiag.Common/public/Get-SdnCertificate.ps1
@@ -52,8 +52,10 @@ function Get-SdnCertificate {
             return $null
         }
 
-        if ($filteredCert.NotAfter -le (Get-Date)) {
-            "Certificate [Thumbprint: {0} | Subject: {1}] is currently expired" -f $filteredCert.Thumbprint, $filteredCert.Subject | Trace-Output -Level:Error
+        $filteredCert | ForEach-Object {
+            if ($_.NotAfter -le (Get-Date)) {
+                "Certificate [Thumbprint: {0} | Subject: {1}] is currently expired" -f $_.Thumbprint, $_.Subject | Trace-Output -Level:Warning
+            }
         }
 
         return $filteredCert

--- a/src/modules/SdnDiag.Common/public/Get-SdnCertificate.ps1
+++ b/src/modules/SdnDiag.Common/public/Get-SdnCertificate.ps1
@@ -60,5 +60,6 @@ function Get-SdnCertificate {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Get-SdnEventLog.ps1
+++ b/src/modules/SdnDiag.Common/public/Get-SdnEventLog.ps1
@@ -83,6 +83,5 @@ function Get-SdnEventLog {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Get-SdnEventLog.ps1
+++ b/src/modules/SdnDiag.Common/public/Get-SdnEventLog.ps1
@@ -83,5 +83,6 @@ function Get-SdnEventLog {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Invoke-SdnGetNetView.ps1
+++ b/src/modules/SdnDiag.Common/public/Invoke-SdnGetNetView.ps1
@@ -74,6 +74,5 @@ function Invoke-SdnGetNetView {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Invoke-SdnGetNetView.ps1
+++ b/src/modules/SdnDiag.Common/public/Invoke-SdnGetNetView.ps1
@@ -74,5 +74,6 @@ function Invoke-SdnGetNetView {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/New-SdnCertificate.ps1
+++ b/src/modules/SdnDiag.Common/public/New-SdnCertificate.ps1
@@ -50,6 +50,5 @@ function New-SdnCertificate {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/New-SdnCertificate.ps1
+++ b/src/modules/SdnDiag.Common/public/New-SdnCertificate.ps1
@@ -50,5 +50,6 @@ function New-SdnCertificate {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Repair-SdnDiagnosticsScheduledTask.ps1
+++ b/src/modules/SdnDiag.Common/public/Repair-SdnDiagnosticsScheduledTask.ps1
@@ -37,5 +37,6 @@ function Repair-SdnDiagnosticsScheduledTask {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Repair-SdnDiagnosticsScheduledTask.ps1
+++ b/src/modules/SdnDiag.Common/public/Repair-SdnDiagnosticsScheduledTask.ps1
@@ -37,6 +37,5 @@ function Repair-SdnDiagnosticsScheduledTask {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Set-SdnCertificateAcl.ps1
+++ b/src/modules/SdnDiag.Common/public/Set-SdnCertificateAcl.ps1
@@ -71,6 +71,5 @@ function Set-SdnCertificateAcl {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Set-SdnCertificateAcl.ps1
+++ b/src/modules/SdnDiag.Common/public/Set-SdnCertificateAcl.ps1
@@ -71,5 +71,6 @@ function Set-SdnCertificateAcl {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Start-SdnEtwTraceCapture.ps1
+++ b/src/modules/SdnDiag.Common/public/Start-SdnEtwTraceCapture.ps1
@@ -42,5 +42,6 @@ function Start-SdnEtwTraceCapture {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Start-SdnEtwTraceCapture.ps1
+++ b/src/modules/SdnDiag.Common/public/Start-SdnEtwTraceCapture.ps1
@@ -42,6 +42,5 @@ function Start-SdnEtwTraceCapture {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Start-SdnNetshTrace.ps1
+++ b/src/modules/SdnDiag.Common/public/Start-SdnNetshTrace.ps1
@@ -130,6 +130,5 @@ function Start-SdnNetshTrace {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Start-SdnNetshTrace.ps1
+++ b/src/modules/SdnDiag.Common/public/Start-SdnNetshTrace.ps1
@@ -130,5 +130,6 @@ function Start-SdnNetshTrace {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Stop-SdnEtwTraceCapture.ps1
+++ b/src/modules/SdnDiag.Common/public/Stop-SdnEtwTraceCapture.ps1
@@ -29,5 +29,6 @@ function Stop-SdnEtwTraceCapture {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Stop-SdnEtwTraceCapture.ps1
+++ b/src/modules/SdnDiag.Common/public/Stop-SdnEtwTraceCapture.ps1
@@ -29,6 +29,5 @@ function Stop-SdnEtwTraceCapture {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Stop-SdnNetshTrace.ps1
+++ b/src/modules/SdnDiag.Common/public/Stop-SdnNetshTrace.ps1
@@ -31,6 +31,5 @@ function Stop-SdnNetshTrace {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Common/public/Stop-SdnNetshTrace.ps1
+++ b/src/modules/SdnDiag.Common/public/Stop-SdnNetshTrace.ps1
@@ -31,5 +31,6 @@ function Stop-SdnNetshTrace {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Gateway/private/Get-GatewayConfigState.ps1
+++ b/src/modules/SdnDiag.Gateway/private/Get-GatewayConfigState.ps1
@@ -74,7 +74,6 @@ function Get-GatewayConfigState {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 
     $ProgressPreference = 'Continue'

--- a/src/modules/SdnDiag.Gateway/private/Get-GatewayConfigState.ps1
+++ b/src/modules/SdnDiag.Gateway/private/Get-GatewayConfigState.ps1
@@ -74,6 +74,7 @@ function Get-GatewayConfigState {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 
     $ProgressPreference = 'Continue'

--- a/src/modules/SdnDiag.Gateway/public/Disable-SdnRasGatewayTracing.ps1
+++ b/src/modules/SdnDiag.Gateway/public/Disable-SdnRasGatewayTracing.ps1
@@ -22,6 +22,5 @@ function Disable-SdnRasGatewayTracing {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Gateway/public/Disable-SdnRasGatewayTracing.ps1
+++ b/src/modules/SdnDiag.Gateway/public/Disable-SdnRasGatewayTracing.ps1
@@ -22,5 +22,6 @@ function Disable-SdnRasGatewayTracing {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Gateway/public/Enable-SdnRasGatewayTracing.ps1
+++ b/src/modules/SdnDiag.Gateway/public/Enable-SdnRasGatewayTracing.ps1
@@ -37,6 +37,5 @@ function Enable-SdnRasGatewayTracing {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Gateway/public/Enable-SdnRasGatewayTracing.ps1
+++ b/src/modules/SdnDiag.Gateway/public/Enable-SdnRasGatewayTracing.ps1
@@ -37,5 +37,6 @@ function Enable-SdnRasGatewayTracing {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-EncapOverhead.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-EncapOverhead.ps1
@@ -63,6 +63,5 @@ function Test-EncapOverhead {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-EncapOverhead.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-EncapOverhead.ps1
@@ -63,5 +63,6 @@ function Test-EncapOverhead {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-HostRootStoreNonRootCert.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-HostRootStoreNonRootCert.ps1
@@ -62,6 +62,5 @@ function Test-HostRootStoreNonRootCert {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-HostRootStoreNonRootCert.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-HostRootStoreNonRootCert.ps1
@@ -62,5 +62,6 @@ function Test-HostRootStoreNonRootCert {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-MuxBgpConnectionState.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-MuxBgpConnectionState.ps1
@@ -71,6 +71,5 @@ function Test-MuxBgpConnectionState {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-MuxBgpConnectionState.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-MuxBgpConnectionState.ps1
@@ -71,5 +71,6 @@ function Test-MuxBgpConnectionState {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-NcHostAgentConnectionToApiService.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-NcHostAgentConnectionToApiService.ps1
@@ -78,6 +78,5 @@ function Test-NcHostAgentConnectionToApiService {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-NcHostAgentConnectionToApiService.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-NcHostAgentConnectionToApiService.ps1
@@ -78,5 +78,6 @@ function Test-NcHostAgentConnectionToApiService {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-NcUrlNameResolution.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-NcUrlNameResolution.ps1
@@ -78,6 +78,5 @@ function Test-NcUrlNameResolution {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-NcUrlNameResolution.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-NcUrlNameResolution.ps1
@@ -78,5 +78,6 @@ function Test-NcUrlNameResolution {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-NetworkControllerCertCredential.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-NetworkControllerCertCredential.ps1
@@ -88,5 +88,6 @@ function Test-NetworkControllerCertCredential {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-NetworkControllerCertCredential.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-NetworkControllerCertCredential.ps1
@@ -88,6 +88,5 @@ function Test-NetworkControllerCertCredential {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-NetworkInterfaceAPIDuplicateMacAddress.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-NetworkInterfaceAPIDuplicateMacAddress.ps1
@@ -53,5 +53,6 @@ function Test-NetworkInterfaceAPIDuplicateMacAddress {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-NetworkInterfaceAPIDuplicateMacAddress.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-NetworkInterfaceAPIDuplicateMacAddress.ps1
@@ -53,6 +53,5 @@ function Test-NetworkInterfaceAPIDuplicateMacAddress {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ProviderNetwork.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ProviderNetwork.ps1
@@ -74,5 +74,6 @@ function Test-ProviderNetwork {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ProviderNetwork.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ProviderNetwork.ps1
@@ -74,6 +74,5 @@ function Test-ProviderNetwork {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ResourceConfigurationState.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ResourceConfigurationState.ps1
@@ -117,6 +117,5 @@ function Test-ResourceConfigurationState {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ResourceConfigurationState.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ResourceConfigurationState.ps1
@@ -117,5 +117,6 @@ function Test-ResourceConfigurationState {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ResourceProvisioningState.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ResourceProvisioningState.ps1
@@ -65,5 +65,6 @@ function Test-ResourceProvisioningState {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ResourceProvisioningState.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ResourceProvisioningState.ps1
@@ -65,6 +65,5 @@ function Test-ResourceProvisioningState {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ScheduledTaskEnabled.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ScheduledTaskEnabled.ps1
@@ -79,6 +79,5 @@ function Test-ScheduledTaskEnabled {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ScheduledTaskEnabled.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ScheduledTaskEnabled.ps1
@@ -79,5 +79,6 @@ function Test-ScheduledTaskEnabled {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ServerHostId.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServerHostId.ps1
@@ -56,5 +56,6 @@ function Test-ServerHostId {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ServerHostId.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServerHostId.ps1
@@ -56,6 +56,5 @@ function Test-ServerHostId {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricApplicationHealth.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricApplicationHealth.ps1
@@ -35,5 +35,6 @@ function Test-ServiceFabricApplicationHealth {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricApplicationHealth.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricApplicationHealth.ps1
@@ -35,6 +35,5 @@ function Test-ServiceFabricApplicationHealth {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricClusterHealth.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricClusterHealth.ps1
@@ -35,5 +35,6 @@ function Test-ServiceFabricClusterHealth {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricClusterHealth.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricClusterHealth.ps1
@@ -35,6 +35,5 @@ function Test-ServiceFabricClusterHealth {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricNodeStatus.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricNodeStatus.ps1
@@ -36,6 +36,5 @@ function Test-ServiceFabricNodeStatus {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricNodeStatus.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricNodeStatus.ps1
@@ -36,5 +36,6 @@ function Test-ServiceFabricNodeStatus {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricPartitionDatabaseSize.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricPartitionDatabaseSize.ps1
@@ -87,5 +87,6 @@ function Test-ServiceFabricPartitionDatabaseSize {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ServiceFabricPartitionDatabaseSize.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceFabricPartitionDatabaseSize.ps1
@@ -87,6 +87,5 @@ function Test-ServiceFabricPartitionDatabaseSize {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ServiceState.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceState.ps1
@@ -53,6 +53,5 @@ function Test-ServiceState {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-ServiceState.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-ServiceState.ps1
@@ -53,5 +53,6 @@ function Test-ServiceState {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-SlbManagerConnectionToMux.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-SlbManagerConnectionToMux.ps1
@@ -78,5 +78,6 @@ function Test-SlbManagerConnectionToMux {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-SlbManagerConnectionToMux.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-SlbManagerConnectionToMux.ps1
@@ -78,6 +78,5 @@ function Test-SlbManagerConnectionToMux {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-VMNetAdapterDuplicateMacAddress.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-VMNetAdapterDuplicateMacAddress.ps1
@@ -44,5 +44,6 @@ function Test-VMNetAdapterDuplicateMacAddress {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-VMNetAdapterDuplicateMacAddress.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-VMNetAdapterDuplicateMacAddress.ps1
@@ -44,6 +44,5 @@ function Test-VMNetAdapterDuplicateMacAddress {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-VfpDuplicatePort.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-VfpDuplicatePort.ps1
@@ -45,5 +45,6 @@ function Test-VfpDuplicatePort {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/private/Test-VfpDuplicatePort.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-VfpDuplicatePort.ps1
@@ -45,6 +45,5 @@ function Test-VfpDuplicatePort {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
+++ b/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
@@ -226,5 +226,6 @@ function Debug-SdnFabricInfrastructure {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
+++ b/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
@@ -226,6 +226,5 @@ function Debug-SdnFabricInfrastructure {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/private/Get-SlbMuxConfigState.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/private/Get-SlbMuxConfigState.ps1
@@ -45,7 +45,6 @@ function Get-SlbMuxConfigState {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 
     $ProgressPreference = 'Continue'

--- a/src/modules/SdnDiag.LoadBalancerMux/private/Get-SlbMuxConfigState.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/private/Get-SlbMuxConfigState.ps1
@@ -45,6 +45,7 @@ function Get-SlbMuxConfigState {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 
     $ProgressPreference = 'Continue'

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxCertificate.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxCertificate.ps1
@@ -15,5 +15,6 @@ function Get-SdnMuxCertificate {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxCertificate.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxCertificate.ps1
@@ -15,6 +15,5 @@ function Get-SdnMuxCertificate {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxDistributedRouterIP.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxDistributedRouterIP.ps1
@@ -32,6 +32,5 @@ function Get-SdnMuxDistributedRouterIP {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxDistributedRouterIP.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxDistributedRouterIP.ps1
@@ -32,5 +32,6 @@ function Get-SdnMuxDistributedRouterIP {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxState.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxState.ps1
@@ -10,6 +10,5 @@ function Get-SdnMuxState {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxState.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxState.ps1
@@ -10,5 +10,6 @@ function Get-SdnMuxState {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxStatefulVip.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxStatefulVip.ps1
@@ -32,6 +32,5 @@ function Get-SdnMuxStatefulVip {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxStatefulVip.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxStatefulVip.ps1
@@ -32,5 +32,6 @@ function Get-SdnMuxStatefulVip {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxStatelessVip.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxStatelessVip.ps1
@@ -32,6 +32,5 @@ function Get-SdnMuxStatelessVip {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxStatelessVip.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxStatelessVip.ps1
@@ -32,5 +32,6 @@ function Get-SdnMuxStatelessVip {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxStats.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxStats.ps1
@@ -27,5 +27,6 @@ function Get-SdnMuxStats {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxStats.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxStats.ps1
@@ -27,6 +27,5 @@ function Get-SdnMuxStats {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxVip.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxVip.ps1
@@ -32,6 +32,5 @@ function Get-SdnMuxVip {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxVip.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxVip.ps1
@@ -32,5 +32,6 @@ function Get-SdnMuxVip {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxVipConfig.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxVipConfig.ps1
@@ -38,6 +38,5 @@ function Get-SdnMuxVipConfig {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxVipConfig.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Get-SdnMuxVipConfig.ps1
@@ -38,5 +38,6 @@ function Get-SdnMuxVipConfig {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/New-SdnMuxCertificate.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/New-SdnMuxCertificate.ps1
@@ -71,6 +71,5 @@ function New-SdnMuxCertificate {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/New-SdnMuxCertificate.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/New-SdnMuxCertificate.ps1
@@ -71,5 +71,6 @@ function New-SdnMuxCertificate {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
@@ -201,6 +201,5 @@ function Start-SdnMuxCertificateRotation {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
@@ -201,5 +201,6 @@ function Start-SdnMuxCertificateRotation {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
@@ -80,11 +80,6 @@ function Start-SdnMuxCertificateRotation {
     # add disclaimer that this feature is currently under preview
     if (!$Force) {
         "This feature is currently under preview. Please report any issues to https://github.com/microsoft/SdnDiagnostics/issues so we can accurately track any issues and help unblock your cert rotation." | Trace-Output -Level:Warning
-        $confirm = Confirm-UserInput -Message "Do you want to proceed with certificate rotation? [Y/N]:"
-        if (-NOT $confirm) {
-            "User has opted to abort the operation. Terminating operation" | Trace-Output -Level:Warning
-            return
-        }
     }
 
     $array = @()

--- a/src/modules/SdnDiag.NetworkController/private/Copy-ServiceFabricManifestFromNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Copy-ServiceFabricManifestFromNetworkController.ps1
@@ -62,5 +62,6 @@ function Copy-ServiceFabricManifestFromNetworkController {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Copy-ServiceFabricManifestFromNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Copy-ServiceFabricManifestFromNetworkController.ps1
@@ -29,10 +29,10 @@ function Copy-ServiceFabricManifestFromNetworkController {
 
     try {
         if ($NcNodeList.Count -eq 0) {
-            Trace-Output "No NC Node found" -Level:Error
+            Trace-Output -Message "No NC Node found" -Level:Error
             return
         }
-        Trace-Output "Copying Manifest files from $($NcNodeList.IpAddressOrFQDN)" -Level:Verbose
+        Trace-Output -Message "Copying Manifest files from $($NcNodeList.IpAddressOrFQDN)" -Level:Verbose
 
         New-Item -Path $ManifestFolder -ItemType Directory -Force | Out-Null
         New-Item -Path $ManifestFolderNew -ItemType Directory -Force | Out-Null

--- a/src/modules/SdnDiag.NetworkController/private/Copy-ServiceFabricManifestFromNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Copy-ServiceFabricManifestFromNetworkController.ps1
@@ -62,6 +62,5 @@ function Copy-ServiceFabricManifestFromNetworkController {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Copy-ServiceFabricManifestToNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Copy-ServiceFabricManifestToNetworkController.ps1
@@ -66,5 +66,6 @@ function Copy-ServiceFabricManifestToNetworkController {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Copy-ServiceFabricManifestToNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Copy-ServiceFabricManifestToNetworkController.ps1
@@ -66,6 +66,5 @@ function Copy-ServiceFabricManifestToNetworkController {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Copy-ServiceFabricManifestToNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Copy-ServiceFabricManifestToNetworkController.ps1
@@ -24,12 +24,12 @@ function Copy-ServiceFabricManifestToNetworkController {
 
     try {
         if ($NcNodeList.Count -eq 0) {
-            Trace-Output "No NC VMs found" -Level:Error
+            Trace-Output -Message "No NC VMs found" -Level:Error
             return
         }
-        Trace-Output "Copying Service Fabric Manifests to NC VMs: $($NcNodeList.IpAddressOrFQDN)"
+        Trace-Output -Message "Copying Service Fabric Manifests to NC VMs: $($NcNodeList.IpAddressOrFQDN)"
 
-        Trace-Output "Stopping Service Fabric Service"
+        Trace-Output -Message "Stopping Service Fabric Service"
         foreach ($nc in $NcNodeList.IpAddressOrFQDN) {
             Invoke-PSRemoteCommand -ComputerName $nc -Credential $Credential -ScriptBlock {
                 Write-Host "[$(HostName)] Stopping Service Fabric Service"

--- a/src/modules/SdnDiag.NetworkController/private/Get-NetworkControllerConfigState.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-NetworkControllerConfigState.ps1
@@ -43,7 +43,6 @@ function Get-NetworkControllerConfigState {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 
     $ProgressPreference = 'Continue'

--- a/src/modules/SdnDiag.NetworkController/private/Get-NetworkControllerConfigState.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-NetworkControllerConfigState.ps1
@@ -43,6 +43,7 @@ function Get-NetworkControllerConfigState {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 
     $ProgressPreference = 'Continue'

--- a/src/modules/SdnDiag.NetworkController/private/Get-NetworkControllerNodeInfoFromClusterManifest.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-NetworkControllerNodeInfoFromClusterManifest.ps1
@@ -3,12 +3,21 @@ function Get-NetworkControllerNodeInfoFromClusterManifest {
     <#
     .SYNOPSIS
         This function is used as fallback method in the event that normal Get-NetworkControllerNode cmdlet fails in scenarios where certs may be expired
+    .PARAMETER NetworkController
+        Specifies the Network Controller to retrieve the information from.
+    .PARAMETER Name
+        Specifies the friendly name of the node for the network controller. If not provided, settings are retrieved for all nodes in the deployment.
+    .PARAMETER Credential
+        Specifies a user account that has permission to perform this action. The default is the current user.
     #>
 
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]
         [String]$NetworkController = $(HostName),
+
+        [Parameter(Mandatory = $false)]
+        [String]$Name,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
@@ -34,6 +43,10 @@ function Get-NetworkControllerNodeInfoFromClusterManifest {
         $object | Add-Member -MemberType NoteProperty -Name NodeCertificateThumbprint -Value $certificate
 
         $array += $object
+    }
+
+    if ($Name) {
+        return ($array | Where-Object { $_.Name.Split(".")[0] -ieq $Name.Split(".")[0] -or $_.Server -ieq $Name.Split(".")[0] })
     }
 
     return $array

--- a/src/modules/SdnDiag.NetworkController/private/Get-PublicIpReference.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-PublicIpReference.ps1
@@ -70,5 +70,6 @@ function Get-PublicIpReference {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Get-PublicIpReference.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-PublicIpReference.ps1
@@ -70,6 +70,5 @@ function Get-PublicIpReference {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnDiscovery.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnDiscovery.ps1
@@ -25,6 +25,5 @@ function Get-SdnDiscovery {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnDiscovery.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnDiscovery.ps1
@@ -20,8 +20,7 @@ function Get-SdnDiscovery {
     )
 
     try {
-        [System.String]$uri = Get-SdnApiEndpoint -NcUri $NcUri.AbsoluteUri -ResourceName 'Discovery'
-        $result = Invoke-RestMethodWithRetry -Uri $uri -Method GET -UseBasicParsing -Credential $Credential -ErrorAction Stop
+        $result = Get-SdnResource -NcUri $NcUri -Resource 'Discovery' -Credential $Credential
         return $result
     }
     catch {

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnDiscovery.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnDiscovery.ps1
@@ -25,5 +25,6 @@ function Get-SdnDiscovery {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnDiscovery.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnDiscovery.ps1
@@ -26,5 +26,6 @@ function Get-SdnDiscovery {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnNetworkControllerInfoOffline.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnNetworkControllerInfoOffline.ps1
@@ -62,6 +62,5 @@ function Get-SdnNetworkControllerInfoOffline {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnNetworkControllerInfoOffline.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnNetworkControllerInfoOffline.ps1
@@ -62,5 +62,6 @@ function Get-SdnNetworkControllerInfoOffline {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnNetworkControllerRestURL.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnNetworkControllerRestURL.ps1
@@ -34,6 +34,5 @@ function Get-SdnNetworkControllerRestURL {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnNetworkControllerRestURL.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnNetworkControllerRestURL.ps1
@@ -34,5 +34,6 @@ function Get-SdnNetworkControllerRestURL {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnVirtualServer.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnVirtualServer.ps1
@@ -45,6 +45,5 @@ function Get-SdnVirtualServer {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnVirtualServer.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnVirtualServer.ps1
@@ -45,5 +45,6 @@ function Get-SdnVirtualServer {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Invoke-SdnNetworkControllerStateDump.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Invoke-SdnNetworkControllerStateDump.ps1
@@ -58,6 +58,5 @@ function Invoke-SdnNetworkControllerStateDump {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Invoke-SdnNetworkControllerStateDump.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Invoke-SdnNetworkControllerStateDump.ps1
@@ -58,5 +58,6 @@ function Invoke-SdnNetworkControllerStateDump {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Start-SdnExpiredCertificateRotation.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Start-SdnExpiredCertificateRotation.ps1
@@ -37,26 +37,26 @@ function Start-SdnExpiredCertificateRotation {
     $ManifestFolderNew = "$NcUpdateFolder\manifest_new"
 
     $NcInfraInfo = Get-SdnNetworkControllerInfoOffline -Credential $Credential
-    Trace-Output "Network Controller Infrastrucutre Info detected:"
-    Trace-Output "ClusterCredentialType: $($NcInfraInfo.ClusterCredentialType)"
-    Trace-Output "NcRestName: $($NcInfraInfo.NcRestName)"
+    Trace-Output -Message "Network Controller Infrastrucutre Info detected:"
+    Trace-Output -Message "ClusterCredentialType: $($NcInfraInfo.ClusterCredentialType)"
+    Trace-Output -Message "NcRestName: $($NcInfraInfo.NcRestName)"
 
     $NcNodeList = $NcInfraInfo.NodeList
 
     if ($null -eq $NcNodeList -or $NcNodeList.Count -eq 0) {
-        Trace-Output "Failed to get NC Node List from NetworkController: $(HostName)" -Level:Error
+        Trace-Output -Message "Failed to get NC Node List from NetworkController: $(HostName)" -Level:Error
     }
 
-    Trace-Output "NcNodeList: $($NcNodeList.IpAddressOrFQDN)"
+    Trace-Output -Message "NcNodeList: $($NcNodeList.IpAddressOrFQDN)"
 
-    Trace-Output "Validate CertRotateConfig"
+    Trace-Output -Message "Validate CertRotateConfig"
     if(!(Test-SdnCertificateRotationConfig -NcNodeList $NcNodeList -CertRotateConfig $CertRotateConfig -Credential $Credential)){
-        Trace-Output "Invalid CertRotateConfig, please correct the configuration and try again" -Level:Error
+        Trace-Output -Message "Invalid CertRotateConfig, please correct the configuration and try again" -Level:Error
         return
     }
 
     if ([String]::IsNullOrEmpty($NcInfraInfo.NcRestName)) {
-        Trace-Output "Failed to get NcRestName using current secret certificate thumbprint. This might indicate the certificate not found on $(HOSTNAME). We won't be able to recover." -Level:Error
+        Trace-Output -Message "Failed to get NcRestName using current secret certificate thumbprint. This might indicate the certificate not found on $(HOSTNAME). We won't be able to recover." -Level:Error
         throw New-Object System.NotSupportedException("Current NC Rest Cert not found, Certificate Rotation cannot be continue.")
     }
 
@@ -82,55 +82,55 @@ function Start-SdnExpiredCertificateRotation {
         }
     }
 
-    Trace-Output "Step 1 Copy manifests and settings.xml from Network Controller"
+    Trace-Output -Message "Step 1 Copy manifests and settings.xml from Network Controller"
     Copy-ServiceFabricManifestFromNetworkController -NcNodeList $NcNodeList -ManifestFolder $ManifestFolder -ManifestFolderNew $ManifestFolderNew -Credential $Credential
 
     # Step 2 Update certificate thumbprint
-    Trace-Output "Step 2 Update certificate thumbprint and secret in manifest"
+    Trace-Output -Message "Step 2 Update certificate thumbprint and secret in manifest"
     Update-NetworkControllerCertificateInManifest -NcNodeList $NcNodeList -ManifestFolder $ManifestFolder -ManifestFolderNew $ManifestFolderNew -CertRotateConfig $CertRotateConfig -Credential $Credential
 
     # Step 3 Copy the new files back to the NC vms
-    Trace-Output "Step 3 Copy the new files back to the NC vms"
+    Trace-Output -Message "Step 3 Copy the new files back to the NC vms"
     Copy-ServiceFabricManifestToNetworkController -NcNodeList $NcNodeList -ManifestFolder $ManifestFolderNew -Credential $Credential
 
     # Step 5 Start FabricHostSvc and wait for SF system service to become healty
-    Trace-Output "Step 4 Start FabricHostSvc and wait for SF system service to become healty"
-    Trace-Output "Step 4.1 Update Network Controller Certificate ACL to allow 'Network Service' Access"
+    Trace-Output -Message "Step 4 Start FabricHostSvc and wait for SF system service to become healty"
+    Trace-Output -Message "Step 4.1 Update Network Controller Certificate ACL to allow 'Network Service' Access"
     Update-NetworkControllerCertificateAcl -NcNodeList $NcNodeList -CertRotateConfig $CertRotateConfig -Credential $Credential
-    Trace-Output "Step 4.2 Start Service Fabric Host Service and wait"
+    Trace-Output -Message "Step 4.2 Start Service Fabric Host Service and wait"
     $clusterHealthy = Wait-ServiceFabricClusterHealthy -NcNodeList $NcNodeList -CertRotateConfig $CertRotateConfig -Credential $Credential
-    Trace-Output "ClusterHealthy: $clusterHealthy"
+    Trace-Output -Message "ClusterHealthy: $clusterHealthy"
     if($clusterHealthy -ne $true){
         throw New-Object System.NotSupportedException("Cluster unheathy after manifest update, we cannot continue with current situation")
     }
     # Step 6 Invoke SF Cluster Upgrade
-    Trace-Output "Step 5 Invoke SF Cluster Upgrade"
+    Trace-Output -Message "Step 5 Invoke SF Cluster Upgrade"
     Update-ServiceFabricCluster -NcNodeList $NcNodeList -CertRotateConfig $CertRotateConfig -ManifestFolderNew $ManifestFolderNew -Credential $Credential
     $clusterHealthy = Wait-ServiceFabricClusterHealthy -NcNodeList $NcNodeList -CertRotateConfig $CertRotateConfig -Credential $Credential
-    Trace-Output "ClusterHealthy: $clusterHealthy"
+    Trace-Output -Message "ClusterHealthy: $clusterHealthy"
     if($clusterHealthy -ne $true){
         throw New-Object System.NotSupportedException("Cluster unheathy after cluster update, we cannot continue with current situation")
     }
 
     # Step 7 Fix NC App
-    Trace-Output "Step 6 Fix NC App"
-    Trace-Output "Step 6.1 Updating Network Controller Global and Cluster Config"
+    Trace-Output -Message "Step 6 Fix NC App"
+    Trace-Output -Message "Step 6.1 Updating Network Controller Global and Cluster Config"
     if ($NcInfraInfo.ClusterCredentialType -eq "X509") {
         Update-NetworkControllerConfig -NcNodeList $NcNodeList -CertRotateConfig $CertRotateConfig -Credential $Credential
     }
 
     # Step 7 Restart
-    Trace-Output "Step 7 Restarting Service Fabric Cluster after configuration change"
+    Trace-Output -Message "Step 7 Restarting Service Fabric Cluster after configuration change"
     $clusterHealthy = Wait-ServiceFabricClusterHealthy -NcNodeList $NcNodeList -CertRotateConfig $CertRotateConfig -Credential $Credential -Restart
 
-<#     Trace-Output "Step 7.2 Rotate Network Controller Certificate"
+<#     Trace-Output -Message "Step 7.2 Rotate Network Controller Certificate"
     #$null = Invoke-CertRotateCommand -Command 'Set-NetworkController' -Credential $Credential -Thumbprint $NcRestCertThumbprint
 
     # Step 8 Update REST CERT credential
-    Trace-Output "Step 8 Update REST CERT credential"
+    Trace-Output -Message "Step 8 Update REST CERT credential"
     # Step 8.1 Wait for NC App Healthy
-    Trace-Output "Step 8.1 Wiating for Network Controller App Ready"
+    Trace-Output -Message "Step 8.1 Wiating for Network Controller App Ready"
     #Wait-NetworkControllerAppHealthy -Interval 60
-    Trace-Output "Step 8.2 Updating REST CERT Credential object calling REST API" #>
+    Trace-Output -Message "Step 8.2 Updating REST CERT Credential object calling REST API" #>
     #Update-NetworkControllerCredentialResource -NcUri "https://$($NcInfraInfo.NcRestName)" -NewRestCertThumbprint $NcRestCertThumbprint -Credential $NcRestCredential
 }

--- a/src/modules/SdnDiag.NetworkController/private/Update-NetworkControllerCertificateAcl.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Update-NetworkControllerCertificateAcl.ps1
@@ -43,5 +43,6 @@ function Update-NetworkControllerCertificateAcl {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Update-NetworkControllerCertificateAcl.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Update-NetworkControllerCertificateAcl.ps1
@@ -43,6 +43,5 @@ function Update-NetworkControllerCertificateAcl {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Update-NetworkControllerCertificateInManifest.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Update-NetworkControllerCertificateInManifest.ps1
@@ -42,7 +42,7 @@ function Update-NetworkControllerCertificateInManifest {
     $clusterManifestXml = [xml](Get-Content "$ManifestFolder\ClusterManifest.current.xml")
 
     if ($null -eq $clusterManifestXml) {
-        Trace-Output "ClusterManifest not found at $ManifestFolder\ClusterManifest.current.xml" -Level:Error
+        Trace-Output -Message "ClusterManifest not found at $ManifestFolder\ClusterManifest.current.xml" -Level:Error
         throw
     }
 
@@ -60,7 +60,7 @@ function Update-NetworkControllerCertificateInManifest {
 
     # Update SecretsCertificate to new REST Cert
 
-    Trace-Output "Updating SecretsCertificate with new rest cert thumbprint $NcRestCertThumbprint"
+    Trace-Output -Message "Updating SecretsCertificate with new rest cert thumbprint $NcRestCertThumbprint"
     $clusterManifestXml.ClusterManifest.Certificates.SecretsCertificate.X509FindValue = "$NcRestCertThumbprint"
 
     $securitySection = $clusterManifestXml.ClusterManifest.FabricSettings.Section | Where-Object Name -eq "Security"

--- a/src/modules/SdnDiag.NetworkController/private/Wait-NetworkControllerAppHealthy.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Wait-NetworkControllerAppHealthy.ps1
@@ -91,6 +91,5 @@ function Wait-NetworkControllerAppHealthy {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Wait-NetworkControllerAppHealthy.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Wait-NetworkControllerAppHealthy.ps1
@@ -91,5 +91,6 @@ function Wait-NetworkControllerAppHealthy {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Wait-ServiceFabricClusterHealthy.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Wait-ServiceFabricClusterHealthy.ps1
@@ -101,6 +101,5 @@ function Wait-ServiceFabricClusterHealthy {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/private/Wait-ServiceFabricClusterHealthy.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Wait-ServiceFabricClusterHealthy.ps1
@@ -50,7 +50,7 @@ function Wait-ServiceFabricClusterHealthy {
             } -ArgumentList $Restart
         }
 
-        Trace-Output "Sleeping 60s to wait for Serice Fabric Service to be ready"
+        Trace-Output -Message "Sleeping 60s to wait for Serice Fabric Service to be ready"
         Start-Sleep -Seconds 60
         "Waiting for service fabric service healthy" | Trace-Output
         $NodeFQDN = (get-ciminstance win32_computersystem).DNSHostName + "." + (get-ciminstance win32_computersystem).Domain

--- a/src/modules/SdnDiag.NetworkController/private/Wait-ServiceFabricClusterHealthy.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Wait-ServiceFabricClusterHealthy.ps1
@@ -101,5 +101,6 @@ function Wait-ServiceFabricClusterHealthy {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
@@ -95,5 +95,6 @@ function Get-SdnGateway {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
@@ -95,6 +95,5 @@ function Get-SdnGateway {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnInfrastructureInfo.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnInfrastructureInfo.ps1
@@ -89,22 +89,22 @@ function Get-SdnInfrastructureInfo {
 
         # get the network controllers
         if ([System.String]::IsNullOrEmpty($global:SdnDiagnostics.EnvironmentInfo.NetworkController)) {
-            [System.Array]$global:SdnDiagnostics.EnvironmentInfo.NetworkController = Get-SdnNetworkControllerNode -NetworkController $NetworkController -ServerNameOnly -Credential $Credential
+            [System.Array]$global:SdnDiagnostics.EnvironmentInfo.NetworkController = Get-SdnNetworkControllerNode -NetworkController $NetworkController -ServerNameOnly -Credential $Credential -ErrorAction Continue
         }
 
         # get the load balancer muxes
         if ([System.String]::IsNullOrEmpty($global:SdnDiagnostics.EnvironmentInfo.LoadBalancerMux)) {
-            [System.Array]$global:SdnDiagnostics.EnvironmentInfo.LoadBalancerMux = Get-SdnLoadBalancerMux -NcUri $Global:SdnDiagnostics.EnvironmentInfo.NcUrl -ManagementAddressOnly -Credential $NcRestCredential
+            [System.Array]$global:SdnDiagnostics.EnvironmentInfo.LoadBalancerMux = Get-SdnLoadBalancerMux -NcUri $Global:SdnDiagnostics.EnvironmentInfo.NcUrl -ManagementAddressOnly -Credential $NcRestCredential -ErrorAction Continue
         }
 
         # get the gateways
         if ([System.String]::IsNullOrEmpty($Global:SdnDiagnostics.EnvironmentInfo.Gateway)) {
-            [System.Array]$Global:SdnDiagnostics.EnvironmentInfo.Gateway = Get-SdnGateway -NcUri $Global:SdnDiagnostics.EnvironmentInfo.NcUrl -ManagementAddressOnly -Credential $NcRestCredential
+            [System.Array]$Global:SdnDiagnostics.EnvironmentInfo.Gateway = Get-SdnGateway -NcUri $Global:SdnDiagnostics.EnvironmentInfo.NcUrl -ManagementAddressOnly -Credential $NcRestCredential -ErrorAction Continue
         }
 
         # get the hypervisor hosts
         if ([System.String]::IsNullOrEmpty($Global:SdnDiagnostics.EnvironmentInfo.Server)) {
-            [System.Array]$Global:SdnDiagnostics.EnvironmentInfo.Server = Get-SdnServer -NcUri $Global:SdnDiagnostics.EnvironmentInfo.NcUrl -ManagementAddressOnly -Credential $NcRestCredential
+            [System.Array]$Global:SdnDiagnostics.EnvironmentInfo.Server = Get-SdnServer -NcUri $Global:SdnDiagnostics.EnvironmentInfo.NcUrl -ManagementAddressOnly -Credential $NcRestCredential -ErrorAction Continue
         }
 
         # populate the global cache that contains the names of the nodes for the roles defined above

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnInternalLoadBalancer.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnInternalLoadBalancer.ps1
@@ -128,6 +128,5 @@ function Get-SdnInternalLoadBalancer {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnInternalLoadBalancer.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnInternalLoadBalancer.ps1
@@ -128,5 +128,6 @@ function Get-SdnInternalLoadBalancer {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnLoadBalancerMux.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnLoadBalancerMux.ps1
@@ -95,5 +95,6 @@ function Get-SdnLoadBalancerMux {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnLoadBalancerMux.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnLoadBalancerMux.ps1
@@ -95,6 +95,5 @@ function Get-SdnLoadBalancerMux {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkController.ps1
@@ -50,5 +50,6 @@ function Get-SdnNetworkController {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkController.ps1
@@ -50,6 +50,5 @@ function Get-SdnNetworkController {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerClusterInfo.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerClusterInfo.ps1
@@ -78,5 +78,6 @@ function Get-SdnNetworkControllerClusterInfo {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerClusterInfo.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerClusterInfo.ps1
@@ -78,6 +78,5 @@ function Get-SdnNetworkControllerClusterInfo {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNode.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNode.ps1
@@ -87,5 +87,6 @@ function Get-SdnNetworkControllerNode {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNode.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNode.ps1
@@ -87,6 +87,5 @@ function Get-SdnNetworkControllerNode {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNodeCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNodeCertificate.ps1
@@ -4,15 +4,28 @@ function Get-SdnNetworkControllerNodeCertificate {
         Returns the current Network Controller node certificate
     .PARAMETER Name
         Specifies the friendly name of the node for the network controller. If not provided, settings are retrieved for all nodes in the deployment.
+    .PARAMETER NetworkController
+        Specifies the name or IP address of the network controller node on which this cmdlet operates. The parameter is optional if running on network controller node.
+    .PARAMETER Credential
+        Specifies a user account that has permission to perform this action. The default is the current user.
     #>
 
     [CmdletBinding()]
     param(
-        [string]$Name = $env:COMPUTERNAME
+        [Parameter(Mandatory = $false)]
+        [string]$Name = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [System.String]$NetworkController = $env:COMPUTERNAME,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     try {
-        $networkControllerNode = Get-SdnNetworkControllerNode -Name $Name
+        $networkControllerNode = Get-SdnNetworkControllerNode -Name $Name -NetworkController $NetworkController -Credential $Credential
 
         # check to see if FindCertificateBy property exists as this was added in later builds
         # else if does not exist, default to Thumbprint for certificate

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNodeCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNodeCertificate.ps1
@@ -35,6 +35,5 @@ function Get-SdnNetworkControllerNodeCertificate {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNodeCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNodeCertificate.ps1
@@ -2,10 +2,17 @@ function Get-SdnNetworkControllerNodeCertificate {
     <#
     .SYNOPSIS
         Returns the current Network Controller node certificate
+    .PARAMETER Name
+        Specifies the friendly name of the node for the network controller. If not provided, settings are retrieved for all nodes in the deployment.
     #>
 
+    [CmdletBinding()]
+    param(
+        [string]$Name = $env:COMPUTERNAME
+    )
+
     try {
-        $networkControllerNode = Get-SdnNetworkControllerNode -Name $env:COMPUTERNAME
+        $networkControllerNode = Get-SdnNetworkControllerNode -Name $Name
 
         # check to see if FindCertificateBy property exists as this was added in later builds
         # else if does not exist, default to Thumbprint for certificate

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNodeCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNodeCertificate.ps1
@@ -35,5 +35,6 @@ function Get-SdnNetworkControllerNodeCertificate {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerRestCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerRestCertificate.ps1
@@ -4,15 +4,17 @@ function Get-SdnNetworkControllerRestCertificate {
         Returns the current Network Controller REST Certificate
     #>
 
+    [CmdletBinding()]
+    param ()
+
+    $config = Get-SdnModuleConfiguration -Role 'NetworkController'
+    $confirmFeatures = Confirm-RequiredFeaturesInstalled -Name $config.windowsFeature
+    if (-NOT ($confirmFeatures)) {
+        "The current machine is not a NetworkController, run this on NetworkController or use -NetworkController parameter to specify one" | Trace-Output -Level:Warning
+        return # don't throw exception, since this is a controlled scenario and we do not need stack exception tracing
+    }
+
     try {
-
-        $config = Get-SdnModuleConfiguration -Role 'NetworkController'
-        $confirmFeatures = Confirm-RequiredFeaturesInstalled -Name $config.windowsFeature
-        if (-NOT ($confirmFeatures)) {
-            "The current machine is not a NetworkController, run this on NetworkController or use -NetworkController parameter to specify one" | Trace-Output -Level:Warning
-            return # don't throw exception, since this is a controlled scenario and we do not need stack exception tracing
-        }
-
         $networkController = Get-SdnNetworkController
         $ncRestCertThumprint = $($networkController.ServerCertificate.Thumbprint).ToString()
         $certificate = Get-SdnCertificate -Path 'Cert:\LocalMachine\My' -Thumbprint $ncRestCertThumprint

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerRestCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerRestCertificate.ps1
@@ -25,5 +25,6 @@ function Get-SdnNetworkControllerRestCertificate {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerRestCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerRestCertificate.ps1
@@ -25,6 +25,5 @@ function Get-SdnNetworkControllerRestCertificate {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerState.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerState.ps1
@@ -76,5 +76,6 @@ function Get-SdnNetworkControllerState {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerState.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerState.ps1
@@ -76,6 +76,5 @@ function Get-SdnNetworkControllerState {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkInterfaceOutboundPublicIPAddress.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkInterfaceOutboundPublicIPAddress.ps1
@@ -56,6 +56,5 @@ function Get-SdnNetworkInterfaceOutboundPublicIPAddress {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkInterfaceOutboundPublicIPAddress.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkInterfaceOutboundPublicIPAddress.ps1
@@ -56,5 +56,6 @@ function Get-SdnNetworkInterfaceOutboundPublicIPAddress {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnPublicIPPoolUsageSummary.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnPublicIPPoolUsageSummary.ps1
@@ -85,5 +85,6 @@ function Get-SdnPublicIPPoolUsageSummary {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnPublicIPPoolUsageSummary.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnPublicIPPoolUsageSummary.ps1
@@ -85,6 +85,5 @@ function Get-SdnPublicIPPoolUsageSummary {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnResource.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnResource.ps1
@@ -77,6 +77,13 @@ function Get-SdnResource {
     }
     catch [System.Net.WebException] {
         if ($_.Exception.Response.StatusCode -eq 404) {
+
+            # if the resource is iDNSServer configuration, we want to return null instead of throwing a warning
+            # as this may be expected behavior if the iDNSServer is not configured
+            if ($Resource -like "*/iDNSServer/configuration*" -or $ResourceRef -like "*/iDNSServer/configuration*") {
+                return $null
+            }
+
             "{0} ({1})" -f $_.Exception.Message, $_.Exception.Response.ResponseUri.AbsoluteUri | Write-Warning
             return $null
         }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnResource.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnResource.ps1
@@ -76,16 +76,17 @@ function Get-SdnResource {
         $result = Invoke-RestMethodWithRetry -Uri $uri -Method 'GET' -UseBasicParsing -Credential $Credential -ErrorAction Stop
     }
     catch [System.Net.WebException] {
-        if ($_.Exception.Response.StatusCode -eq 404) {
+        if ($_.Exception.Response.StatusCode -eq 'NotFound') {
 
             # if the resource is iDNSServer configuration, we want to return null instead of throwing a warning
             # as this may be expected behavior if the iDNSServer is not configured
-            if ($Resource -like "*/iDNSServer/configuration*" -or $ResourceRef -like "*/iDNSServer/configuration*") {
+            if ($_.Exception.Response.ResponseUri.AbsoluteUri -ilike '*/idnsserver/configuration') {
                 return $null
             }
-
-            "{0} ({1})" -f $_.Exception.Message, $_.Exception.Response.ResponseUri.AbsoluteUri | Write-Warning
-            return $null
+            else {
+                "{0} ({1})" -f $_.Exception.Message, $_.Exception.Response.ResponseUri.AbsoluteUri | Write-Warning
+                return $null
+            }
         }
         else {
             throw $_

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
@@ -90,5 +90,6 @@ function Get-SdnServer {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
@@ -90,6 +90,5 @@ function Get-SdnServer {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricApplicationHealth.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricApplicationHealth.ps1
@@ -36,5 +36,6 @@ function Get-SdnServiceFabricApplicationHealth {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricApplicationHealth.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricApplicationHealth.ps1
@@ -15,7 +15,7 @@ function Get-SdnServiceFabricApplicationHealth {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]
-        [System.String[]]$NetworkController = $global:SdnDiagnostics.EnvironmentInfo.NetworkController,
+        [System.String]$NetworkController = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $false, ValueFromPipeline = $false)]
         [String]$ApplicationName = 'fabric:/NetworkController',
@@ -26,13 +26,13 @@ function Get-SdnServiceFabricApplicationHealth {
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
+    $sb = {
+        param([string]$param1)
+        Get-ServiceFabricApplicationHealth -ApplicationName $param1
+    }
+
     try {
-        if ($NetworkController) {
-            Invoke-SdnServiceFabricCommand -NetworkController $NetworkController -ScriptBlock { Get-ServiceFabricApplicationHealth -ApplicationName $using:ApplicationName } -Credential $Credential
-        }
-        else {
-            Invoke-SdnServiceFabricCommand -ScriptBlock { Get-ServiceFabricApplicationHealth -ApplicationName $using:ApplicationName } -Credential $Credential
-        }
+        Invoke-SdnServiceFabricCommand -NetworkController $NetworkController -Credential $Credential -ScriptBlock $sb -ArgumentList @($ApplicationName)
     }
     catch {
         $_ | Trace-Exception

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricApplicationHealth.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricApplicationHealth.ps1
@@ -36,6 +36,5 @@ function Get-SdnServiceFabricApplicationHealth {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricClusterConfig.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricClusterConfig.ps1
@@ -77,5 +77,6 @@ function Get-SdnServiceFabricClusterConfig {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricClusterConfig.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricClusterConfig.ps1
@@ -77,6 +77,5 @@ function Get-SdnServiceFabricClusterConfig {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricClusterHealth.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricClusterHealth.ps1
@@ -31,6 +31,5 @@ function Get-SdnServiceFabricClusterHealth {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricClusterHealth.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricClusterHealth.ps1
@@ -31,5 +31,6 @@ function Get-SdnServiceFabricClusterHealth {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricClusterHealth.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricClusterHealth.ps1
@@ -13,7 +13,7 @@ function Get-SdnServiceFabricClusterHealth {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]
-        [System.String[]]$NetworkController = $global:SdnDiagnostics.EnvironmentInfo.NetworkController,
+        [System.String]$NetworkController = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
@@ -22,12 +22,7 @@ function Get-SdnServiceFabricClusterHealth {
     )
 
     try {
-        if ($NetworkController) {
-            Invoke-SdnServiceFabricCommand -NetworkController $NetworkController -ScriptBlock { Get-ServiceFabricClusterHealth } -Credential $Credential
-        }
-        else {
-            Invoke-SdnServiceFabricCommand -ScriptBlock { Get-ServiceFabricClusterHealth } -Credential $Credential
-        }
+        Invoke-SdnServiceFabricCommand -NetworkController $NetworkController -Credential $Credential -ScriptBlock { Get-ServiceFabricClusterHealth }
     }
     catch {
         $_ | Trace-Exception

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricClusterManifest.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricClusterManifest.ps1
@@ -99,6 +99,5 @@ function Get-SdnServiceFabricClusterManifest {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricClusterManifest.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricClusterManifest.ps1
@@ -99,5 +99,6 @@ function Get-SdnServiceFabricClusterManifest {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricNode.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricNode.ps1
@@ -57,5 +57,6 @@ function Get-SdnServiceFabricNode {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricNode.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricNode.ps1
@@ -57,6 +57,5 @@ function Get-SdnServiceFabricNode {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricNode.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricNode.ps1
@@ -19,7 +19,7 @@ function Get-SdnServiceFabricNode {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]
-        [System.String[]]$NetworkController = $env:COMPUTERNAME,
+        [System.String]$NetworkController = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
@@ -31,29 +31,35 @@ function Get-SdnServiceFabricNode {
 
     )
 
+    if (-NOT ($PSBoundParameters.ContainsKey('NetworkController'))) {
+        $config = Get-SdnModuleConfiguration -Role 'NetworkController'
+        $confirmFeatures = Confirm-RequiredFeaturesInstalled -Name $config.windowsFeature
+        if (-NOT ($confirmFeatures)) {
+            "The current machine is not a NetworkController, run this on NetworkController or use -NetworkController parameter to specify one" | Trace-Output -Level:Warning
+            return # don't throw exception, since this is a controlled scenario and we do not need stack exception tracing
+        }
+    }
+
+    $sfParams = @{
+        NetworkController = $NetworkController
+        Credential = $Credential
+    }
+
+    if ($NodeName) {
+        $sfParams.Add('ArgumentList', @($NodeName))
+        $sb = {
+            param([string]$param1)
+            Get-ServiceFabricNode -NodeName $param1
+        }
+    }
+    else {
+        $sb = {
+            Get-ServiceFabricNode
+        }
+    }
+
     try {
-
-        if (-NOT ($PSBoundParameters.ContainsKey('NetworkController'))) {
-            $config = Get-SdnModuleConfiguration -Role 'NetworkController'
-            $confirmFeatures = Confirm-RequiredFeaturesInstalled -Name $config.windowsFeature
-            if (-NOT ($confirmFeatures)) {
-                "The current machine is not a NetworkController, run this on NetworkController or use -NetworkController parameter to specify one" | Trace-Output -Level:Warning
-                return # don't throw exception, since this is a controlled scenario and we do not need stack exception tracing
-            }
-        }
-
-        if ($NodeName) {
-            $sb = {
-                Get-ServiceFabricNode -NodeName $using:NodeName
-            }
-        }
-        else {
-            $sb = {
-                Get-ServiceFabricNode
-            }
-        }
-
-        Invoke-SdnServiceFabricCommand -NetworkController $NetworkController -ScriptBlock $sb -Credential $Credential
+        Invoke-SdnServiceFabricCommand @sfParams -ScriptBlock $sb
     }
     catch {
         $_ | Trace-Exception

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricPartition.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricPartition.ps1
@@ -82,5 +82,6 @@ function Get-SdnServiceFabricPartition {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricPartition.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricPartition.ps1
@@ -38,7 +38,7 @@ function Get-SdnServiceFabricPartition {
         [Parameter(Mandatory = $false, ValueFromPipeline = $false, ParameterSetName = 'NamedService')]
         [Parameter(Mandatory = $false, ValueFromPipeline = $false, ParameterSetName = 'NamedServiceTypeName')]
         [Parameter(Mandatory = $false, ValueFromPipeline = $false, ParameterSetName = 'PartitionID')]
-        [System.String[]]$NetworkController = $global:SdnDiagnostics.EnvironmentInfo.NetworkController,
+        [System.String]$NetworkController,
 
         [Parameter(Mandatory = $false, ValueFromPipeline = $false, ParameterSetName = 'NamedService')]
         [Parameter(Mandatory = $false, ValueFromPipeline = $false, ParameterSetName = 'NamedServiceTypeName')]
@@ -48,37 +48,38 @@ function Get-SdnServiceFabricPartition {
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
+    $sfParams = @{
+        Credential  = $Credential
+        NetworkController = $NetworkController
+    }
+
+    switch ($PSCmdlet.ParameterSetName) {
+        'NamedService' {
+            $sfParams.Add('ArgumentList',@($ApplicationName, $ServiceName))
+            $sb = {
+                param([string]$param1, [string]$param2)
+                Get-ServiceFabricApplication -ApplicationName $param1 | Get-ServiceFabricService -ServiceName $param2 | Get-ServiceFabricPartition
+            }
+        }
+
+        'NamedServiceTypeName' {
+            $sfParams.Add('ArgumentList',@($ApplicationName, $ServiceTypeName))
+            $sb = {
+                Get-ServiceFabricApplication -ApplicationName $param1 | Get-ServiceFabricService -ServiceTypeName $param2 | Get-ServiceFabricPartition
+            }
+        }
+
+        'PartitionID' {
+            $sfParams.Add('ArgumentList',@($PartitionId))
+            $sb = {
+                param([Guid]$param1)
+                Get-ServiceFabricPartition -PartitionId $param1
+            }
+        }
+    }
+
     try {
-        switch ($PSCmdlet.ParameterSetName) {
-            'NamedService' {
-                $sb = {
-                    Get-ServiceFabricApplication -ApplicationName $using:ApplicationName | Get-ServiceFabricService -ServiceName $using:ServiceName | Get-ServiceFabricPartition
-                }
-            }
-
-            'NamedServiceTypeName' {
-                $sb = {
-                    Get-ServiceFabricApplication -ApplicationName $using:ApplicationName | Get-ServiceFabricService -ServiceTypeName $using:ServiceTypeName | Get-ServiceFabricPartition
-                }
-            }
-
-            'PartitionID' {
-                $sb = {
-                    Get-ServiceFabricPartition -PartitionId $using:PartitionId
-                }
-            }
-
-            default {
-                # no default
-            }
-        }
-
-        if ($NetworkController) {
-            return (Invoke-SdnServiceFabricCommand -NetworkController $NetworkController -ScriptBlock $sb -Credential $Credential)
-        }
-        else {
-            return (Invoke-SdnServiceFabricCommand -ScriptBlock $sb -Credential $Credential)
-        }
+        Invoke-SdnServiceFabricCommand @sfParams -ScriptBlock $sb
     }
     catch {
         $_ | Trace-Exception

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricPartition.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricPartition.ps1
@@ -82,6 +82,5 @@ function Get-SdnServiceFabricPartition {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricReplica.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricReplica.ps1
@@ -82,6 +82,5 @@ function Get-SdnServiceFabricReplica {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricReplica.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricReplica.ps1
@@ -82,5 +82,6 @@ function Get-SdnServiceFabricReplica {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricService.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricService.ps1
@@ -85,5 +85,6 @@ function Get-SdnServiceFabricService {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricService.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServiceFabricService.ps1
@@ -85,6 +85,5 @@ function Get-SdnServiceFabricService {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnSlbStateInformation.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnSlbStateInformation.ps1
@@ -89,5 +89,6 @@ function Get-SdnSlbStateInformation {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnSlbStateInformation.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnSlbStateInformation.ps1
@@ -89,6 +89,5 @@ function Get-SdnSlbStateInformation {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Invoke-SdnResourceDump.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Invoke-SdnResourceDump.ps1
@@ -62,5 +62,6 @@ function Invoke-SdnResourceDump {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Invoke-SdnResourceDump.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Invoke-SdnResourceDump.ps1
@@ -62,6 +62,5 @@ function Invoke-SdnResourceDump {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Invoke-SdnServiceFabricCommand.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Invoke-SdnServiceFabricCommand.ps1
@@ -72,7 +72,7 @@ function Invoke-SdnServiceFabricCommand {
             }
             catch {
                 "Unable to connect to Service Fabric Cluster. Attempt {0}/{1}`n`t{2}" -f $i, $maxRetry, $_ | Trace-Output -Level:Error
-                "Terminating remote session {0} to {1}" -f $session.Name, $session.ComputerName | Trace-Output -Level:Warning
+                "Terminating remote session {0} to {1}" -f $session.Name, $session.ComputerName | Trace-Output -Level:Verbose
                 Get-PSSession -Id $session.Id | Remove-PSSession
             }
         }

--- a/src/modules/SdnDiag.NetworkController/public/Move-SdnServiceFabricReplica.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Move-SdnServiceFabricReplica.ps1
@@ -103,6 +103,5 @@ function Move-SdnServiceFabricReplica {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Move-SdnServiceFabricReplica.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Move-SdnServiceFabricReplica.ps1
@@ -103,5 +103,6 @@ function Move-SdnServiceFabricReplica {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/New-SdnCertificateRotationConfig.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/New-SdnCertificateRotationConfig.ps1
@@ -67,6 +67,5 @@ function New-SdnCertificateRotationConfig {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/New-SdnCertificateRotationConfig.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/New-SdnCertificateRotationConfig.ps1
@@ -67,5 +67,6 @@ function New-SdnCertificateRotationConfig {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/New-SdnNetworkControllerNodeCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/New-SdnNetworkControllerNodeCertificate.ps1
@@ -76,5 +76,6 @@ function New-SdnNetworkControllerNodeCertificate {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/New-SdnNetworkControllerNodeCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/New-SdnNetworkControllerNodeCertificate.ps1
@@ -76,6 +76,5 @@ function New-SdnNetworkControllerNodeCertificate {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/New-SdnNetworkControllerRestCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/New-SdnNetworkControllerRestCertificate.ps1
@@ -87,6 +87,5 @@ function New-SdnNetworkControllerRestCertificate {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/New-SdnNetworkControllerRestCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/New-SdnNetworkControllerRestCertificate.ps1
@@ -87,5 +87,6 @@ function New-SdnNetworkControllerRestCertificate {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Set-SdnNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Set-SdnNetworkController.ps1
@@ -154,7 +154,6 @@ function Set-SdnNetworkController {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
     finally {
         if ($client) {

--- a/src/modules/SdnDiag.NetworkController/public/Set-SdnNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Set-SdnNetworkController.ps1
@@ -154,6 +154,7 @@ function Set-SdnNetworkController {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
     finally {
         if ($client) {

--- a/src/modules/SdnDiag.NetworkController/public/Set-SdnServiceFabricClusterConfig.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Set-SdnServiceFabricClusterConfig.ps1
@@ -44,6 +44,5 @@ function Set-SdnServiceFabricClusterConfig {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Set-SdnServiceFabricClusterConfig.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Set-SdnServiceFabricClusterConfig.ps1
@@ -44,5 +44,6 @@ function Set-SdnServiceFabricClusterConfig {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Show-SdnVipState.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Show-SdnVipState.ps1
@@ -28,6 +28,5 @@ function Show-SdnVipState {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Show-SdnVipState.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Show-SdnVipState.ps1
@@ -28,5 +28,6 @@ function Show-SdnVipState {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
@@ -178,7 +178,7 @@ function Start-SdnCertificateRotation {
             "== STAGE: CREATE SELF SIGNED CERTIFICATES ==" | Trace-Output
 
             $newSelfSignedCert = New-SdnNetworkControllerRestCertificate -RestName $NcInfraInfo.NcRestName.ToString() -NotAfter $NotAfter -Path $CertPath.FullName `
-            -CertPassword $CertPassword -Credential $Credential -FabricDetails $sdnFabricDetails
+            -CertPassword $CertPassword -Credential $Credential -FabricDetails $sdnFabricDetails -ErrorAction Stop
 
             $selfSignedRestCertFile = $newSelfSignedCert.FileInfo
 

--- a/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
@@ -152,7 +152,7 @@ function Start-SdnCertificateRotation {
             }
 
             # before we proceed with anything else, we want to make sure that all the Network Controllers within the SDN fabric are running the current version
-            Install-SdnDiagnostics -ComputerName $sdnFabricDetails.NetworkController -ErrorAction Stop
+            Install-SdnDiagnostics -ComputerName $sdnFabricDetails.NetworkController -Credential $Credential -ErrorAction Stop
 
             "Network Controller version: {0}" -f $ncSettings.NetworkControllerVersion | Trace-Output
             "Network Controller cluster version: {0}" -f $ncSettings.NetworkControllerClusterVersion | Trace-Output

--- a/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
@@ -251,8 +251,9 @@ function Start-SdnCertificateRotation {
             foreach ($node in $NcInfraInfo.NodeList) {
                 $nodeCertThumbprint = $certRotateConfig[$node.NodeName.ToLower()]
                 $currentNodeCert = Invoke-PSRemoteCommand -ComputerName $node.IpAddressOrFQDN -Credential $Credential -ScriptBlock {
-                    Get-SdnNetworkControllerNodeCertificate
-                }
+                    param([Parameter(Position = 0)][string]$param1)
+                    Get-SdnNetworkControllerNodeCertificate -Name $param1
+                } -ArgumentList @($node.NodeName)
 
                 $newNodeCert = Invoke-PSRemoteCommand -ComputerName $node.IpAddressOrFQDN -Credential $Credential -ScriptBlock {
                     param([Parameter(Position = 0)][String]$param1, [Parameter(Position = 1)][String]$param2)

--- a/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
@@ -111,9 +111,13 @@ function Start-SdnCertificateRotation {
 
         # Get the current rest certificate to determine if it is expired scenario or not.
         $currentRestCert = Get-SdnNetworkControllerRestCertificate
-
         $restCertExpired = (Get-Date) -gt $($currentRestCert.NotAfter)
-        $ncHealthy = $true
+        if ($restCertExpired) {
+            $ncHealthy = $false
+        }
+        else {
+            $ncHealthy = $true
+        }
 
         if (!$restCertExpired) {
             try {

--- a/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
@@ -399,5 +399,6 @@ function Start-SdnCertificateRotation {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
@@ -399,6 +399,5 @@ function Start-SdnCertificateRotation {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Test-SdnCertificateRotationConfig.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Test-SdnCertificateRotationConfig.ps1
@@ -83,5 +83,6 @@ function Test-SdnCertificateRotationConfig {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.NetworkController/public/Test-SdnCertificateRotationConfig.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Test-SdnCertificateRotationConfig.ps1
@@ -26,7 +26,7 @@ function Test-SdnCertificateRotationConfig {
     try {
 
         if ([string]::IsNullOrEmpty($CertRotateConfig["NcRestCert"])) {
-            Trace-Output "NcRestCert not specified in CertRotateConfig" -Level:Error
+            Trace-Output -Message "NcRestCert not specified in CertRotateConfig" -Level:Error
             return $false
         }
 
@@ -35,7 +35,7 @@ function Test-SdnCertificateRotationConfig {
             if ($CertRotateConfig["ClusterCredentialType"] -ieq "X509") {
                 $nodeCert = $CertRotateConfig[$ncNode.NodeName.ToLower()]
                 if ([string]::IsNullOrEmpty($nodeCert)) {
-                    Trace-Output "The ClusterCredentialType is X509 but Node $($ncNode.NodeName) does not have certificate specified" -Level:Error
+                    Trace-Output -Message "The ClusterCredentialType is X509 but Node $($ncNode.NodeName) does not have certificate specified" -Level:Error
                     return $false
                 }
                 else {
@@ -54,7 +54,7 @@ function Test-SdnCertificateRotationConfig {
                     } -ArgumentList $nodeCert
 
                     if (!$certValid) {
-                        Trace-Output "Node $($ncNode.NodeName) does not have validate Node certificate with thumbprint $nodeCert installed" -Level:Error
+                        Trace-Output -Message "Node $($ncNode.NodeName) does not have validate Node certificate with thumbprint $nodeCert installed" -Level:Error
                         return $false
                     }
                 }
@@ -75,7 +75,7 @@ function Test-SdnCertificateRotationConfig {
             } -ArgumentList $ncRestCert
 
             if (!$certValid) {
-                Trace-Output "Node $($ncNode.NodeName) does not have validate NcRest certificate with thumbprint $ncRestCert installed" -Level:Error
+                Trace-Output -Message "Node $($ncNode.NodeName) does not have validate NcRest certificate with thumbprint $ncRestCert installed" -Level:Error
                 return $false
             }
         }

--- a/src/modules/SdnDiag.NetworkController/public/Test-SdnCertificateRotationConfig.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Test-SdnCertificateRotationConfig.ps1
@@ -83,6 +83,5 @@ function Test-SdnCertificateRotationConfig {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbAddressMapping.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbAddressMapping.ps1
@@ -61,6 +61,5 @@ function Get-OvsdbAddressMapping {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbAddressMapping.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbAddressMapping.ps1
@@ -6,60 +6,55 @@ function Get-OvsdbAddressMapping {
         PS> Get-OvsdbAddressMapping
     #>
 
-    try {
-        $arrayList = [System.Collections.ArrayList]::new()
+    $arrayList = [System.Collections.ArrayList]::new()
 
-        $ovsdbResults = Get-OvsdbDatabase -Table ms_vtep
-        $paMappingTable = $ovsdbResults | Where-Object { $_.caption -eq 'Physical_Locator table' }
-        $caMappingTable = $ovsdbResults | Where-Object { $_.caption -eq 'Ucast_Macs_Remote table' }
-        $logicalSwitchTable = $ovsdbResults | Where-Object { $_.caption -eq 'Logical_Switch table' }
+    $ovsdbResults = Get-OvsdbDatabase -Table ms_vtep
+    $paMappingTable = $ovsdbResults | Where-Object { $_.caption -eq 'Physical_Locator table' }
+    $caMappingTable = $ovsdbResults | Where-Object { $_.caption -eq 'Ucast_Macs_Remote table' }
+    $logicalSwitchTable = $ovsdbResults | Where-Object { $_.caption -eq 'Logical_Switch table' }
 
-        if ($null -eq $caMappingTable) {
-            return $null
+    if ($null -eq $caMappingTable) {
+        return $null
+    }
+
+    # enumerate the json rules for each of the tables and create psobject for the mappings
+    # unfortunately these values do not return in key/value pair and need to manually map each property
+    foreach ($caMapping in $caMappingTable.Data) {
+
+        # create the object
+        $addressMapping = [OvsdbAddressMapping]@{
+            UUID            = $caMapping[1][1]
+            CustomerAddress = $caMapping[2]
+            MacAddress      = $caMapping[0]
+            MappingType     = $caMapping[5]
         }
 
-        # enumerate the json rules for each of the tables and create psobject for the mappings
-        # unfortunately these values do not return in key/value pair and need to manually map each property
-        foreach ($caMapping in $caMappingTable.Data) {
+        $locator = $caMapping[3][1]
+        $logicalSwitch = $caMapping[4][1]
 
-            # create the object
-            $addressMapping = [OvsdbAddressMapping]@{
-                UUID            = $caMapping[1][1]
-                CustomerAddress = $caMapping[2]
-                MacAddress      = $caMapping[0]
-                MappingType     = $caMapping[5]
+        # Get PA from locator table
+        foreach ($paMapping in $paMappingTable.Data) {
+            $curLocator = $paMapping[0][1]
+            if ($curLocator -eq $locator) {
+                $addressMapping.ProviderAddress = $paMapping[3]
+                $addressMapping.EncapType = $paMapping[4]
+                break
             }
-
-            $locator = $caMapping[3][1]
-            $logicalSwitch = $caMapping[4][1]
-
-            # Get PA from locator table
-            foreach ($paMapping in $paMappingTable.Data) {
-                $curLocator = $paMapping[0][1]
-                if ($curLocator -eq $locator) {
-                    $addressMapping.ProviderAddress = $paMapping[3]
-                    $addressMapping.EncapType = $paMapping[4]
-                    break
-                }
-            }
-
-            # Get Rdid and VSID from logical switch table
-            foreach ($switch in $logicalSwitchTable.Data) {
-                $curSwitch = $switch[0][1]
-                if ($curSwitch -eq $logicalSwitch) {
-                    $addressMapping.RoutingDomainId = $switch[1]
-                    $addressMapping.VSwitchID = $switch[3]
-                    break
-                }
-            }
-
-            # add the object to the array
-            [void]$arrayList.Add($addressMapping)
         }
 
-        return $arrayList
+        # Get Rdid and VSID from logical switch table
+        foreach ($switch in $logicalSwitchTable.Data) {
+            $curSwitch = $switch[0][1]
+            if ($curSwitch -eq $logicalSwitch) {
+                $addressMapping.RoutingDomainId = $switch[1]
+                $addressMapping.VSwitchID = $switch[3]
+                break
+            }
+        }
+
+        # add the object to the array
+        [void]$arrayList.Add($addressMapping)
     }
-    catch {
-        $_ | Trace-Exception
-    }
+
+    return $arrayList
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbAddressMapping.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbAddressMapping.ps1
@@ -61,5 +61,6 @@ function Get-OvsdbAddressMapping {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbDatabase.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbDatabase.ps1
@@ -5,24 +5,19 @@ function Get-OvsdbDatabase {
         [OvsdbTable]$Table
     )
 
-    try {
-        $localPort = Get-NetTCPConnection -LocalPort:6641 -ErrorAction:SilentlyContinue
-        if ($null -eq $localPort){
-            throw New-Object System.NullReferenceException("No endpoint listening on port 6641. Ensure NCHostAgent service is running.")
-        }
-
-        $cmdline = "ovsdb-client.exe dump tcp:127.0.0.1:6641 -f json {0}" -f $Table
-        $databaseResults = Invoke-Expression $cmdline | ConvertFrom-Json
-
-        if($null -eq $databaseResults){
-            $msg = "Unable to retrieve OVSDB results`n`t{0}" -f $_
-            throw New-Object System.NullReferenceException($msg)
-        }
-        else {
-            return $databaseResults
-        }
+    $localPort = Get-NetTCPConnection -LocalPort:6641 -ErrorAction:SilentlyContinue
+    if ($null -eq $localPort){
+        throw New-Object System.NullReferenceException("No endpoint listening on port 6641. Ensure NCHostAgent service is running.")
     }
-    catch {
-        $_ | Trace-Exception
+
+    $cmdline = "ovsdb-client.exe dump tcp:127.0.0.1:6641 -f json {0}" -f $Table
+    $databaseResults = Invoke-Expression $cmdline | ConvertFrom-Json
+
+    if($null -eq $databaseResults){
+        $msg = "Unable to retrieve OVSDB results`n`t{0}" -f $_
+        throw New-Object System.NullReferenceException($msg)
+    }
+    else {
+        return $databaseResults
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbDatabase.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbDatabase.ps1
@@ -24,6 +24,5 @@ function Get-OvsdbDatabase {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbDatabase.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbDatabase.ps1
@@ -24,5 +24,6 @@ function Get-OvsdbDatabase {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbFirewallRuleTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbFirewallRuleTable.ps1
@@ -43,5 +43,6 @@ function Get-OvsdbFirewallRuleTable {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbFirewallRuleTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbFirewallRuleTable.ps1
@@ -43,6 +43,5 @@ function Get-OvsdbFirewallRuleTable {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbFirewallRuleTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbFirewallRuleTable.ps1
@@ -6,42 +6,37 @@ function Get-OvsdbFirewallRuleTable {
         PS> Get-OvsdbFirewallRuleTable
     #>
 
-    try {
-        $arrayList = [System.Collections.ArrayList]::new()
+    $arrayList = [System.Collections.ArrayList]::new()
 
-        $ovsdbResults = Get-OvsdbDatabase -Table ms_firewall
-        $firewallTable = $ovsdbResults | Where-Object { $_.caption -eq 'FW_Rules table' }
+    $ovsdbResults = Get-OvsdbDatabase -Table ms_firewall
+    $firewallTable = $ovsdbResults | Where-Object { $_.caption -eq 'FW_Rules table' }
 
-        if ($null -eq $firewallTable) {
-            return $null
-        }
-        # enumerate the json rules and create object for each firewall rule returned
-        # there is no nice way to generate this and requires manually mapping as only the values are return
-        foreach ($obj in $firewallTable.data) {
-            $result = [OvsdbFirewallRule]@{
-                UUID               = $obj[0][1]
-                Action             = $obj[1]
-                Direction          = $obj[2]
-                DestinationAddress = $obj[3]
-                DestinationPort    = $obj[4]
-                Logging            = $obj[5]
-                Priority           = $obj[6]
-                Protocols          = $obj[7]
-                RuleId             = $obj[8]
-                State              = $obj[9]
-                Type               = $obj[10]
-                SourceAddress      = $obj[11]
-                SourcePort         = $obj[12]
-                VirtualNicId       = $obj[13]
-            }
-
-            # add the psobject to array list
-            [void]$arrayList.Add($result)
+    if ($null -eq $firewallTable) {
+        return $null
+    }
+    # enumerate the json rules and create object for each firewall rule returned
+    # there is no nice way to generate this and requires manually mapping as only the values are return
+    foreach ($obj in $firewallTable.data) {
+        $result = [OvsdbFirewallRule]@{
+            UUID               = $obj[0][1]
+            Action             = $obj[1]
+            Direction          = $obj[2]
+            DestinationAddress = $obj[3]
+            DestinationPort    = $obj[4]
+            Logging            = $obj[5]
+            Priority           = $obj[6]
+            Protocols          = $obj[7]
+            RuleId             = $obj[8]
+            State              = $obj[9]
+            Type               = $obj[10]
+            SourceAddress      = $obj[11]
+            SourcePort         = $obj[12]
+            VirtualNicId       = $obj[13]
         }
 
-        return $arrayList
+        # add the psobject to array list
+        [void]$arrayList.Add($result)
     }
-    catch {
-        $_ | Trace-Exception
-    }
+
+    return $arrayList
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbGlobalTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbGlobalTable.ps1
@@ -6,32 +6,27 @@ function Get-OvsdbGlobalTable {
         PS> Get-OvsdbGlobalTable
     #>
 
-    try {
-        $arrayList = [System.Collections.ArrayList]::new()
+    $arrayList = [System.Collections.ArrayList]::new()
 
-        $ovsdbResults = Get-OvsdbDatabase -Table ms_vtep
-        $globalTable = $ovsdbResults | Where-Object { $_.caption -eq 'Global table' }
+    $ovsdbResults = Get-OvsdbDatabase -Table ms_vtep
+    $globalTable = $ovsdbResults | Where-Object { $_.caption -eq 'Global table' }
 
-        if ($null -eq $globalTable) {
-            return $null
+    if ($null -eq $globalTable) {
+        return $null
+    }
+
+    # enumerate the json results and add to psobject
+    foreach ($obj in $globalTable.data) {
+        $result = [OvsdbGlobalTable]@{
+            uuid     = $obj[0][1]
+            CurrentConfig  = $obj[1]
+            NextConfig = $obj[4]
+            Switches = $obj[6][1]
         }
 
-        # enumerate the json results and add to psobject
-        foreach ($obj in $globalTable.data) {
-            $result = [OvsdbGlobalTable]@{
-                uuid     = $obj[0][1]
-                CurrentConfig  = $obj[1]
-                NextConfig = $obj[4]
-                Switches = $obj[6][1]
-            }
-
-            # add the psobject to array
-            [void]$arrayList.Add($result)
-        }
-
-        return $arrayList
+        # add the psobject to array
+        [void]$arrayList.Add($result)
     }
-    catch {
-        $_ | Trace-Exception
-    }
+
+    return $arrayList
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbGlobalTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbGlobalTable.ps1
@@ -33,5 +33,6 @@ function Get-OvsdbGlobalTable {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbGlobalTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbGlobalTable.ps1
@@ -33,6 +33,5 @@ function Get-OvsdbGlobalTable {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbPhysicalPortTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbPhysicalPortTable.ps1
@@ -38,6 +38,5 @@ function Get-OvsdbPhysicalPortTable {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbPhysicalPortTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbPhysicalPortTable.ps1
@@ -6,37 +6,32 @@ function Get-OvsdbPhysicalPortTable {
         PS> Get-OvsdbPhysicalPortTable
     #>
 
-    try {
-        $arrayList = [System.Collections.ArrayList]::new()
+    $arrayList = [System.Collections.ArrayList]::new()
 
-        $ovsdbResults = Get-OvsdbDatabase -Table ms_vtep
-        $portTable = $ovsdbResults | Where-Object { $_.caption -eq 'Physical_Port table' }
+    $ovsdbResults = Get-OvsdbDatabase -Table ms_vtep
+    $portTable = $ovsdbResults | Where-Object { $_.caption -eq 'Physical_Port table' }
 
-        if ($null -eq $portTable) {
-            return $null
+    if ($null -eq $portTable) {
+        return $null
+    }
+
+    # enumerate the json objects and create psobject for each port
+    foreach ($obj in $portTable.data) {
+        $physicalPort = [OvsdbPhysicalPort]@{
+            UUID        = $obj[0][1]
+            Description = $obj[1]
+            Name        = $obj[2].Trim('{', '}')  # remove the curly braces from the name
         }
 
-        # enumerate the json objects and create psobject for each port
-        foreach ($obj in $portTable.data) {
-            $physicalPort = [OvsdbPhysicalPort]@{
-                UUID        = $obj[0][1]
-                Description = $obj[1]
-                Name        = $obj[2].Trim('{', '}')  # remove the curly braces from the name
-            }
-
-            # there are numerous key/value pairs within this object with some having different properties
-            # enumerate through the properties and add property and value for each
-            foreach ($property in $obj[4][1]) {
-                $physicalPort | Add-Member -MemberType NoteProperty -Name $property[0] -Value $property[1]
-            }
-
-            # add the psobject to array
-            [void]$arrayList.Add($physicalPort)
+        # there are numerous key/value pairs within this object with some having different properties
+        # enumerate through the properties and add property and value for each
+        foreach ($property in $obj[4][1]) {
+            $physicalPort | Add-Member -MemberType NoteProperty -Name $property[0] -Value $property[1]
         }
 
-        return $arrayList
+        # add the psobject to array
+        [void]$arrayList.Add($physicalPort)
     }
-    catch {
-        $_ | Trace-Exception
-    }
+
+    return $arrayList
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbPhysicalPortTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbPhysicalPortTable.ps1
@@ -38,5 +38,6 @@ function Get-OvsdbPhysicalPortTable {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbRouterTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbRouterTable.ps1
@@ -6,55 +6,50 @@ function Get-OvsdbRouterTable {
         PS> Get-OvsdbRouterTable
     #>
 
-    try {
-        $arrayList = [System.Collections.ArrayList]::new()
+    $arrayList = [System.Collections.ArrayList]::new()
 
-        $ovsdbResults = Get-OvsdbDatabase -Table ms_vtep
-        $routerTable = $ovsdbResults | Where-Object { $_.caption -eq 'Logical_Router table' }
+    $ovsdbResults = Get-OvsdbDatabase -Table ms_vtep
+    $routerTable = $ovsdbResults | Where-Object { $_.caption -eq 'Logical_Router table' }
 
-        if ($null -eq $routerTable) {
-            return $null
+    if ($null -eq $routerTable) {
+        return $null
+    }
+
+    # enumerate the json results and add to psobject
+    foreach ($obj in $routerTable.data) {
+        $staticroute = @()
+        if($obj[5][1].count -gt 0){
+            foreach($route in $obj[5][1]){
+                if(![string]::IsNullOrEmpty(($staticroute))){
+                    $staticroute += ', '
+                }
+                $staticRoute += "$($route[0])=$($route[1])"
+            }
         }
 
-        # enumerate the json results and add to psobject
-        foreach ($obj in $routerTable.data) {
-            $staticroute = @()
-            if($obj[5][1].count -gt 0){
-                foreach($route in $obj[5][1]){
-                    if(![string]::IsNullOrEmpty(($staticroute))){
-                        $staticroute += ', '
-                    }
-                    $staticRoute += "$($route[0])=$($route[1])"
+        $switchbinding = @()
+        if($obj[6][1].count -gt 0){
+            foreach($switch in $obj[6][1]){
+                if(![string]::IsNullOrEmpty(($switchbinding))){
+                    $switchbinding += ', '
                 }
+
+                $switchbinding += "$($switch[0])=$($switch[1][1])"
             }
-
-            $switchbinding = @()
-            if($obj[6][1].count -gt 0){
-                foreach($switch in $obj[6][1]){
-                    if(![string]::IsNullOrEmpty(($switchbinding))){
-                        $switchbinding += ', '
-                    }
-
-                    $switchbinding += "$($switch[0])=$($switch[1][1])"
-                }
-            }
-
-            $result = [OvsdbRouter]@{
-                uuid     = $obj[0][1]
-                Description  = $obj[1]
-                EnableLogicalRouter = $obj[2]
-                VirtualNetworkId = $obj[3]
-                StaticRoutes = $staticroute
-                SwitchBinding = $switchbinding
-            }
-
-            # add the psobject to array
-            [void]$arrayList.Add($result)
         }
 
-        return $arrayList
+        $result = [OvsdbRouter]@{
+            uuid     = $obj[0][1]
+            Description  = $obj[1]
+            EnableLogicalRouter = $obj[2]
+            VirtualNetworkId = $obj[3]
+            StaticRoutes = $staticroute
+            SwitchBinding = $switchbinding
+        }
+
+        # add the psobject to array
+        [void]$arrayList.Add($result)
     }
-    catch {
-        $_ | Trace-Exception
-    }
+
+    return $arrayList
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbRouterTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbRouterTable.ps1
@@ -56,6 +56,5 @@ function Get-OvsdbRouterTable {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbRouterTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbRouterTable.ps1
@@ -56,5 +56,6 @@ function Get-OvsdbRouterTable {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbUcastMacRemoteTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbUcastMacRemoteTable.ps1
@@ -6,33 +6,28 @@ function Get-OvsdbUcastMacRemoteTable {
         PS> Get-OvsdbUcastMacRemoteTable
     #>
 
-    try {
-        $arrayList = [System.Collections.ArrayList]::new()
+    $arrayList = [System.Collections.ArrayList]::new()
 
-        $ovsdbResults = Get-OvsdbDatabase -Table ms_vtep
-        $ucastMacsRemoteTable = $ovsdbResults | Where-Object { $_.caption -eq 'Ucast_Macs_Remote table' }
+    $ovsdbResults = Get-OvsdbDatabase -Table ms_vtep
+    $ucastMacsRemoteTable = $ovsdbResults | Where-Object { $_.caption -eq 'Ucast_Macs_Remote table' }
 
-        if ($null -eq $ucastMacsRemoteTable) {
-            return $null
+    if ($null -eq $ucastMacsRemoteTable) {
+        return $null
+    }
+
+    # enumerate the json objects and create psobject for each port
+    foreach ($obj in $ucastMacsRemoteTable.data) {
+        $result = [OvsdbUcastMacRemote]@{
+            UUID            = $obj[1][1]
+            MacAddress      = $obj[0]
+            CustomerAddress = $obj[2]
+            Locator         = $obj[3][1]
+            LogicalSwitch   = $obj[4][1]
+            MappingType     = $obj[5]
         }
 
-        # enumerate the json objects and create psobject for each port
-        foreach ($obj in $ucastMacsRemoteTable.data) {
-            $result = [OvsdbUcastMacRemote]@{
-                UUID            = $obj[1][1]
-                MacAddress      = $obj[0]
-                CustomerAddress = $obj[2]
-                Locator         = $obj[3][1]
-                LogicalSwitch   = $obj[4][1]
-                MappingType     = $obj[5]
-            }
-
-            [void]$arrayList.Add($result)
-        }
-
-        return $arrayList
+        [void]$arrayList.Add($result)
     }
-    catch {
-        $_ | Trace-Exception
-    }
+
+    return $arrayList
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbUcastMacRemoteTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbUcastMacRemoteTable.ps1
@@ -34,5 +34,6 @@ function Get-OvsdbUcastMacRemoteTable {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-OvsdbUcastMacRemoteTable.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-OvsdbUcastMacRemoteTable.ps1
@@ -34,6 +34,5 @@ function Get-OvsdbUcastMacRemoteTable {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/private/Get-ServerConfigState.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-ServerConfigState.ps1
@@ -102,7 +102,6 @@ function Get-ServerConfigState {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 
     $ProgressPreference = 'Continue'

--- a/src/modules/SdnDiag.Server/private/Get-ServerConfigState.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-ServerConfigState.ps1
@@ -102,6 +102,7 @@ function Get-ServerConfigState {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 
     $ProgressPreference = 'Continue'

--- a/src/modules/SdnDiag.Server/public/Get-SdnNetAdapterEncapOverheadConfig.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnNetAdapterEncapOverheadConfig.ps1
@@ -68,5 +68,6 @@ function Get-SdnNetAdapterEncapOverheadConfig {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnNetAdapterEncapOverheadConfig.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnNetAdapterEncapOverheadConfig.ps1
@@ -68,6 +68,5 @@ function Get-SdnNetAdapterEncapOverheadConfig {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnNetAdapterRdmaConfig.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnNetAdapterRdmaConfig.ps1
@@ -137,5 +137,6 @@ function Get-SdnNetAdapterRdmaConfig {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnNetAdapterRdmaConfig.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnNetAdapterRdmaConfig.ps1
@@ -137,6 +137,5 @@ function Get-SdnNetAdapterRdmaConfig {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnOvsdbAddressMapping.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnOvsdbAddressMapping.ps1
@@ -57,5 +57,6 @@ function Get-SdnOvsdbAddressMapping {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnOvsdbAddressMapping.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnOvsdbAddressMapping.ps1
@@ -57,6 +57,5 @@ function Get-SdnOvsdbAddressMapping {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnOvsdbFirewallRule.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnOvsdbFirewallRule.ps1
@@ -58,6 +58,5 @@ function Get-SdnOvsdbFirewallRule {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnOvsdbFirewallRule.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnOvsdbFirewallRule.ps1
@@ -58,5 +58,6 @@ function Get-SdnOvsdbFirewallRule {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnOvsdbGlobalTable.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnOvsdbGlobalTable.ps1
@@ -33,5 +33,6 @@ function Get-SdnOvsdbGlobalTable {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnOvsdbGlobalTable.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnOvsdbGlobalTable.ps1
@@ -33,6 +33,5 @@ function Get-SdnOvsdbGlobalTable {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnOvsdbPhysicalPort.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnOvsdbPhysicalPort.ps1
@@ -74,5 +74,6 @@ function Get-SdnOvsdbPhysicalPort {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnOvsdbPhysicalPort.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnOvsdbPhysicalPort.ps1
@@ -74,6 +74,5 @@ function Get-SdnOvsdbPhysicalPort {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnOvsdbRouterTable.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnOvsdbRouterTable.ps1
@@ -33,6 +33,5 @@ function Get-SdnOvsdbRouterTable {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnOvsdbRouterTable.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnOvsdbRouterTable.ps1
@@ -33,5 +33,6 @@ function Get-SdnOvsdbRouterTable {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnOvsdbUcastMacRemoteTable.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnOvsdbUcastMacRemoteTable.ps1
@@ -33,5 +33,6 @@ function Get-SdnOvsdbUcastMacRemoteTable {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnOvsdbUcastMacRemoteTable.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnOvsdbUcastMacRemoteTable.ps1
@@ -33,6 +33,5 @@ function Get-SdnOvsdbUcastMacRemoteTable {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnProviderAddress.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnProviderAddress.ps1
@@ -55,6 +55,5 @@ function Get-SdnProviderAddress {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnProviderAddress.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnProviderAddress.ps1
@@ -55,5 +55,6 @@ function Get-SdnProviderAddress {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnServerCertificate.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnServerCertificate.ps1
@@ -15,5 +15,6 @@ function Get-SdnServerCertificate {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnServerCertificate.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnServerCertificate.ps1
@@ -15,6 +15,5 @@ function Get-SdnServerCertificate {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnVMNetworkAdapter.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnVMNetworkAdapter.ps1
@@ -60,5 +60,6 @@ function Get-SdnVMNetworkAdapter {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnVMNetworkAdapter.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnVMNetworkAdapter.ps1
@@ -60,6 +60,5 @@ function Get-SdnVMNetworkAdapter {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnVMNetworkAdapterPortProfile.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnVMNetworkAdapterPortProfile.ps1
@@ -74,5 +74,6 @@ function Get-SdnVMNetworkAdapterPortProfile {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnVMNetworkAdapterPortProfile.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnVMNetworkAdapterPortProfile.ps1
@@ -74,6 +74,5 @@ function Get-SdnVMNetworkAdapterPortProfile {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnVfpPortGroup.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnVfpPortGroup.ps1
@@ -100,5 +100,6 @@ function Get-SdnVfpPortGroup {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnVfpPortGroup.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnVfpPortGroup.ps1
@@ -100,6 +100,5 @@ function Get-SdnVfpPortGroup {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnVfpPortLayer.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnVfpPortLayer.ps1
@@ -57,6 +57,5 @@ function Get-SdnVfpPortLayer {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnVfpPortLayer.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnVfpPortLayer.ps1
@@ -57,5 +57,6 @@ function Get-SdnVfpPortLayer {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnVfpPortRule.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnVfpPortRule.ps1
@@ -68,5 +68,6 @@ function Get-SdnVfpPortRule {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnVfpPortRule.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnVfpPortRule.ps1
@@ -68,6 +68,5 @@ function Get-SdnVfpPortRule {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnVfpPortState.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnVfpPortState.ps1
@@ -47,6 +47,5 @@ function Get-SdnVfpPortState {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnVfpPortState.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnVfpPortState.ps1
@@ -47,5 +47,6 @@ function Get-SdnVfpPortState {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnVfpVmSwitchPort.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnVfpVmSwitchPort.ps1
@@ -77,6 +77,5 @@ function Get-SdnVfpVmSwitchPort {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Get-SdnVfpVmSwitchPort.ps1
+++ b/src/modules/SdnDiag.Server/public/Get-SdnVfpVmSwitchPort.ps1
@@ -77,5 +77,6 @@ function Get-SdnVfpVmSwitchPort {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/New-SdnServerCertificate.ps1
+++ b/src/modules/SdnDiag.Server/public/New-SdnServerCertificate.ps1
@@ -71,5 +71,6 @@ function New-SdnServerCertificate {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/New-SdnServerCertificate.ps1
+++ b/src/modules/SdnDiag.Server/public/New-SdnServerCertificate.ps1
@@ -71,6 +71,5 @@ function New-SdnServerCertificate {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Set-SdnVMNetworkAdapterPortProfile.ps1
+++ b/src/modules/SdnDiag.Server/public/Set-SdnVMNetworkAdapterPortProfile.ps1
@@ -149,6 +149,5 @@ function Set-SdnVMNetworkAdapterPortProfile {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Set-SdnVMNetworkAdapterPortProfile.ps1
+++ b/src/modules/SdnDiag.Server/public/Set-SdnVMNetworkAdapterPortProfile.ps1
@@ -149,5 +149,6 @@ function Set-SdnVMNetworkAdapterPortProfile {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Show-SdnVfpPortConfig.ps1
+++ b/src/modules/SdnDiag.Server/public/Show-SdnVfpPortConfig.ps1
@@ -59,6 +59,5 @@ function Show-SdnVfpPortConfig {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Show-SdnVfpPortConfig.ps1
+++ b/src/modules/SdnDiag.Server/public/Show-SdnVfpPortConfig.ps1
@@ -59,5 +59,6 @@ function Show-SdnVfpPortConfig {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
+++ b/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
@@ -200,5 +200,6 @@ function Start-SdnServerCertificateRotation {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
+++ b/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
@@ -80,11 +80,6 @@ function Start-SdnServerCertificateRotation {
     # add disclaimer that this feature is currently under preview
     if (!$Force) {
         "This feature is currently under preview. Please report any issues to https://github.com/microsoft/SdnDiagnostics/issues so we can accurately track any issues and help unblock your cert rotation." | Trace-Output -Level:Warning
-        $confirm = Confirm-UserInput -Message "Do you want to proceed with certificate rotation? [Y/N]:"
-        if (-NOT $confirm) {
-            "User has opted to abort the operation. Terminating operation" | Trace-Output -Level:Warning
-            return
-        }
     }
 
     $array = @()

--- a/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
+++ b/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
@@ -200,6 +200,5 @@ function Start-SdnServerCertificateRotation {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Test-SdnProviderAddressConnectivity.ps1
+++ b/src/modules/SdnDiag.Server/public/Test-SdnProviderAddressConnectivity.ps1
@@ -59,6 +59,5 @@ function Test-SdnProviderAddressConnectivity {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Server/public/Test-SdnProviderAddressConnectivity.ps1
+++ b/src/modules/SdnDiag.Server/public/Test-SdnProviderAddressConnectivity.ps1
@@ -59,5 +59,6 @@ function Test-SdnProviderAddressConnectivity {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Confirm-DiskSpace.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Confirm-DiskSpace.ps1
@@ -12,38 +12,33 @@ function Confirm-DiskSpace {
         $MinimumMB
     )
 
-    try {
-        $drive = Get-PSDrive $DriveLetter -ErrorAction Stop
-        if ($null -eq $drive) {
-            throw New-Object System.NullReferenceException("Unable to retrieve PSDrive information")
-        }
-
-        $freeSpace = Format-ByteSize -Bytes $drive.Free
-        switch ($PSCmdlet.ParameterSetName) {
-            'GB' {
-                "Required: {0} GB | Available: {1} GB" -f ([float]$MinimumGB).ToString(), $freeSpace.GB | Trace-Output -Level:Verbose
-                if ([float]$freeSpace.GB -gt [float]$MinimumGB) {
-                    return $true
-                }
-
-                # if we do not have enough disk space, we want to provide what was required vs what was available
-                "Required: {0} GB | Available: {1} GB" -f ([float]$MinimumGB).ToString(), $freeSpace.GB | Trace-Output -Level:Error
-                return $false
-            }
-
-            'MB' {
-                "Required: {0} MB | Available: {1} MB" -f ([float]$MinimumMB).ToString(), $freeSpace.MB | Trace-Output -Level:Verbose
-                if ([float]$freeSpace.MB -gt [float]$MinimumMB) {
-                    return $true
-                }
-
-                # if we do not have enough disk space, we want to provide what was required vs what was available
-                "Required: {0} MB | Available: {1} MB" -f ([float]$MinimumMB).ToString(), $freeSpace.MB | Trace-Output -Level:Error
-                return $false
-            }
-        }
+    $drive = Get-PSDrive $DriveLetter -ErrorAction Stop
+    if ($null -eq $drive) {
+        throw New-Object System.NullReferenceException("Unable to retrieve PSDrive information")
     }
-    catch {
-        $_ | Trace-Exception
+
+    $freeSpace = Format-ByteSize -Bytes $drive.Free
+    switch ($PSCmdlet.ParameterSetName) {
+        'GB' {
+            "Required: {0} GB | Available: {1} GB" -f ([float]$MinimumGB).ToString(), $freeSpace.GB | Trace-Output -Level:Verbose
+            if ([float]$freeSpace.GB -gt [float]$MinimumGB) {
+                return $true
+            }
+
+            # if we do not have enough disk space, we want to provide what was required vs what was available
+            "Required: {0} GB | Available: {1} GB" -f ([float]$MinimumGB).ToString(), $freeSpace.GB | Trace-Output -Level:Error
+            return $false
+        }
+
+        'MB' {
+            "Required: {0} MB | Available: {1} MB" -f ([float]$MinimumMB).ToString(), $freeSpace.MB | Trace-Output -Level:Verbose
+            if ([float]$freeSpace.MB -gt [float]$MinimumMB) {
+                return $true
+            }
+
+            # if we do not have enough disk space, we want to provide what was required vs what was available
+            "Required: {0} MB | Available: {1} MB" -f ([float]$MinimumMB).ToString(), $freeSpace.MB | Trace-Output -Level:Error
+            return $false
+        }
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Confirm-DiskSpace.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Confirm-DiskSpace.ps1
@@ -45,6 +45,5 @@ function Confirm-DiskSpace {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Confirm-DiskSpace.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Confirm-DiskSpace.ps1
@@ -45,5 +45,6 @@ function Confirm-DiskSpace {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Copy-FileFromRemoteComputer.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Copy-FileFromRemoteComputer.ps1
@@ -77,5 +77,6 @@ function Copy-FileFromRemoteComputer {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Copy-FileFromRemoteComputer.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Copy-FileFromRemoteComputer.ps1
@@ -77,6 +77,5 @@ function Copy-FileFromRemoteComputer {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Copy-FileToRemoteComputer.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Copy-FileToRemoteComputer.ps1
@@ -77,5 +77,6 @@ function Copy-FileToRemoteComputer {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Copy-FileToRemoteComputer.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Copy-FileToRemoteComputer.ps1
@@ -77,6 +77,5 @@ function Copy-FileToRemoteComputer {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Format-NetshTraceProviderAsString.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Format-NetshTraceProviderAsString.ps1
@@ -43,6 +43,5 @@ function Format-NetshTraceProviderAsString {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Format-NetshTraceProviderAsString.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Format-NetshTraceProviderAsString.ps1
@@ -43,5 +43,6 @@ function Format-NetshTraceProviderAsString {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Get-FolderSize.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Get-FolderSize.ps1
@@ -63,5 +63,6 @@ function Get-FolderSize {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Get-FolderSize.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Get-FolderSize.ps1
@@ -63,6 +63,5 @@ function Get-FolderSize {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Get-FunctionFromFile.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Get-FunctionFromFile.ps1
@@ -30,5 +30,6 @@ function Get-FunctionFromFile {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Get-FunctionFromFile.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Get-FunctionFromFile.ps1
@@ -30,6 +30,5 @@ function Get-FunctionFromFile {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Invoke-RestMethodWithRetry.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Invoke-RestMethodWithRetry.ps1
@@ -80,15 +80,6 @@ function Invoke-RestMethodWithRetry {
             break
         }
         catch {
-            if ($_.Exception.Response.StatusCode -eq "NotFound") {
-                "{0} ({1})" -f $_.Exception.Message, $_.Exception.Response.ResponseUri.AbsoluteUri | Trace-Output -Level:Warning
-                return $null
-            }
-            else {
-                $_ | Trace-Exception
-                throw $_
-            }
-
             if (($counter -le $MaxRetry) -and $Retry) {
                 "Retrying operation in {0} seconds. Retry count: {1}." - $RetryIntervalInSeconds, $counter | Trace-Output
                 Start-Sleep -Seconds $RetryIntervalInSeconds

--- a/src/modules/SdnDiag.Utilities/private/Invoke-RestMethodWithRetry.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Invoke-RestMethodWithRetry.ps1
@@ -85,7 +85,8 @@ function Invoke-RestMethodWithRetry {
                 return $null
             }
             else {
-                $_ | Trace-Output -Level:Error
+                $_ | Trace-Exception
+                throw $_
             }
 
             if (($counter -le $MaxRetry) -and $Retry) {
@@ -93,6 +94,7 @@ function Invoke-RestMethodWithRetry {
                 Start-Sleep -Seconds $RetryIntervalInSeconds
             }
             else {
+                $_ | Trace-Exception
                 throw $_
             }
         }

--- a/src/modules/SdnDiag.Utilities/private/Invoke-WebRequestWithRetry.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Invoke-WebRequestWithRetry.ps1
@@ -80,15 +80,6 @@ function Invoke-WebRequestWithRetry {
             break
         }
         catch {
-            if ($_.Exception.Response.StatusCode -eq "NotFound") {
-                "{0} ({1})" -f $_.Exception.Message, $_.Exception.Response.ResponseUri.AbsoluteUri | Trace-Output -Level:Warning
-                return $null
-            }
-            else {
-                $_ | Trace-Exception
-                throw $_
-            }
-
             if (($counter -le $MaxRetry) -and $Retry) {
                 "Retrying operation in {0} seconds. Retry count: {1}." - $RetryIntervalInSeconds, $counter | Trace-Output
                 Start-Sleep -Seconds $RetryIntervalInSeconds

--- a/src/modules/SdnDiag.Utilities/private/Invoke-WebRequestWithRetry.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Invoke-WebRequestWithRetry.ps1
@@ -85,7 +85,8 @@ function Invoke-WebRequestWithRetry {
                 return $null
             }
             else {
-                $_ | Trace-Output -Level:Error
+                $_ | Trace-Exception
+                throw $_
             }
 
             if (($counter -le $MaxRetry) -and $Retry) {
@@ -93,6 +94,7 @@ function Invoke-WebRequestWithRetry {
                 Start-Sleep -Seconds $RetryIntervalInSeconds
             }
             else {
+                $_ | Trace-Exception
                 throw $_
             }
         }

--- a/src/modules/SdnDiag.Utilities/private/Test-ComputerNameIsLocal.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Test-ComputerNameIsLocal.ps1
@@ -33,5 +33,6 @@ function Test-ComputerNameIsLocal {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Test-ComputerNameIsLocal.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Test-ComputerNameIsLocal.ps1
@@ -33,6 +33,5 @@ function Test-ComputerNameIsLocal {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Test-Ping.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Test-Ping.ps1
@@ -67,6 +67,5 @@ function Test-Ping {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Test-Ping.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Test-Ping.ps1
@@ -67,5 +67,6 @@ function Test-Ping {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Trace-Exception.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Trace-Exception.ps1
@@ -22,5 +22,5 @@ function Trace-Exception {
         $Exception
     )
 
-    Trace-Output -Level:Exception -Exception $Exception
+    Trace-Output -Exception $Exception -FunctionName (Get-PSCallStack)[1].Command -Level 'Exception'
 }

--- a/src/modules/SdnDiag.Utilities/private/Trace-Exception.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Trace-Exception.ps1
@@ -22,5 +22,5 @@ function Trace-Exception {
         $Exception
     )
 
-    Trace-Output -Level:Error -Message $Exception.Exception.Message -Exception $Exception
+    Trace-Output -Level:Exception -Exception $Exception
 }

--- a/src/modules/SdnDiag.Utilities/private/Trace-Output.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Trace-Output.ps1
@@ -2,13 +2,14 @@ function Trace-Output {
 
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'Message')]
         [System.String]$Message,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Message')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Exception')]
         [TraceLevel]$Level,
 
-        [parameter(Mandatory = $false)]
+        [parameter(Mandatory = $true, ParameterSetName = 'Exception')]
         $Exception
     )
 
@@ -46,7 +47,7 @@ function Trace-Output {
                 if ($Exception) {
                     Write-Error -Exception $Exception.Exception -Message $Message
                     $traceEvent.FunctionName = (Get-PSCallStack)[2].Command
-                    $traceEvent.Message = "{0}`n`t{1}" -f $Exception.Exception.Message, $Exception.Exception.ScriptStackTrace
+                    $traceEvent.Message = "{0}`n{1}" -f $Exception.Exception, $Exception.ScriptStackTrace
                 }
                 else {
                     Write-Error -Message $Message

--- a/src/modules/SdnDiag.Utilities/private/Trace-Output.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Trace-Output.ps1
@@ -11,7 +11,7 @@ function Trace-Output {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Message')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Exception')]
-        [System.String]$FunctionName = (Get-PSCallStack)[1].Command,
+        [System.String]$FunctionName = (Get-PSCallStack)[0].Command,
 
         [parameter(Mandatory = $true, ParameterSetName = 'Exception')]
         $Exception

--- a/src/modules/SdnDiag.Utilities/private/Trace-Output.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Trace-Output.ps1
@@ -7,17 +7,17 @@ function Trace-Output {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Message')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Exception')]
-        [TraceLevel]$Level,
+        [TraceLevel]$Level = 'Information',
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Message')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Exception')]
+        [System.String]$FunctionName = (Get-PSCallStack)[1].Command,
 
         [parameter(Mandatory = $true, ParameterSetName = 'Exception')]
         $Exception
     )
 
     begin {
-        if (!$PSBoundParameters.ContainsKey('Level')) {
-            $Level = [TraceLevel]::Information
-        }
-
         $traceFile = (Get-TraceOutputFile)
         if ([string]::IsNullOrEmpty($traceFile)) {
             New-WorkingDirectory
@@ -30,9 +30,18 @@ function Trace-Output {
         $traceEvent = [PSCustomObject]@{
             Computer = $env:COMPUTERNAME.ToUpper().ToString()
             TimestampUtc = [DateTime]::UtcNow.ToString('yyyy-MM-dd HH-mm-ss')
-            FunctionName = (Get-PSCallStack)[1].Command
+            FunctionName = $FunctionName
             Level = $Level.ToString()
-            Message = $Message
+            Message = $null
+        }
+
+        switch ($PSCmdlet.ParameterSetName) {
+            'Message' {
+                $traceEvent.Message = $Message
+            }
+            'Exception' {
+                $traceEvent.Message = "{0}`n{1}" -f $Exception.Exception, $Exception.ScriptStackTrace
+            }
         }
 
         $formattedMessage = "[{0}] {1}" -f $traceEvent.Computer, $traceEvent.Message
@@ -44,14 +53,8 @@ function Trace-Output {
             }
 
             'Exception' {
-                if ($Exception) {
-                    Write-Error -Exception $Exception.Exception -Message $Message
-                    $traceEvent.FunctionName = (Get-PSCallStack)[2].Command
-                    $traceEvent.Message = "{0}`n{1}" -f $Exception.Exception, $Exception.ScriptStackTrace
-                }
-                else {
-                    Write-Error -Message $Message
-                }
+                # do nothing here, as the exception should be written to the console by the caller using Write-Error
+                # as this will preserve the proper call stack tracing
             }
 
             'Success' {

--- a/src/modules/SdnDiag.Utilities/private/Wait-PSJob.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Wait-PSJob.ps1
@@ -84,6 +84,5 @@ function Wait-PSJob {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/private/Wait-PSJob.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Wait-PSJob.ps1
@@ -84,5 +84,6 @@ function Wait-PSJob {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/public/Clear-SdnWorkingDirectory.ps1
+++ b/src/modules/SdnDiag.Utilities/public/Clear-SdnWorkingDirectory.ps1
@@ -97,5 +97,6 @@ function Clear-SdnWorkingDirectory {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/public/Clear-SdnWorkingDirectory.ps1
+++ b/src/modules/SdnDiag.Utilities/public/Clear-SdnWorkingDirectory.ps1
@@ -97,6 +97,5 @@ function Clear-SdnWorkingDirectory {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/public/Install-SdnDiagnostics.ps1
+++ b/src/modules/SdnDiag.Utilities/public/Install-SdnDiagnostics.ps1
@@ -136,6 +136,5 @@ function Install-SdnDiagnostics {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/public/Install-SdnDiagnostics.ps1
+++ b/src/modules/SdnDiag.Utilities/public/Install-SdnDiagnostics.ps1
@@ -136,5 +136,6 @@ function Install-SdnDiagnostics {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/public/Invoke-SdnCommand.ps1
+++ b/src/modules/SdnDiag.Utilities/public/Invoke-SdnCommand.ps1
@@ -28,5 +28,6 @@ function Invoke-SdnCommand {
     }
     catch {
         $_ | Trace-Exception
+        $_ | Write-Error
     }
 }

--- a/src/modules/SdnDiag.Utilities/public/Invoke-SdnCommand.ps1
+++ b/src/modules/SdnDiag.Utilities/public/Invoke-SdnCommand.ps1
@@ -28,6 +28,5 @@ function Invoke-SdnCommand {
     }
     catch {
         $_ | Trace-Exception
-        $_ | Write-Error
     }
 }


### PR DESCRIPTION
# Description
Summary of changes:
- Code fixes to address ScriptStackTrace exception not being captured into log file. When errors are generated, we now capture the full call stack properly.
```
"SDN-HOST01","2024-03-19 22-42-47","Get-OvsdbDatabase","Exception","System.NullReferenceException: No endpoint listening on port 6641. Ensure NCHostAgent service is running.
at Get-OvsdbDatabase, C:\Program Files\WindowsPowerShell\Modules\SdnDiagnostics\4.2403.978.222023\modules\SdnDiag.Server\SdnDiag.Server.psm1: line 92
at Get-OvsdbAddressMapping, C:\Program Files\WindowsPowerShell\Modules\SdnDiagnostics\4.2403.978.222023\modules\SdnDiag.Server\SdnDiag.Server.psm1: line 26
at Get-SdnOvsdbAddressMapping, C:\Program Files\WindowsPowerShell\Modules\SdnDiagnostics\4.2403.978.222023\modules\SdnDiag.Server\SdnDiag.Server.psm1: line 1402"
```
- Updated catch blocks to perform Write-Error so errors properly generated that can be captured by calling functions
    - Caller functions can handle them as necassary leveraging `-ErrorAction`

![image](https://github.com/microsoft/SdnDiagnostics/assets/18577812/2d1ab08b-85c3-4cb3-883c-5e23e758e5e2)

- Improved fault tolerance for `Start-SdnDataCollection`
     - If NcUrl is not populated, will skip data collection for any components that require that property
     - Prior to performing operation against node(s) that may be inaccessible, perform a `Test-NetConnection` to verify connectivity via WinRM.
- Suppress Warning stream when attempting to stop FabricHostSvc as part of certificate rotate when certs are expired.
- Fixed scenario where unhealthy NC cluster is not detected
- Fixed logging for if multiple certs are returned via `Get-SdnCertificate`
- Added additional fault tolerance if FabricHostSvc not running during cert rotate
- Improved performance for cert rotate

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.