### PR TITLE
Fix regression of NC information from clustermanifest

### DIFF
--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnNetworkControllerInfoFromClusterManifest.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnNetworkControllerInfoFromClusterManifest.ps1
@@ -4,8 +4,6 @@ function Get-SdnNetworkControllerInfoFromClusterManifest {
         Get the Network Controller Configuration from network controller cluster manifest file. The function is used to retrieve information of the network controller when cluster down.
     .PARAMETER NetworkController
         Specifies the name the network controller node on which this cmdlet operates. The parameter is optional if running on network controller node.
-    .PARAMETER Name
-        Specifies the friendly name of the node for the network controller. If not provided, settings are retrieved for all nodes in the deployment.
     .PARAMETER Credential
         Specifies a user account that has permission to perform this action. The default is the current user.
     #>
@@ -13,10 +11,7 @@ function Get-SdnNetworkControllerInfoFromClusterManifest {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]
-        [String]$NetworkController = $(HostName),
-
-        [Parameter(Mandatory = $false)]
-        [String]$Name,
+        [String]$NetworkController = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
@@ -24,29 +19,37 @@ function Get-SdnNetworkControllerInfoFromClusterManifest {
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
-    "Attempting to retrieve NetworkControllerNode information via ClusterManifest" | Trace-Output
-    $array = @()
+    "Attempting to retrieve NetworkController information via ClusterManifest" | Trace-Output
 
-    $clusterManifest = [xml](Get-SdnServiceFabricClusterManifest -NetworkController $NetworkController -Credential $Credential)
-    $clusterManifest.ClusterManifest.Infrastructure.WindowsServer.NodeList.Node | ForEach-Object {
-        $object = [PSCustomObject]@{
-            Name = $_.NodeName
-            Server = $_.IPAddressOrFQDN
-            FaultDomain = $_.FaultDomain
-            RestInterface = $null
-            Status = $null
-            NodeCertificate = $null
-        }
+    $clusterManifestXml = [xml](Get-SdnServiceFabricClusterManifest -NetworkController $NetworkController -Credential $Credential)
+    $nodeList = $clusterManifestXml.ClusterManifest.Infrastructure.WindowsServer.NodeList.Node.NodeName
+    $secretCertThumbprint = $clusterManifestXml.ClusterManifest.Certificates.SecretsCertificate.X509FindValue
 
-	    $certificate = ($clusterManifest.ClusterManifest.NodeTypes.NodeType | Where-Object Name -ieq $_.NodeName).Certificates.ServerCertificate.X509FindValue.ToString()
-        $object | Add-Member -MemberType NoteProperty -Name NodeCertificateThumbprint -Value $certificate
-
-        $array += $object
+    $splat = @{
+        Path = 'Cert:\LocalMachine\My'
+        Thumbprint = $secretCertThumbprint
     }
 
-    if ($Name) {
-        return ($array | Where-Object { $_.Name.Split(".")[0] -ieq $Name.Split(".")[0] -or $_.Server -ieq $Name.Split(".")[0] })
+    if (Test-ComputerNameIsLocal -ComputerName $NetworkController) {
+        $serverCertificate = Get-SdnCertificate @splat
+    }
+    else {
+        $serverCertificate = Invoke-PSRemoteCommand -ComputerName $NetworkController -Credential $Credential -ScriptBlock {
+            param([Parameter(Position = 0)][String]$param1, [Parameter(Position = 1)][String]$param2)
+            Get-SdnCertificate -Path $param1 -Thumbprint $param2
+        } -ArgumentList @($splat.Path, $splat.Thumbprint)
     }
 
-    return $array
+    $infraInfo = [PSCustomObject]@{
+        Node = $nodeList
+        ClientAuthentication = $null
+        ClientCertificateThumbprint = $null
+        ClientSecurityGroup = $null
+        ServerCertificate = $serverCertificate
+        RestIPAddress = $null
+        RestName = $null
+        Version = $null
+    }
+
+    return $infraInfo
 }


### PR DESCRIPTION
# Description
Summary of changes:
- Fix regression introduced in #265 where `Get-NetworkControllerNodeInfoFromClusterManifest` is returning node information rather than NetworkController information

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.