### PR TITLE
Fix parsing of expired certificates

### DIFF
--- a/src/modules/SdnDiag.Common/public/Get-SdnCertificate.ps1
+++ b/src/modules/SdnDiag.Common/public/Get-SdnCertificate.ps1
@@ -52,8 +52,10 @@ function Get-SdnCertificate {
             return $null
         }
 
-        if ($filteredCert.NotAfter -le (Get-Date)) {
-            "Certificate [Thumbprint: {0} | Subject: {1}] is currently expired" -f $filteredCert.Thumbprint, $filteredCert.Subject | Trace-Output -Level:Error
+        $filteredCert | ForEach-Object {
+            if ($_.NotAfter -le (Get-Date)) {
+                "Certificate [Thumbprint: {0} | Subject: {1}] is currently expired" -f $_.Thumbprint, $_.Subject | Trace-Output -Level:Warning
+            }
         }
 
         return $filteredCert


### PR DESCRIPTION
# Description
Summary of changes:
- Fixed an issue where `Get-SdnCertificate` does not handle if multiple certs returned when checking if expired.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.