### PR TITLE
Add ErrorActionPreference for NetAdapter cmdlets

### DIFF
--- a/src/modules/SdnDiag.Common/private/Get-CommonConfigState.ps1
+++ b/src/modules/SdnDiag.Common/private/Get-CommonConfigState.ps1
@@ -57,11 +57,11 @@ function Get-CommonConfigState {
                 $prefix = $_.Name.ToString().Replace(' ','_').Trim()
                 $_ | Get-NetAdapterAdvancedProperty | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterAdvancedProperty' -FileType json
                 $_ | Get-NetAdapterBinding | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterBinding' -FileType json
-                $_ | Get-NetAdapterChecksumOffload | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterChecksumOffload' -FileType json
+                $_ | Get-NetAdapterChecksumOffload -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterChecksumOffload' -FileType json
                 $_ | Get-NetAdapterHardwareInfo -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterHardwareInfo' -FileType json
                 $_ | Get-NetAdapterRsc -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterRsc' -FileType json
                 $_ | Get-NetAdapterSriov -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterSriov' -FileType json
-                $_ | Get-NetAdapterStatistics | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterStatistics' -FileType json
+                $_ | Get-NetAdapterStatistics -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterStatistics' -FileType json
             }
         }
 


### PR DESCRIPTION
# Description
Summary of changes:
This pull request includes changes to the `Get-CommonConfigState` function in the `Get-CommonConfigState.ps1` file. The changes mainly involve adding `-ErrorAction $ErrorActionPreference` to the `Get-NetAdapterChecksumOffload` and `Get-NetAdapterStatistics` commands. This addition allows the function to handle errors more effectively.

* [`src/modules/SdnDiag.Common/private/Get-CommonConfigState.ps1`](diffhunk://#diff-835b08b8e1c0bce0a59f0c589152e1a7e9a6e24bfb443ad00669c63f3924d881L60-R64): Added `-ErrorAction $ErrorActionPreference` to the `Get-NetAdapterChecksumOffload` and `Get-NetAdapterStatistics` commands in the `Get-CommonConfigState` function. This change allows the function to handle errors more effectively.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.