### PR TITLE
Disable certain functions from executing on SFNC clusters

### DIFF
--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -149,7 +149,11 @@ function Start-SdnCertificateRotation {
         throw New-Object System.Exception("This function requires elevated permissions. Run PowerShell as an Administrator and import the module again.")
     }
 
-    $config = Get-SdnModuleConfiguration -Role 'NetworkController'
+    if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ine 'ServiceFabric') {
+        throw New-Object System.NotSupportedException("This function is only supported on Service Fabric clusters.")
+    }
+
+    $config = Get-SdnModuleConfiguration -Role 'NetworkController_SF'
     $confirmFeatures = Confirm-RequiredFeaturesInstalled -Name $config.windowsFeature
     if (-NOT ($confirmFeatures)) {
         throw New-Object System.NotSupportedException("The current machine is not a NetworkController, run this on NetworkController.")

--- a/src/modules/SdnDiag.Common/public/Repair-SdnDiagnosticsScheduledTask.ps1
+++ b/src/modules/SdnDiag.Common/public/Repair-SdnDiagnosticsScheduledTask.ps1
@@ -7,7 +7,15 @@ function Repair-SdnDiagnosticsScheduledTask {
     [CmdletBinding()]
     param()
 
-    $taskName = "SDN Diagnostics Task"
+    switch ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType) {
+        'FailoverCluster' {
+            $taskName = "FcDiagnostics"
+        }
+        'ServiceFabric' {
+            $taskName = "SDN Diagnostics Task"
+        }
+    }
+
     try {
         $isLoggingEnabled = Get-ItemPropertyValue -Path "HKLM:\Software\Microsoft\NetworkController\Sdn\Diagnostics\Parameters" -Name 'IsLoggingEnabled'
         if (-NOT $isLoggingEnabled ) {

--- a/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
+++ b/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
@@ -44,6 +44,10 @@ function Debug-SdnFabricInfrastructure {
         $NcRestCredential = [System.Management.Automation.PSCredential]::Empty
     )
 
+    if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ine 'ServiceFabric') {
+        throw New-Object System.NotSupportedException("This function is only supported on Service Fabric clusters.")
+    }
+
     $script:SdnDiagnostics_Health.Cache = $null
     $aggregateHealthReport = @()
 

--- a/src/modules/SdnDiag.NetworkController.SF/private/Invoke-CertRotateCommand.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/private/Invoke-CertRotateCommand.ps1
@@ -27,6 +27,10 @@ function Invoke-CertRotateCommand {
         [Int]$MaxRetry = 3
     )
 
+    if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ine 'ServiceFabric') {
+        throw New-Object System.NotSupportedException("This function is only supported on Service Fabric clusters.")
+    }
+
     $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
     $retryAttempt = 0
 

--- a/src/modules/SdnDiag.NetworkController.SF/public/Get-SdnServiceFabricNode.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/public/Get-SdnServiceFabricNode.ps1
@@ -28,7 +28,6 @@ function Get-SdnServiceFabricNode {
 
         [Parameter(Mandatory = $false)]
         [System.String]$NodeName
-
     )
 
     $sfParams = @{

--- a/src/modules/SdnDiag.NetworkController.SF/public/Invoke-SdnServiceFabricCommand.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/public/Invoke-SdnServiceFabricCommand.ps1
@@ -31,6 +31,10 @@ function Invoke-SdnServiceFabricCommand {
         [Object[]]$ArgumentList = $null
     )
 
+    if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ine 'ServiceFabric') {
+        throw New-Object System.NotSupportedException("This function is only supported on Service Fabric clusters.")
+    }
+
     $params = @{
         ScriptBlock = $ScriptBlock
     }

--- a/src/modules/SdnDiag.NetworkController.SF/public/Move-SdnServiceFabricReplica.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/public/Move-SdnServiceFabricReplica.ps1
@@ -45,6 +45,10 @@ function Move-SdnServiceFabricReplica {
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
+    if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ine 'ServiceFabric') {
+        throw New-Object System.NotSupportedException("This function is only supported on Service Fabric clusters.")
+    }
+
     $sfParams = @{
         NetworkController = $NetworkController
         Credential = $Credential

--- a/src/modules/SdnDiag.NetworkController.SF/public/Set-SdnNetworkController.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/public/Set-SdnNetworkController.ps1
@@ -33,10 +33,8 @@ function Set-SdnNetworkController {
         $Credential
     )
 
-    $waitDuration = 30 # seconds
-    $params = @{}
-    if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
-        $params.Add('Credential', $Credential)
+    if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ine 'ServiceFabric') {
+        throw New-Object System.NotSupportedException("This function is only supported on Service Fabric clusters.")
     }
 
     Confirm-IsAdmin
@@ -45,6 +43,12 @@ function Set-SdnNetworkController {
         if ($Credential -eq [System.Management.Automation.PSCredential]::Empty -or $null -eq $Credential) {
             throw New-Object System.NotSupportedException("This operation is not supported in a remote session without supplying -Credential.")
         }
+    }
+
+    $waitDuration = 30 # seconds
+    $params = @{}
+    if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
+        $params.Add('Credential', $Credential)
     }
 
     try {

--- a/src/modules/SdnDiag.NetworkController.SF/public/Set-SdnServiceFabricClusterConfig.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/public/Set-SdnServiceFabricClusterConfig.ps1
@@ -35,6 +35,10 @@ function Set-SdnServiceFabricClusterConfig {
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
+    if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ine 'ServiceFabric') {
+        throw New-Object System.NotSupportedException("This function is only supported on Service Fabric clusters.")
+    }
+
     try {
         Connect-ServiceFabricCluster | Out-Null
         $client = [System.Fabric.FabricClient]::new()

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNodeCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNodeCertificate.ps1
@@ -14,6 +14,10 @@ function Get-SdnNetworkControllerNodeCertificate {
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
+    if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ine 'ServiceFabric') {
+        throw New-Object System.NotSupportedException("This function is only supported on Service Fabric clusters.")
+    }
+
     Confirm-IsNetworkController
 
     try {

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerRestCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerRestCertificate.ps1
@@ -14,6 +14,10 @@ function Get-SdnNetworkControllerRestCertificate {
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
+    if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ine 'ServiceFabric') {
+        throw New-Object System.NotSupportedException("This function is only supported on Service Fabric clusters.")
+    }
+
     Confirm-IsNetworkController
 
     try {

--- a/src/modules/SdnDiag.NetworkController/public/New-SdnNetworkControllerNodeCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/New-SdnNetworkControllerNodeCertificate.ps1
@@ -35,6 +35,10 @@ function New-SdnNetworkControllerNodeCertificate {
         throw New-Object System.NotSupportedException("The current machine is not a NetworkController, run this on NetworkController.")
     }
 
+    if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ine 'ServiceFabric') {
+        throw New-Object System.NotSupportedException("This function is only supported on Service Fabric clusters.")
+    }
+
     # ensure that the module is running as local administrator
     $elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     if (-NOT $elevated) {

--- a/src/modules/SdnDiag.NetworkController/public/New-SdnNetworkControllerRestCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/New-SdnNetworkControllerRestCertificate.ps1
@@ -30,6 +30,10 @@ function New-SdnNetworkControllerRestCertificate {
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
+    if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ine 'ServiceFabric') {
+        throw New-Object System.NotSupportedException("This function is only supported on Service Fabric clusters.")
+    }
+
     $config = Get-SdnModuleConfiguration -Role 'NetworkController'
     $confirmFeatures = Confirm-RequiredFeaturesInstalled -Name $config.windowsFeature
     if (-NOT ($confirmFeatures)) {


### PR DESCRIPTION
This pull request primarily focuses on enhancing the support for Service Fabric clusters in the SdnDiagnostics module. The changes involve adding conditional checks in various functions to ensure they are only executed on Service Fabric clusters. Additionally, some code has been refactored for better organization and readability.

The most significant changes are as follows:

**Added checks for Service Fabric cluster configuration:**

* `Start-SdnCertificateRotation` in `SdnDiagnostics.psm1`: Added a condition to check if the cluster configuration type is Service Fabric. If not, an exception is thrown. Also, the role for getting the SdnModuleConfiguration has been changed to 'NetworkController_SF'.
* `Repair-SdnDiagnosticsScheduledTask` in `Repair-SdnDiagnosticsScheduledTask.ps1`: Added a switch statement to set the task name based on the cluster configuration type.
* Several functions in `SdnDiag.NetworkController.SF` and `SdnDiag.NetworkController` modules: Added a condition to check if the cluster configuration type is Service Fabric. If not, an exception is thrown. [[1]](diffhunk://#diff-324c08d6d20cb9d37d1a5b9756303f40024eb3d5c4008d8b210c8e7295ea1151R47-R50) [[2]](diffhunk://#diff-9e1adf0cfe8d7b8cf607e163c0a96ffc5c307137717e02c2c6b241176d47b502R30-R33) [[3]](diffhunk://#diff-da56c5aff5c8d4ae1f24d32ba504c7708faf180de322fca8cd422a318f6ca088R34-R37) [[4]](diffhunk://#diff-de7dc7282f0b7233ad4ce1ccf8882c14469a3cb33837707792c5d660dd91605aR48-R51) [[5]](diffhunk://#diff-67eb6850f4f3aa92b6398560376b7e8ae52e5be6b6b9504ba882588c7843e4fbL36-R37) [[6]](diffhunk://#diff-dd2d52a041fb0b98591e81eb4c4f2a8a1807f54f1510401f498ef4e6d1451b4bR38-R41) [[7]](diffhunk://#diff-705c2c643df865da51dd5c96aab0f2b1b892dba826f9e62e51302f6f3fd90ee1R17-R20) [[8]](diffhunk://#diff-a54d2dff16ad518ff9e95173bfb4bdc38c7f5241c46c76e3f79f36359b672b31R17-R20) [[9]](diffhunk://#diff-99617b1bd78044ec20af4d249f5641df0de3a0beae707ac9f9cbf97084b25278R38-R41) [[10]](diffhunk://#diff-0b23655b2855a4a49fd3072131d78f5feec01254c422213affdc0b22b2c27eefR33-R36)

**Code refactoring:**

* `Set-SdnNetworkController` in `Set-SdnNetworkController.ps1`: The code to set the parameters for the function has been moved after the check for Service Fabric cluster configuration.
* `Get-SdnServiceFabricNode` in `Get-SdnServiceFabricNode.ps1`: Removed an unnecessary line of code.

These changes aim to improve the module's functionality and compatibility with Service Fabric clusters, ensuring that the appropriate functions are executed based on the cluster configuration type.