### PR TITLE
Re-Enable remote invocation of Start-SdnCertificateRotation

### DIFF
--- a/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Start-SdnCertificateRotation.ps1
@@ -58,11 +58,6 @@ function Start-SdnCertificateRotation {
         [switch]$Force
     )
 
-    # we do not support this operation being executed from remote session
-    if ($PSSenderInfo) {
-        throw New-Object System.NotSupportedException("This operation is not supported in a remote session. Please run this operation locally on Network Controller.")
-    }
-
     # ensure that the module is running as local administrator
     $elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     if (-NOT $elevated) {
@@ -87,6 +82,11 @@ function Start-SdnCertificateRotation {
 
     try {
         "Starting certificate rotation" | Trace-Output
+
+        # purge any existing remote sessions to prevent situation where
+        # we leverage a session without credentials
+        Remove-PSRemotingSession
+
         "Retrieving current SDN environment details" | Trace-Output
 
         if ([String]::IsNullOrEmpty($CertPath)) {


### PR DESCRIPTION
# Description
Summary of changes:
- Re-enable support to run Start-SdnCertificateRotation via remote session
- Clean up any prior PSSessions when starting certificate rotation
    - If existing sessions already exist, they may not be using credentials which may result in certificate rotate function failing

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.