### PR TITLE
Fix issue where proper class is not used when parsing vfp rules

### DIFF
--- a/src/modules/SdnDiag.Server/SdnDiag.Server.Helper.psm1
+++ b/src/modules/SdnDiag.Server/SdnDiag.Server.Helper.psm1
@@ -133,16 +133,13 @@ class VfpEncapRule : VfpRule {
     [string]$EncapType
     [string[]]$EncapDestination
     [string]$EncapSourceIP
+    [string]$Transposition
+    [string[]]$Modify
     [string[]]$RuleData
     [int]$GREKey
 }
 
 class VfpFirewallRule : VfpRule {}
-
-class VfpVnetRule : VfpRule {
-    [string]$Transposition
-    [string[]]$Modify
-}
 
 class VfpPortState {
     [boolean]$Enabled

--- a/src/modules/SdnDiag.Server/private/Get-VfpPortRule.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-VfpPortRule.ps1
@@ -158,27 +158,51 @@ function Get-VfpPortRule {
 
                         # create the custom object based on the layer
                         # so that we can add appropriate properties
-                        switch -Wildcard ($Layer) {
-                            "*_METER_*" {
-                                $object = [VfpMeterRule]@{
-                                    Rule = $value
-                                }
-                            }
-
-                            "FW_*" {
+                        switch ($Layer) {
+                            "FW_ADMIN_LAYER_ID" {
                                 $object = [VfpFirewallRule]@{
                                     Rule = $value
                                 }
                             }
 
-                            "*_ENCAP_*" {
+                            "FW_CONTROLLER_LAYER_ID" {
+                                $object = [VfpFirewallRule]@{
+                                    Rule = $value
+                                }
+                            }
+
+                            "VNET_METER_LAYER_OUT" {
+                                $object = [VfpMeterRule]@{
+                                    Rule = $value
+                                }
+                            }
+
+                            "VNET_MAC_REWRITE_LAYER" {
                                 $object = [VfpEncapRule]@{
                                     Rule = $value
                                 }
                             }
 
-                            "VNET_*" {
-                                $object = [VfpVnetRule]@{
+                            "VNET_ENCAP_LAYER" {
+                                $object = [VfpEncapRule]@{
+                                    Rule = $value
+                                }
+                            }
+
+                            "VNET_PA_ROUTE_LAYER" {
+                                $object = [VfpEncapRule]@{
+                                    Rule = $value
+                                }
+                            }
+
+                            "SLB_NAT_LAYER" {
+                                $object = [VfpRule]@{
+                                    Rule = $value
+                                }
+                            }
+
+                            "SLB_DECAP_LAYER_STATEFUL" {
+                                $object = [VfpRule]@{
                                     Rule = $value
                                 }
                             }

--- a/src/modules/SdnDiag.Server/private/Get-VfpPortRule.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-VfpPortRule.ps1
@@ -159,6 +159,12 @@ function Get-VfpPortRule {
                         # create the custom object based on the layer
                         # so that we can add appropriate properties
                         switch ($Layer) {
+                            "GW_PA_ROUTE_LAYER" {
+                                $object = [VfpEncapRule]@{
+                                    Rule = $value
+                                }
+                            }
+
                             "FW_ADMIN_LAYER_ID" {
                                 $object = [VfpFirewallRule]@{
                                     Rule = $value

--- a/src/modules/SdnDiag.Server/private/Get-VfpPortRule.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-VfpPortRule.ps1
@@ -237,7 +237,8 @@ function Get-VfpPortRule {
                             $object.$key = $value
                         }
                         catch {
-                            "Unable to add {0} to object. Failing back to use NoteProperty." -f $key | Trace-Output -Level:Warning
+                            # this is the fallback method to just add a property to the object
+                            # outside of the defined class properties
                             $object | Add-Member -MemberType NoteProperty -Name $key -Value $value
                             continue
                         }

--- a/src/modules/SdnDiag.Server/private/Get-VfpPortRule.ps1
+++ b/src/modules/SdnDiag.Server/private/Get-VfpPortRule.ps1
@@ -44,8 +44,9 @@ function Get-VfpPortRule {
         # in situations where the value might be nested in another line we need to do some additional data processing
         # subkey is declared below if the value is null after the split
         if ($subKey) {
+            $doneProcessingSubKey = $false
             if($null -eq $subObject){
-                $subObject = New-Object -TypeName PSObject
+                $subObject = [PSCustomObject]::new()
             }
             if ($null -eq $subArrayList) {
                 $subArrayList = [System.Collections.ArrayList]::new()
@@ -59,7 +60,8 @@ function Get-VfpPortRule {
                     if ($line.Contains('Flow TTL')) {
                         $object.Conditions = $subObject
 
-                        $subObject = [PSCustomObject]::new()
+                        $doneProcessingSubKey = $true
+                        $subObject = $null
                         $subKey = $null
                     }
 
@@ -67,7 +69,8 @@ function Get-VfpPortRule {
                     elseif ($line.Contains('<none>')) {
                         $object.Conditions = $null
 
-                        $subObject = [PSCustomObject]::new()
+                        $doneProcessingSubKey = $true
+                        $subObject = $null
                         $subKey = $null
                     }
 
@@ -127,8 +130,13 @@ function Get-VfpPortRule {
                 }
             }
 
-            # since we are processing sub values, we want to move to the next line and not do any further processing
-            continue
+            if ($doneProcessingSubKey) {
+                # we are done processing the subkey, so we can proceed to the rest of the script
+            }
+            else {
+                # we are not done processing the subkey values, so we need to continue to the next line
+                continue
+            }
         }
 
         # lines in the VFP output that contain : contain properties and values


### PR DESCRIPTION
# Description
Summary of changes:
- Statically define the class type to use based on the layer provided
- Fix parsing logic issue where TTL was not being processed

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.