### PR TITLE
Enable support for data collection of FC clusters

### DIFF
--- a/src/SdnDiagnostics.psd1
+++ b/src/SdnDiagnostics.psd1
@@ -82,12 +82,8 @@
         'Get-SdnNetAdapterRdmaConfig',
         'Get-SdnNetworkInterfaceOutboundPublicIPAddress',
         'Get-SdnNetworkController',
-        'Get-SdnNetworkControllerFC',
-        'Get-SdnNetworkControllerSF',
         'Get-SdnNetworkControllerClusterInfo',
         'Get-SdnNetworkControllerNode',
-        'Get-SdnNetworkControllerFCNode',
-        'Get-SdnNetworkControllerSFNode',
         'Get-SdnNetworkControllerNodeCertificate'
         'Get-SdnNetworkControllerRestCertificate',
         'Get-SdnNetworkControllerState',

--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -675,6 +675,7 @@ function Start-SdnDataCollection {
         else {
             $sdnFabricDetails = Get-SdnInfrastructureInfo -NetworkController $NetworkController -Credential $Credential -NcRestCredential $NcRestCredential
         }
+        $sdnFabricDetails | Export-ObjectToFile -FilePath $OutputDirectory.FullName -FileName 'Get-SdnInfrastructureInfo'
 
         # determine if network controller is using default logging mechanism to local devices or network share
         if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ieq 'ServiceFabric') {

--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -675,7 +675,7 @@ function Start-SdnDataCollection {
         else {
             $sdnFabricDetails = Get-SdnInfrastructureInfo -NetworkController $NetworkController -Credential $Credential -NcRestCredential $NcRestCredential
         }
-        $sdnFabricDetails | Export-ObjectToFile -FilePath $OutputDirectory.FullName -FileName 'Get-SdnInfrastructureInfo'
+        $sdnFabricDetails | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-SdnInfrastructureInfo'
 
         # determine if network controller is using default logging mechanism to local devices or network share
         if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ieq 'ServiceFabric') {

--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -8,11 +8,18 @@ New-Variable -Name 'SdnDiagnostics' -Scope 'Global' -Force -Value @{
     EnvironmentInfo = @{
         # defines the cluster configuration type, supported values are 'ServiceFabric', 'FailoverCluster'
         # will default to 'ServiceFabric' on module import and updated once environment details have been retrieved
-        ClusterConfigurationType = 'ServiceFabric'
+        ClusterConfigType = 'ServiceFabric'
+        FailoverClusterConfig = @{
+            Name = $null
+        }
 
-        # defines the version of rest api that network controller is using
-        # defaults to v1 on module load, and updated once environment details have been retrieved
-        RestApiVersion = 'V1'
+        RestApiVersion = 'V1' # defaults to v1 on module load, and updated once environment details have been retrieved
+        NcUrl = $null
+        Gateway = @()
+        NetworkController = @()
+        LoadBalancerMux = @()
+        Server = @()
+        FabricNodes = @()
     }
     Config = @{
         # when creating remote sessions, the module will be imported automatically
@@ -614,6 +621,26 @@ function Start-SdnDataCollection {
         Invoke-SdnGetNetView -OutputDirectory $OutputDirectory -SkipAdminCheck -SkipNetshTrace -SkipVM -SkipCounters
     }
 
+    $collectClusterLogsSB = {
+        param([Parameter(Position = 0)][String]$OutputDirectory)
+        # The 3>$null 4>$null sends warning and error to null
+        # typically Get-ClusterLog does not like remote powershell operations and generates warnings/errors
+        $clusterLogFiles = Get-ClusterLog -Destination $OutputDirectory 2>$null 3>$null
+
+        # if we have cluster log files, we will zip them up to preserve disk space
+        if ($clusterLogFiles) {
+            $clusterLogFiles | ForEach-Object {
+                $zipFilePath = Join-Path -Path $OutputDirectory -ChildPath ($_.Name + ".zip")
+                Compress-Archive -Path $_.FullName -DestinationPath $zipFilePath -Force -ErrorAction Stop
+
+                # if the file was successfully zipped, we can remove the original file
+                if (Get-Item -Path $zipFilePath -ErrorAction Ignore) {
+                    Remove-Item -Path $_.FullName -Force -ErrorAction Ignore
+                }
+            }
+        }
+    }
+
     if (Test-ComputerNameIsLocal -ComputerName $NetworkController) {
         Confirm-IsNetworkController
     }
@@ -650,13 +677,15 @@ function Start-SdnDataCollection {
         }
 
         # determine if network controller is using default logging mechanism to local devices or network share
-        [xml]$clusterManifest = Get-SdnServiceFabricClusterManifest -NetworkController $NetworkController -Credential $Credential
-        $fileShareWinFabEtw = $clusterManifest.ClusterManifest.FabricSettings.Section | Where-Object {$_.Name -ieq 'FileShareWinFabEtw'}
-        $connectionString = $fileShareWinFabEtw.Parameter | Where-Object {$_.Name -ieq 'StoreConnectionString'}
-        if ($connectionString.value) {
-            # typically the network share will be in a format of file://share/path
-            $diagLogNetShare = ($connectionString.value).Split(':')[1].Replace('/', '\').Trim()
-            $ncNodeFolders = @()
+        if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ieq 'ServiceFabric') {
+            [xml]$clusterManifest = Get-SdnServiceFabricClusterManifest -NetworkController $NetworkController -Credential $Credential
+            $fileShareWinFabEtw = $clusterManifest.ClusterManifest.FabricSettings.Section | Where-Object {$_.Name -ieq 'FileShareWinFabEtw'}
+            $connectionString = $fileShareWinFabEtw.Parameter | Where-Object {$_.Name -ieq 'StoreConnectionString'}
+            if ($connectionString.value) {
+                # typically the network share will be in a format of file://share/path
+                $diagLogNetShare = ($connectionString.value).Split(':')[1].Replace('/', '\').Trim()
+                $ncNodeFolders = @()
+            }
         }
 
         switch ($PSCmdlet.ParameterSetName) {
@@ -817,24 +846,40 @@ function Start-SdnDataCollection {
 
                     # collect the logs related to the network controller
                     if ($group.Name -ieq 'NetworkController') {
-                        # check to see if we are using SF cluster and if so, collect the SF logs
-                        if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigurationType -ieq 'ServiceFabric') {
-                            $ncConfig = Get-SdnModuleConfiguration -Role 'NetworkController_SF'
-                            [string[]]$sfLogDir = $ncConfig.Properties.CommonPaths.serviceFabricLogDirectory
+                        # switched based on the cluster configuration type to define the logs we need to collect
+                        switch ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType) {
+                            'ServiceFabric' {
+                                $ncConfig = Get-SdnModuleConfiguration -Role 'NetworkController_SF'
+                                [string[]]$sfLogDir = $ncConfig.Properties.CommonPaths.serviceFabricLogDirectory
 
-                            "Collect service fabric logs for {0} nodes: {1}" -f $group.Name, ($dataNodes -join ', ') | Trace-Output
-                            $outputDir = Join-Path -Path $tempDirectory.FullName -ChildPath 'ServiceFabricLogs'
-                            $splat = @{
-                                ComputerName = $dataNodes
-                                Credential   = $Credential
-                                ScriptBlock  = $collectLogSB
-                                ArgumentList = @($sfLogDir, $outputDir, $FromDate, $ToDate)
-                                AsJob        = $true
-                                PassThru     = $true
-                                Activity     = 'Get Service Fabric Logs'
+                                "Collect service fabric logs for {0} nodes: {1}" -f $group.Name, ($dataNodes -join ', ') | Trace-Output
+                                $outputDir = Join-Path -Path $tempDirectory.FullName -ChildPath 'ServiceFabricLogs'
+                                $splat = @{
+                                    ComputerName = $dataNodes
+                                    Credential   = $Credential
+                                    ScriptBlock  = $collectLogSB
+                                    ArgumentList = @($sfLogDir, $outputDir, $FromDate, $ToDate)
+                                    AsJob        = $true
+                                    PassThru     = $true
+                                    Activity     = 'Get Service Fabric Logs'
+                                }
                             }
-                            Invoke-PSRemoteCommand @splat
+                            'FailoverCluster' {
+                                "Collect cluster logs for {0} nodes: {1}" -f $group.Name, ($dataNodes -join ', ') | Trace-Output
+                                $outputDir = Join-Path -Path $tempDirectory.FullName -ChildPath 'ClusterLogs'
+                                $splat = @{
+                                    ComputerName = $dataNodes
+                                    Credential   = $Credential
+                                    ScriptBlock  = $collectClusterLogsSB
+                                    ArgumentList = @($outputDir)
+                                    AsJob        = $true
+                                    PassThru     = $true
+                                    Activity     = 'Get Cluster Logs'
+                                }
+                            }
                         }
+
+                        Invoke-PSRemoteCommand @splat
                     }
 
                     # if the role is a server, collect the audit logs if they are available

--- a/src/modules/SdnDiag.Common/private/Get-CommonConfigState.ps1
+++ b/src/modules/SdnDiag.Common/private/Get-CommonConfigState.ps1
@@ -55,7 +55,7 @@ function Get-CommonConfigState {
             $netAdapter | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-NetAdapter' -FileType json
             $netAdapter | ForEach-Object {
                 $prefix = $_.Name.ToString().Replace(' ','_').Trim()
-                $_ | Get-NetAdapterAdvancedProperty | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterAdvancedProperty' -FileType json
+                $_ | Get-NetAdapterAdvancedProperty -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterAdvancedProperty' -FileType json
                 $_ | Get-NetAdapterBinding | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterBinding' -FileType json
                 $_ | Get-NetAdapterChecksumOffload -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterChecksumOffload' -FileType json
                 $_ | Get-NetAdapterHardwareInfo -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterHardwareInfo' -FileType json

--- a/src/modules/SdnDiag.NetworkController.FC/SdnDiag.NetworkController.FC.Config.psd1
+++ b/src/modules/SdnDiag.NetworkController.FC/SdnDiag.NetworkController.FC.Config.psd1
@@ -12,9 +12,8 @@
     Properties = @{
         CommonPaths = @{}
         EventLogProviders = @(
-            'Microsoft-Windows-FailoverClustering/Diagnostic',
-            'Microsoft-Windows-FailoverClustering/Operational',
-            'Microsoft-Windows-FailoverClustering-Manager/Admin',
+            'Microsoft-Windows-FailoverClustering*',
+            'Microsoft-Windows-FailoverClustering-Manager*',
             'NetworkControllerFc'
         )
         RegKeyPaths = @(

--- a/src/modules/SdnDiag.NetworkController.FC/private/Get-SdnClusterName.ps1
+++ b/src/modules/SdnDiag.NetworkController.FC/private/Get-SdnClusterName.ps1
@@ -1,0 +1,27 @@
+function Get-SdnClusterName {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [System.String]$NetworkController,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    if (Test-ComputerNameIsLocal -ComputerName $NetworkController) {
+        $clusterName = Get-Cluster | Select-Object -ExpandProperty Name
+    }
+    else {
+        if ($null -ieq $Credential -or $Credential -eq [System.Management.Automation.PSCredential]::Empty) {
+            $clusterName = Invoke-PSRemoteCommand -ComputerName $NetworkController -ScriptBlock { Get-Cluster } | Select-Object -ExpandProperty Name
+        }
+        else {
+            $clusterName = Invoke-PSRemoteCommand -ComputerName $NetworkController -ScriptBlock { Get-Cluster } -Credential $Credential | Select-Object -ExpandProperty Name
+        }
+    }
+
+    "Cluster Name: $clusterName" | Trace-Output -Level:Verbose
+    return $clusterName
+}

--- a/src/modules/SdnDiag.NetworkController.FC/public/Get-SdnNetworkControllerFCClusterInfo.ps1
+++ b/src/modules/SdnDiag.NetworkController.FC/public/Get-SdnNetworkControllerFCClusterInfo.ps1
@@ -5,7 +5,7 @@ function Get-SdnNetworkControllerFCClusterInfo {
     .PARAMETER NetworkController
         Specifies the name of the network controller node on which this cmdlet operates.
     .PARAMETER Credential
-		Specifies a user account that has permission to perform this action. The default is the current user.
+        Specifies a user account that has permission to perform this action. The default is the current user.
     .PARAMETER OutputDirectory
         Directory location to save results. It will create a new sub-folder called NetworkControllerClusterInfo_FC that the files will be saved to
     .EXAMPLE
@@ -43,15 +43,15 @@ function Get-SdnNetworkControllerFCClusterInfo {
             $clusterName = Get-SdnClusterName -NetworkController $NetworkController -Credential $Credential -ErrorAction Stop
         }
 
-        Get-Cluster -Name $clusterName | Export-ObjectToFile -FilePath $outputDir -FileType json
-        Get-ClusterFaultDomain -CimSession $clusterName | Export-ObjectToFile -FilePath $outputDir -FileType json
-        Get-ClusterNode -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -FileType json
-        Get-ClusterGroup -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -FileType json
-        Get-ClusterNetwork -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -FileType json
-        Get-ClusterNetworkInterface -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -FileType json
-        Get-ClusterResource -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -FileType json
-        Get-ClusterResourceType -Cluster $clusterName | Export-ObjectToFile -FilePath $outDir -FileType txt -Format Table
-        Get-ClusterSharedVolume -Cluster $clusterName | Export-ObjectToFile -FilePath$outputDir -FileType json
+        Get-Cluster -Name $clusterName | Export-ObjectToFile -FilePath $outputDir -Name 'Get-Cluster' -FileType json
+        Get-ClusterFaultDomain -CimSession $clusterName | Export-ObjectToFile -FilePath $outputDir -Name 'Get-ClusterFaultDomain' -FileType json
+        Get-ClusterNode -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -Name 'Get-ClusterNode' -FileType json
+        Get-ClusterGroup -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -Name 'Get-ClusterGroup' -FileType json
+        Get-ClusterNetwork -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -Name 'Get-ClusterNetwork' -FileType json
+        Get-ClusterNetworkInterface -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -Name 'Get-ClusterNetworkInterface' -FileType json
+        Get-ClusterResource -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -Name 'Get-ClusterResource' -FileType json
+        Get-ClusterResourceType -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -Name 'Get-ClusterResourceType' -FileType txt -Format Table
+        Get-ClusterSharedVolume -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -Name 'Get-ClusterSharedVolume' -FileType json
     }
     catch {
         $_ | Trace-Exception

--- a/src/modules/SdnDiag.NetworkController.FC/public/Get-SdnNetworkControllerFCClusterInfo.ps1
+++ b/src/modules/SdnDiag.NetworkController.FC/public/Get-SdnNetworkControllerFCClusterInfo.ps1
@@ -1,0 +1,63 @@
+function Get-SdnNetworkControllerFCClusterInfo {
+    <#
+    .SYNOPSIS
+        Gather the Network Controller cluster wide info from one of the Network Controller
+    .PARAMETER NetworkController
+        Specifies the name of the network controller node on which this cmdlet operates.
+    .PARAMETER Credential
+		Specifies a user account that has permission to perform this action. The default is the current user.
+    .PARAMETER OutputDirectory
+        Directory location to save results. It will create a new sub-folder called NetworkControllerClusterInfo_FC that the files will be saved to
+    .EXAMPLE
+        PS> Get-SdnNetworkControllerFCClusterInfo
+    .EXAMPLE
+        PS> Get-SdnNetworkControllerFCClusterInfo -NetworkController 'NC01' -Credential (Get-Credential)
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [System.String]$NetworkController,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $true)]
+        [System.IO.FileInfo]$OutputDirectory
+    )
+
+    $currentErrorActionPreference = $ErrorActionPreference
+    $ProgressPreference = 'SilentlyContinue'
+    $ErrorActionPreference = 'Ignore'
+
+    try {
+        $outputDir = Join-Path -Path $OutputDirectory.FullName -ChildPath 'NetworkControllerClusterInfo_FC'
+        if (!(Test-Path -Path $outputDir -PathType Container)) {
+            $null = New-Item -Path $outputDir -ItemType Directory -Force
+        }
+
+        $clusterName = $Global:SdnDiagnostics.EnvironmentInfo.FailoverClusterConfig.Name
+        if ($null -ieq $clusterName) {
+            $clusterName = Get-SdnClusterName -NetworkController $NetworkController -Credential $Credential -ErrorAction Stop
+        }
+
+        Get-Cluster -Name $clusterName | Export-ObjectToFile -FilePath $outputDir -FileType json
+        Get-ClusterFaultDomain -CimSession $clusterName | Export-ObjectToFile -FilePath $outputDir -FileType json
+        Get-ClusterNode -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -FileType json
+        Get-ClusterGroup -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -FileType json
+        Get-ClusterNetwork -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -FileType json
+        Get-ClusterNetworkInterface -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -FileType json
+        Get-ClusterResource -Cluster $clusterName | Export-ObjectToFile -FilePath $outputDir -FileType json
+        Get-ClusterResourceType -Cluster $clusterName | Export-ObjectToFile -FilePath $outDir -FileType txt -Format Table
+        Get-ClusterSharedVolume -Cluster $clusterName | Export-ObjectToFile -FilePath$outputDir -FileType json
+    }
+    catch {
+        $_ | Trace-Exception
+        $_ | Write-Error
+    }
+
+    $ProgressPreference = 'Continue'
+    $ErrorActionPreference = $currentErrorActionPreference
+}

--- a/src/modules/SdnDiag.NetworkController.SF/public/Get-SdnNetworkControllerSFClusterInfo.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/public/Get-SdnNetworkControllerSFClusterInfo.ps1
@@ -1,4 +1,4 @@
-function Get-SdnNetworkControllerClusterInfo {
+function Get-SdnNetworkControllerSFClusterInfo {
     <#
     .SYNOPSIS
         Gather the Network Controller cluster wide info from one of the Network Controller
@@ -7,11 +7,11 @@ function Get-SdnNetworkControllerClusterInfo {
     .PARAMETER Credential
 		Specifies a user account that has permission to perform this action. The default is the current user.
     .PARAMETER OutputDirectory
-        Directory location to save results. It will create a new sub-folder called NetworkControllerClusterInfo that the files will be saved to
+        Directory location to save results. It will create a new sub-folder called NetworkControllerClusterInfo_SF that the files will be saved to
     .EXAMPLE
-        PS> Get-SdnNetworkControllerClusterInfo
+        PS> Get-SdnNetworkControllerSFClusterInfo
     .EXAMPLE
-        PS> Get-SdnNetworkControllerClusterInfo -NetworkController 'NC01' -Credential (Get-Credential)
+        PS> Get-SdnNetworkControllerSFClusterInfo -NetworkController 'NC01' -Credential (Get-Credential)
     #>
 
     [CmdletBinding()]
@@ -29,7 +29,7 @@ function Get-SdnNetworkControllerClusterInfo {
     )
 
     try {
-        [System.IO.FileInfo]$outputDir = Join-Path -Path $OutputDirectory.FullName -ChildPath 'NetworkControllerClusterInfo'
+        [System.IO.FileInfo]$outputDir = Join-Path -Path $OutputDirectory.FullName -ChildPath 'NetworkControllerClusterInfo_SF'
 
         if (!(Test-Path -Path $outputDir.FullName -PathType Container)) {
             $null = New-Item -Path $outputDir.FullName -ItemType Directory -Force

--- a/src/modules/SdnDiag.NetworkController.SF/public/Get-SdnNetworkControllerSFNode.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/public/Get-SdnNetworkControllerSFNode.ps1
@@ -88,7 +88,8 @@ function Get-SdnNetworkControllerSFNode {
             }
         }
         catch {
-            "Get-NetworkControllerNode failed: {0}" -f $_.Exception.Message | Trace-Output -Level:Error
+            $_ | Trace-Exception
+            "Get-NetworkControllerNode failed: {0}" -f $_.Exception.Message | Trace-Output -Level:Warning
             $result = Get-NetworkControllerNodeInfoFromClusterManifest @params
         }
 

--- a/src/modules/SdnDiag.NetworkController/private/Get-NetworkControllerConfigState.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-NetworkControllerConfigState.ps1
@@ -41,7 +41,7 @@ function Get-NetworkControllerConfigState {
             Get-Item -Path "$($directory.FullName)\*" -Include *.dll,*.exe | Export-ObjectToFile -FilePath $ncAppDir -Name $fileName -FileType txt -Format List
         }
 
-        switch ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigurationType) {
+        switch ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType) {
             'ServiceFabric' {
                 Get-NetworkControllerSFConfigState @PSBoundParameters
             }

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnClusterType.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnClusterType.ps1
@@ -5,7 +5,7 @@ function Get-SdnClusterType {
     .PARAMETER NetworkController
         Specifies the name of the network controller node on which this cmdlet operates.
     .PARAMETER Credential
-		Specifies a user account that has permission to perform this action. The default is the current user.
+        Specifies a user account that has permission to perform this action. The default is the current user.
     .EXAMPLE
         PS> Get-SdnClusterType
     .EXAMPLE

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnClusterType.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnClusterType.ps1
@@ -1,0 +1,49 @@
+function Get-SdnClusterType {
+    <#
+    .SYNOPSIS
+        Determines the cluster type of the Network Controller
+    .PARAMETER NetworkController
+        Specifies the name of the network controller node on which this cmdlet operates.
+    .PARAMETER Credential
+		Specifies a user account that has permission to perform this action. The default is the current user.
+    .EXAMPLE
+        PS> Get-SdnClusterType
+    .EXAMPLE
+        PS> Get-SdnClusterType -NetworkController 'NC01' -Credential (Get-Credential)
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [System.String]$NetworkController,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    $sb = {
+        try {
+            # with failover cluster, the ApiService will run as a service within windows
+            # so we can check if the service exists to determine if it is a failover cluster configuration regardless if running
+            $service = Get-Service -Name 'ApiService' -ErrorAction Ignore
+            if ($service) {
+                return 'FailoverCluster'
+            }
+        }
+        catch {
+            return 'ServiceFabric'
+        }
+    }
+
+    if (Test-ComputerNameIsLocal -ComputerName $NetworkController) {
+        $result = Invoke-Command -ScriptBlock $sb
+    }
+    else {
+        $result = Invoke-PSRemoteCommand -ComputerName $NetworkController -ScriptBlock $sb -Credential $Credential
+    }
+
+    "Cluster Type: $result" | Trace-Output -Level:Verbose
+    return $result
+}

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnClusterType.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnClusterType.ps1
@@ -24,17 +24,14 @@ function Get-SdnClusterType {
     )
 
     $sb = {
-        try {
-            # with failover cluster, the ApiService will run as a service within windows
-            # so we can check if the service exists to determine if it is a failover cluster configuration regardless if running
-            $service = Get-Service -Name 'ApiService' -ErrorAction Ignore
-            if ($service) {
-                return 'FailoverCluster'
-            }
+        # with failover cluster, the ApiService will run as a service within windows
+        # so we can check if the service exists to determine if it is a failover cluster configuration regardless if running
+        $service = Get-Service -Name 'ApiService' -ErrorAction Ignore
+        if ($service) {
+            return 'FailoverCluster'
         }
-        catch {
-            return 'ServiceFabric'
-        }
+
+        return 'ServiceFabric'
     }
 
     if (Test-ComputerNameIsLocal -ComputerName $NetworkController) {

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnClusterType.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnClusterType.ps1
@@ -35,10 +35,10 @@ function Get-SdnClusterType {
     }
 
     if (Test-ComputerNameIsLocal -ComputerName $NetworkController) {
-        $result = Invoke-Command -ScriptBlock $sb
+        [string]$result = Invoke-Command -ScriptBlock $sb
     }
     else {
-        $result = Invoke-PSRemoteCommand -ComputerName $NetworkController -ScriptBlock $sb -Credential $Credential
+        [string]$result = Invoke-PSRemoteCommand -ComputerName $NetworkController -ScriptBlock $sb -Credential $Credential
     }
 
     "Cluster Type: $result" | Trace-Output -Level:Verbose

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnNetworkControllerRestURL.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnNetworkControllerRestURL.ps1
@@ -21,7 +21,7 @@ function Get-SdnNetworkControllerRestURL {
             return $Global:SdnDiagnostics.EnvironmentInfo.NcUrl
         }
 
-        switch ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigurationType) {
+        switch ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType) {
             'FailoverCluster' {
                 $result = Get-SdnNetworkControllerFC @PSBoundParameters -ErrorAction Stop
                 $endpoint = $result.RestCertificateSubjectName

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnInfrastructureInfo.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnInfrastructureInfo.ps1
@@ -81,7 +81,7 @@ function Get-SdnInfrastructureInfo {
         elseif ([System.String]::IsNullOrEmpty($Global:SdnDiagnostics.EnvironmentInfo.NcUrl)) {
             $result = Get-SdnNetworkControllerRestURL -NetworkController $NetworkController -Credential $Credential
 
-            if ($null -eq $result) {
+            if ([string]::IsNullOrEmpty($result)) {
                 throw New-Object System.NullReferenceException("Unable to locate REST API endpoint for Network Controller. Please specify REST API with -RestUri parameter.")
             }
 

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnInfrastructureInfo.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnInfrastructureInfo.ps1
@@ -56,9 +56,22 @@ function Get-SdnInfrastructureInfo {
             $Global:SdnDiagnostics.EnvironmentInfo.NcUrl = $null
             $global:SdnDiagnostics.EnvironmentInfo.NetworkController = $null
             $global:SdnDiagnostics.EnvironmentInfo.LoadBalancerMux = $null
-            $Global:SdnDiagnostics.EnvironmentInfo.RasGateway = $null
+            $Global:SdnDiagnostics.EnvironmentInfo.Gateway = $null
             $Global:SdnDiagnostics.EnvironmentInfo.Server = $null
             $Global:SdnDiagnostics.EnvironmentInfo.FabricNodes = $null
+        }
+
+        # get cluster type
+        $clusterType = Get-SdnClusterType -NetworkController $NetworkController -Credential $Credential
+        if ($clusterType) {
+            $Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType = $clusterType
+        }
+
+        # get the cluster name if we using a failover cluster
+        if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -eq 'FailoverCluster') {
+            if ([System.String]::IsNullOrEmpty($Global:SdnDiagnostics.EnvironmentInfo.FailoverClusterConfig.Name)) {
+                $Global:SdnDiagnostics.EnvironmentInfo.FailoverClusterConfig.Name = Get-SdnClusterName -NetworkController $NetworkController -Credential $Credential
+            }
         }
 
         # get the NC Northbound API endpoint

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkController.ps1
@@ -23,7 +23,7 @@ function Get-SdnNetworkController {
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
-    switch ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigurationType) {
+    switch ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType) {
         'FailoverCluster' {
             Get-SdnNetworkControllerFC @PSBoundParameters
         }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerClusterInfo.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerClusterInfo.ps1
@@ -1,0 +1,39 @@
+function Get-SdnNetworkControllerClusterInfo {
+    <#
+    .SYNOPSIS
+        Gather the Network Controller cluster wide info from one of the Network Controller
+    .PARAMETER NetworkController
+        Specifies the name of the network controller node on which this cmdlet operates.
+    .PARAMETER Credential
+		Specifies a user account that has permission to perform this action. The default is the current user.
+    .PARAMETER OutputDirectory
+        Directory location to save results. It will create a new sub-folder called NetworkControllerClusterInfo that the files will be saved to
+    .EXAMPLE
+        PS> Get-SdnNetworkControllerClusterInfo
+    .EXAMPLE
+        PS> Get-SdnNetworkControllerClusterInfo -NetworkController 'NC01' -Credential (Get-Credential)
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [System.String]$NetworkController,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $true)]
+        [System.IO.FileInfo]$OutputDirectory
+    )
+
+    switch ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType) {
+        'FailoverCluster' {
+            Get-SdnNetworkControllerFCClusterInfo @PSBoundParameters
+        }
+        'ServiceFabric' {
+            Get-SdnNetworkControllerSFClusterInfo @PSBoundParameters
+        }
+    }
+}

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerClusterInfo.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerClusterInfo.ps1
@@ -5,7 +5,7 @@ function Get-SdnNetworkControllerClusterInfo {
     .PARAMETER NetworkController
         Specifies the name of the network controller node on which this cmdlet operates.
     .PARAMETER Credential
-		Specifies a user account that has permission to perform this action. The default is the current user.
+        Specifies a user account that has permission to perform this action. The default is the current user.
     .PARAMETER OutputDirectory
         Directory location to save results. It will create a new sub-folder called NetworkControllerClusterInfo that the files will be saved to
     .EXAMPLE

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNode.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNode.ps1
@@ -31,7 +31,7 @@ function Get-SdnNetworkControllerNode {
         [switch]$ServerNameOnly
     )
 
-    switch ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigurationType) {
+    switch ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType) {
         'FailoverCluster' {
             Get-SdnNetworkControllerFCNode @PSBoundParameters
         }


### PR DESCRIPTION
This pull request introduces several changes to the `SdnDiagnostics` module, primarily to support both Service Fabric and Failover Cluster configurations. The changes simplify the codebase, improve the handling of cluster types, and modify several functions to accommodate the new cluster configurations. 

Here are the most important changes:

Cluster Configuration Support:

* [`src/SdnDiagnostics.psm1`](diffhunk://#diff-490865628c61b2e97c50f45b37d7086647c70b2444cbfb9c60cc8c682801356eL11-R22): Renamed `ClusterConfigurationType` to `ClusterConfigType`, added `FailoverClusterConfig` to the `EnvironmentInfo` global variable, and added several new properties. This change supports both Service Fabric and Failover Cluster configurations.
* [`src/modules/SdnDiag.NetworkController/private/Get-SdnClusterType.ps1`](diffhunk://#diff-2451a381f2b776c4a302eb668f17924aa1ad82307495e04b55ed8e69bea430f8R1-R49): Added a new function `Get-SdnClusterType` to determine the cluster type of the Network Controller. This function checks if the ApiService is running as a service within windows, which indicates a Failover Cluster configuration.
* `src/modules/SdnDiag.NetworkController/private/Get-SdnNetworkControllerRestURL.ps1` and `src/modules/SdnDiag.NetworkController/public/Get-SdnInfrastructureInfo.ps1`: Updated to use `ClusterConfigType` instead of `ClusterConfigurationType`. This change allows these functions to support both Service Fabric and Failover Cluster configurations. [[1]](diffhunk://#diff-fb9eed00d11c628f309c47078a9ef9d96fb8513fd06925ccd1b9313df00910eaL24-R24) [[2]](diffhunk://#diff-5eb3ff3eb27aac8cf3bba7ddb23507bfa1d65b2ff6ae6ab2a176f4d871ba84e6L59-R76)

Function Modifications:

* [`src/SdnDiagnostics.psm1`](diffhunk://#diff-490865628c61b2e97c50f45b37d7086647c70b2444cbfb9c60cc8c682801356eR624-R643): Added a script block `$collectClusterLogsSB` in the `Start-SdnDataCollection` function to collect cluster logs and compress them into a zip file. This change will help to preserve disk space.
* [`src/modules/SdnDiag.Common/private/Get-CommonConfigState.ps1`](diffhunk://#diff-835b08b8e1c0bce0a59f0c589152e1a7e9a6e24bfb443ad00669c63f3924d881L58-R58): Modified the `Get-CommonConfigState` function to include `-ErrorAction $ErrorActionPreference` in the `Get-NetAdapterAdvancedProperty` cmdlet. This change improves error handling.
* [`src/modules/SdnDiag.NetworkController.FC/private/Get-SdnClusterName.ps1`](diffhunk://#diff-5c8dc2849956c598e30fbe1008e22689493be806df2cf5f403958cdb2e86d99cR1-R27): Added a new function `Get-SdnClusterName` to retrieve the name of the cluster. This function is used when the cluster configuration is a Failover Cluster.

File Renaming and Function Renaming:

* [`src/modules/SdnDiag.NetworkController.SF/public/Get-SdnNetworkControllerSFClusterInfo.ps1`](diffhunk://#diff-5341c9c7f5422384dd3e8c32208ecbbfba0da5d944367bc289b2ee83c0d6b14aL1-R1): Renamed from `Get-SdnNetworkControllerClusterInfo.ps1` and updated the function name to `Get-SdnNetworkControllerSFClusterInfo`. This change reflects the specific use of this function for Service Fabric configurations. [[1]](diffhunk://#diff-5341c9c7f5422384dd3e8c32208ecbbfba0da5d944367bc289b2ee83c0d6b14aL1-R1) [[2]](diffhunk://#diff-5341c9c7f5422384dd3e8c32208ecbbfba0da5d944367bc289b2ee83c0d6b14aL10-R14)

Code Simplification:

* [`src/SdnDiagnostics.psd1`](diffhunk://#diff-17aaaa968cc894449c79b449c228b28d8a8990bde4000e59bcf24d8189671ee1L85-L90): Removed several `Get-SdnNetworkController` function variants that were specific to either FC or SF. This change simplifies the codebase and reflects the new handling of cluster configurations.
* [`src/modules/SdnDiag.NetworkController.FC/SdnDiag.NetworkController.FC.Config.psd1`](diffhunk://#diff-656db7b7942a5c8bebb655094f4e112758a27267910335e9c06d6575c280b295L15-R16): Simplified the `EventLogProviders` array by using wildcard characters. This change makes the code easier to maintain.