### PR TITLE
Remove steps that clean up old certificates

### DIFF
--- a/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
@@ -172,23 +172,22 @@ function Start-SdnMuxCertificateRotation {
                 "Successfully updated the certificate information for {0}" -f $obj.ResourceRef | Trace-Output
             }
 
-            # after we have generated the certificates and updated the virtualServers to use the new certificate
-            # we will want to go and remove any old certificates as this will cause issues in older builds
-            "Removing the old certificates on {0} that match {1}" -f $obj.managementAddress, $obj.Certificate.Subject | Trace-Output
-            $certsRemoved = Invoke-PSRemoteCommand -ComputerName $obj.managementAddress -Credential $Credential -ScriptBlock {
+            # after we have generated the certificates and updated the servers to use the new certificate
+            # we will want to go and locate certificates that may conflict with the new certificate
+            "Checking certificates on {0} that match {1}" -f $obj.managementAddress, $obj.Certificate.Subject | Trace-Output
+            $certsToExamine = Invoke-PSRemoteCommand -ComputerName $obj.managementAddress -Credential $Credential -ScriptBlock {
                 param([Parameter(Mandatory = $true)]$param1)
                 $certs = Get-SdnCertificate -Path 'Cert:\LocalMachine\My' -Subject $param1.Subject
                 if ($certs.Count -ge 2) {
                     $certToRemove = $certs | Where-Object {$_.Thumbprint -ine $param1.Thumbprint}
-                    $certToRemove | Remove-Item
 
                     return $certToRemove
                 }
             } -ArgumentList $obj.Certificate
 
-            if ($certsRemoved) {
-                foreach ($cert in $certsRemoved) {
-                    "Removed certificate subject {0} and thumbprint {1}" -f $cert.Subject, $cert.Thumbprint | Trace-Output
+            if ($certsToExamine) {
+                foreach ($cert in $certsToExamine) {
+                    "Examine certificate subject {0} and thumbprint {1} on {2} and remove if no longer needed" -f $cert.Subject, $cert.Thumbprint, $obj.managementAddress | Trace-Output -Level:Warning
                 }
             }
 

--- a/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
+++ b/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
@@ -172,22 +172,21 @@ function Start-SdnServerCertificateRotation {
             }
 
             # after we have generated the certificates and updated the servers to use the new certificate
-            # we will want to go and remove any old certificates as this will cause issues in older builds
-            "Removing the old certificates on {0} that match {1}" -f $obj.managementAddress, $obj.Certificate.Subject | Trace-Output
-            $certsRemoved = Invoke-PSRemoteCommand -ComputerName $obj.managementAddress -Credential $Credential -ScriptBlock {
+            # we will want to go and locate certificates that may conflict with the new certificate
+            "Checking certificates on {0} that match {1}" -f $obj.managementAddress, $obj.Certificate.Subject | Trace-Output
+            $certsToExamine = Invoke-PSRemoteCommand -ComputerName $obj.managementAddress -Credential $Credential -ScriptBlock {
                 param([Parameter(Mandatory = $true)]$param1)
                 $certs = Get-SdnCertificate -Path 'Cert:\LocalMachine\My' -Subject $param1.Subject
                 if ($certs.Count -ge 2) {
                     $certToRemove = $certs | Where-Object {$_.Thumbprint -ine $param1.Thumbprint}
-                    $certToRemove | Remove-Item
 
                     return $certToRemove
                 }
             } -ArgumentList $obj.Certificate
 
-            if ($certsRemoved) {
-                foreach ($cert in $certsRemoved) {
-                    "Removed certificate subject {0} and thumbprint {1}" -f $cert.Subject, $cert.Thumbprint | Trace-Output
+            if ($certsToExamine) {
+                foreach ($cert in $certsToExamine) {
+                    "Examine certificate subject {0} and thumbprint {1} on {2} and remove if no longer needed" -f $cert.Subject, $cert.Thumbprint, $obj.managementAddress | Trace-Output -Level:Warning
                 }
             }
 


### PR DESCRIPTION
# Description
Summary of changes:
- Updated `Start-SdnMuxCertificateRotation` and `Start-SdnCertificateRotation` to not cleanup certificates after rotation. This may break HCI 23H2 deployments otherwise.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.