### PR TITLE
Define ErrorActionPreference for data collection

### DIFF
--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -587,6 +587,7 @@ function Start-SdnDataCollection {
         [bool]$ConvertETW = $true
     )
 
+    $ErrorActionPreference = 'Continue'
     $dataCollectionNodes = [System.Collections.ArrayList]::new() # need an arrayList so we can remove objects from this list
     $filteredDataCollectionNodes = @()
     $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()

--- a/src/modules/SdnDiag.Utilities/private/Wait-PSJob.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Wait-PSJob.ps1
@@ -46,6 +46,8 @@ function Wait-PSJob {
 
             # check the stopwatch and break out of loop if we hit execution timeout limit
             if ($stopWatch.Elapsed.TotalSeconds -ge $ExecutionTimeOut) {
+                $stopWatch.Stop()
+
                 Get-Job -Name $Name | Stop-Job -Confirm:$false
                 throw New-Object System.TimeoutException("Unable to complete operation within the specified timeout period")
             }


### PR DESCRIPTION
# Description
Summary of changes:
This pull request includes changes to improve error handling and resource management in the `SdnDiagnostics` module. The most important changes include setting the error action preference to "Continue" and ensuring that the stopwatch is stopped when a timeout occurs.

Improvements to error handling and resource management:

* [`src/SdnDiagnostics.psm1`](diffhunk://#diff-490865628c61b2e97c50f45b37d7086647c70b2444cbfb9c60cc8c682801356eR590): Set `$ErrorActionPreference` to 'Continue' in the `Start-SdnDataCollection` function to ensure the script continues execution even if an error occurs.
* [`src/modules/SdnDiag.Utilities/private/Wait-PSJob.ps1`](diffhunk://#diff-297871d6b2cb15f65f732365c852a117f82cb7963c0a127c1e912ca7c2eaaeadR49-R50): Added a call to `$stopWatch.Stop()` in the `Wait-PSJob` function to ensure the stopwatch is stopped when the execution timeout limit is reached.


# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.