### PR TITLE
Fix missing credentials parameter

### DIFF
--- a/src/modules/SdnDiag.Health/private/Test-NetworkControllerCertCredential.ps1
+++ b/src/modules/SdnDiag.Health/private/Test-NetworkControllerCertCredential.ps1
@@ -31,7 +31,7 @@ function Test-NetworkControllerCertCredential {
         $serverCredentialRefs = [System.Collections.Hashtable]::new()
         foreach ($server in $servers) {
             # find the first connection with credential type of X509Certificate
-            $serverConnection = $server.properties.connections | Where-Object { $_.credentialType -eq "X509Certificate" } | Select-Object -First 1;
+            $serverConnection = $server.properties.connections | Where-Object {$_.credentialType -ieq "X509Certificate" -or $_.credentialType -ieq "X509CertificateSubjectName"} | Select-Object -First 1;
             if ($null -ne $serverConnection) {
                 $credRef = $serverConnection.credential[0].resourceRef
                 "Adding credential {0} for server {1} for validation" -f $credRef, $serverConnection.managementAddresses[0] | Trace-Output -Level:Verbose

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
@@ -124,7 +124,7 @@ function Start-SdnMuxCertificateRotation {
             # and invoke remote operation to the mux to generate the self-signed certificate that matches the managementAddress for x509 credentials
             foreach ($muxResource in $loadBalancerMuxes) {
                 $virtualServer = Get-SdnResource -NcUri $sdnFabricDetails.NcUrl -ResourceRef $muxResource.properties.virtualServer.resourceRef
-                $virtualServerConnection = $virtualServer.properties.connections | Where-Object {$_.credentialType -ieq "X509Certificate"}
+                $virtualServerConnection = $virtualServer.properties.connections | Where-Object { $_.credentialType -ieq "X509Certificate" -or $_.credentialType -ieq "X509CertificateSubjectName" }
                 $managementAddress = $virtualServerConnection.managementAddresses[0]
 
                 $muxCert = Invoke-PSRemoteCommand -ComputerName $managementAddress -Credential $Credential -ScriptBlock {

--- a/src/modules/SdnDiag.NetworkController/private/Update-NetworkControllerCredentialResource.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Update-NetworkControllerCredentialResource.ps1
@@ -32,7 +32,7 @@ function Update-NetworkControllerCredentialResource {
     $servers = Get-SdnServer -NcUri $NcUri -Credential $Credential
     foreach ($object in $servers) {
         "Processing X509 connections for {0}" -f $object.resourceRef | Trace-Output
-        foreach ($connection in $servers.properties.connections | Where-Object {$_.credentialType -ieq 'X509Certificate'}) {
+        foreach ($connection in $servers.properties.connections | Where-Object { $_.credentialType -ieq "X509Certificate" -or $_.credentialType -ieq "X509CertificateSubjectName" }) {
             $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
 
             $cred = Get-SdnResource -NcUri $NcUri -ResourceRef $connection.credential.resourceRef -Credential $Credential

--- a/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
+++ b/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
@@ -107,7 +107,7 @@ function Start-SdnServerCertificateRotation {
         $sdnFabricDetails = Get-SdnInfrastructureInfo -NetworkController $NetworkController -Credential $Credential -NcRestCredential $NcRestCredential -ErrorAction Stop
         $servers = Get-SdnServer -NcUri $sdnFabricDetails.NcUrl -Credential $NcRestCredential -ErrorAction Stop
 
-        # before we proceed with anything else, we want to make sure that all the Network Controllers and MUXes within the SDN fabric are running the current version
+        # before we proceed with anything else, we want to make sure that all the Network Controllers and Servers within the SDN fabric are running the current version
         Install-SdnDiagnostics -ComputerName $sdnFabricDetails.NetworkController -Credential $Credential -ErrorAction Stop
         Install-SdnDiagnostics -ComputerName $sdnFabricDetails.Server -Credential $Credential -ErrorAction Stop
 

--- a/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
+++ b/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
@@ -123,7 +123,7 @@ function Start-SdnServerCertificateRotation {
             # retrieve the corresponding managementAddress from each of the server resources
             # and invoke remote operation to the server to generate the self-signed certificate
             foreach ($server in $servers) {
-                $serverConnection = $server.properties.connections | Where-Object {$_.credentialType -ieq "X509Certificate"}
+                $serverConnection = $server.properties.connections | Where-Object { $_.credentialType -ieq "X509Certificate" -or $_.credentialType -ieq "X509CertificateSubjectName" }
                 $managementAddress = $serverConnection.managementAddresses[0]
 
                 $serverCert = Invoke-PSRemoteCommand -ComputerName $managementAddress -Credential $Credential -ScriptBlock {

--- a/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
+++ b/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
@@ -108,8 +108,8 @@ function Start-SdnServerCertificateRotation {
         $servers = Get-SdnServer -NcUri $sdnFabricDetails.NcUrl -Credential $NcRestCredential -ErrorAction Stop
 
         # before we proceed with anything else, we want to make sure that all the Network Controllers and MUXes within the SDN fabric are running the current version
-        Install-SdnDiagnostics -ComputerName $sdnFabricDetails.NetworkController -ErrorAction Stop
-        Install-SdnDiagnostics -ComputerName $sdnFabricDetails.Server -ErrorAction Stop
+        Install-SdnDiagnostics -ComputerName $sdnFabricDetails.NetworkController -Credential $Credential -ErrorAction Stop
+        Install-SdnDiagnostics -ComputerName $sdnFabricDetails.Server -Credential $Credential -ErrorAction Stop
 
         #####################################
         #


### PR DESCRIPTION
# Description
Summary of changes:
- Fixed scenario where -Credentials are not being passed to method to install sdndiagnostics as part of server certificate rotate
- Added support for Servers and Muxes that are using the credentialtype `X509CertificateSubjectName`

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.