### PR TITLE
Change how Get-NetView is called

### DIFF
--- a/src/modules/SdnDiag.Common/public/Invoke-SdnGetNetView.ps1
+++ b/src/modules/SdnDiag.Common/public/Invoke-SdnGetNetView.ps1
@@ -62,7 +62,8 @@ function Invoke-SdnGetNetView {
             Remove-Module -Name Get-NetView -Force
         }
         # import the Get-NetView module from the external packages
-        Import-Module -Name "$PSScriptRoot\..\..\..\externalPackages\Get-NetView.psd1" -Force
+        $module = Get-Item -Path "$PSScriptRoot\..\..\externalPackages\Get-NetView.*\Get-NetView.psd1" -ErrorAction Stop
+        Import-Module -Name $module.FullName -Force
 
         # initialize the data collection environment which will ensure the path exists and has enough space
         [string]$outDir = Join-Path -Path $OutputDirectory -ChildPath "NetView"

--- a/src/modules/SdnDiag.Common/public/Invoke-SdnGetNetView.ps1
+++ b/src/modules/SdnDiag.Common/public/Invoke-SdnGetNetView.ps1
@@ -7,14 +7,19 @@ function Invoke-SdnGetNetView {
     .PARAMETER BackgroundThreads
         Maximum number of background tasks, from 0 - 16. Defaults to 5.
     .PARAMETER SkipAdminCheck
-        If present, skip the check for admin privileges before execution. Note that without admin privileges, the scope and usefulness of the collected data is limited.
+        If present, skip the check for admin privileges before execution. Note that without admin privileges, the scope and
+        usefulness of the collected data is limited.
     .PARAMETER SkipLogs
         If present, skip the EVT and WER logs gather phases.
+    .PARAMETER SkipNetsh
+        If present, skip all Netsh commands.
     .PARAMETER SkipNetshTrace
-        If present, skip the Netsh Trace data gather phases.
+        If present, skip the Netsh Trace data gather phase.
     .PARAMETER SkipCounters
-        If present, skip the Windows Performance Counters (WPM) data gather phases.
-    .PARAMETER SkipVM
+        If present, skip the Windows Performance Counters collection phase.
+    .PARAMETER SkipWindowsRegistry
+        If present, skip exporting Windows Registry keys.
+    .PARAMETER SkipVm
         If present, skip the Virtual Machine (VM) data gather phases.
     .EXAMPLE
         PS> Invoke-SdnGetNetView -OutputDirectory "C:\Temp\CSS_SDN"
@@ -26,6 +31,7 @@ function Invoke-SdnGetNetView {
         [string]$OutputDirectory,
 
         [Parameter(Mandatory = $false)]
+        [ValidateRange(0, 16)]
         [int]$BackgroundThreads = 5,
 
         [Parameter(Mandatory = $false)]
@@ -35,10 +41,16 @@ function Invoke-SdnGetNetView {
         [switch]$SkipLogs,
 
         [Parameter(Mandatory = $false)]
+        [switch]$SkipNetsh,
+
+        [Parameter(Mandatory = $false)]
         [switch]$SkipNetshTrace,
 
         [Parameter(Mandatory = $false)]
         [switch]$SkipCounters,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$SkipWindowsRegistry,
 
         [Parameter(Mandatory = $false)]
         [switch]$SkipVm
@@ -60,13 +72,7 @@ function Invoke-SdnGetNetView {
         }
 
         # execute Get-NetView with specified parameters and redirect all streams to null to prevent unnecessary noise on the screen
-        Get-NetView -OutputDirectory $outDir `
-            -BackgroundThreads $BackgroundThreads `
-            -SkipAdminCheck:$SkipAdminCheck.IsPresent `
-            -SkipLogs:$SkipLogs.IsPresent `
-            -SkipNetshTrace:$SkipNetshTrace.IsPresent `
-            -SkipCounters:$SkipCounters.IsPresent `
-            -SkipVm:$SkipVm.IsPresent *> $null
+        Get-NetView @PSBoundParameters *>$null
 
         # remove the uncompressed files and folders to free up ~ 1.5GB of space
         $compressedArchive = Get-ChildItem -Path $outDir -Filter "*.zip"

--- a/src/modules/SdnDiag.Common/public/Invoke-SdnGetNetView.ps1
+++ b/src/modules/SdnDiag.Common/public/Invoke-SdnGetNetView.ps1
@@ -66,7 +66,7 @@ function Invoke-SdnGetNetView {
         Import-Module -Name $module.FullName -Force
 
         # initialize the data collection environment which will ensure the path exists and has enough space
-        [string]$outDir = Join-Path -Path $OutputDirectory -ChildPath "NetView"
+        [string]$outDir = Join-Path -Path $OutputDirectory -ChildPath "Get-NetView"
         if (-NOT (Initialize-DataCollection -FilePath $outDir -MinimumMB 200)) {
             "Unable to initialize environment for data collection" | Trace-Output -Level:Error
             return


### PR DESCRIPTION
# Description
Summary of changes:
- Instead of copying the updated `Get-NetView.psd1` and `Get-NetView.psm1` into PowerShell directory, we instead will just import the version that ships with the module and ignore anything under default directories.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.