### PR TITLE
Enable functionality for certificate based authentication

### DIFF
--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -153,11 +153,11 @@ function Start-SdnCertificateRotation {
     $ncRestParams = @{
         NcUri = $null
     }
-    if ($NcRestCertificate) {
+    if ($PSBoundParameters.ContainsKey('NcRestCertificate')) {
         $ncRestParams.Add('NcRestCertificate', $NcRestCertificate)
     }
     else {
-        $ncRestParams.Add('NcRestCertificate', $NcRestCredential)
+        $ncRestParams.Add('NcRestCredential', $NcRestCredential)
     }
 
     # ensure that the module is running as local administrator
@@ -374,7 +374,7 @@ function Start-SdnCertificateRotation {
 
         if ($restCertExpired -or !$isNetworkControllerHealthy) {
             # Use this for certificate if either rest cert expired or nc unhealthy, get-networkcontroller failed
-            Start-SdnExpiredCertificateRotation -CertRotateConfig $CertRotateConfig -Credential $Credential -NcRestCredential $NcRestCredential
+            Start-SdnExpiredCertificateRotation -CertRotateConfig $CertRotateConfig -Credential $Credential
         }
 
         #####################################
@@ -614,7 +614,7 @@ function Start-SdnDataCollection {
     $filteredDataCollectionNodes = @()
 
     $ncRestParams = @{}
-    if ($NcRestCertificate) {
+    if ($PSBoundParameters.ContainsKey('NcRestCertificate')) {
         $ncRestParams.Add('NcRestCertificate', $NcRestCertificate)
     }
     else {

--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -615,7 +615,7 @@ function Start-SdnDataCollection {
     $dataCollectionNodes = [System.Collections.ArrayList]::new() # need an arrayList so we can remove objects from this list
     $filteredDataCollectionNodes = @()
 
-    $ncRestParams = @{ NcUri = $null }
+    $ncRestParams = @{}
     if ($PSBoundParameters.ContainsKey('NcUri')) {
         $ncRestParams.Add('NcUri', $NcUri)
     }
@@ -804,7 +804,9 @@ function Start-SdnDataCollection {
         # ensure that the NcUrl is populated before we start collecting data
         # in scenarios where certificate is not trusted or expired, we will not be able to collect data
         if (-NOT ([System.String]::IsNullOrEmpty($sdnFabricDetails.NcUrl))) {
-            $ncRestParams.Add('NcUri', $sdnFabricDetails.NcUrl)
+            if (-NOT ($ncRestParams.ContainsKey('NcUri'))) {
+                $ncRestParams.Add('NcUri', $sdnFabricDetails.NcUrl)
+            }
 
             $slbStateInfo = Get-SdnSlbStateInformation @ncRestParams
             $slbStateInfo | ConvertTo-Json -Depth 100 | Out-File "$($OutputDirectory.FullName)\SlbState.Json"

--- a/src/modules/SdnDiag.Common/public/Enable-SdnVipTrace.ps1
+++ b/src/modules/SdnDiag.Common/public/Enable-SdnVipTrace.ps1
@@ -63,10 +63,10 @@ function Enable-SdnVipTrace {
 
     switch ($PSCmdlet.ParameterSetName) {
         'RestCertificate' {
-            $ncRestParams.Add('Certificate', $NcRestCertificate)
+            $ncRestParams.Add('NcRestCertificate', $NcRestCertificate)
         }
         'RestCredential' {
-            $ncRestParams.Add('Credential', $NcRestCredential)
+            $ncRestParams.Add('NcRestCredential', $NcRestCredential)
         }
     }
 

--- a/src/modules/SdnDiag.Common/public/Enable-SdnVipTrace.ps1
+++ b/src/modules/SdnDiag.Common/public/Enable-SdnVipTrace.ps1
@@ -7,7 +7,10 @@ function Enable-SdnVipTrace {
     .PARAMETER NcUri
         Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
     .PARAMETER Credential
-        Specifies a user account that has permission to perform this action. The default is the current user.
+        Specifies a user account that has permission to access the infrastructure nodes. The default is the current user.
+    .PARAMETER NcRestCertificate
+        Specifies the client certificate that is used for a secure web request to Network Controller REST API.
+        Enter a variable that contains a certificate or a command or expression that gets the certificate.
     .PARAMETER NcRestCredential
         Specifies a user account that has permission to access the northbound NC API interface. The default is the current user.
     .PARAMETER OutputDirectory
@@ -16,12 +19,12 @@ function Enable-SdnVipTrace {
         Optional. Specifies the maximum size in MB for saved trace files. If unspecified, the default is 1536.
     #>
 
-    [CmdletBinding(DefaultParameterSetName = 'Default')]
+    [CmdletBinding(DefaultParameterSetName = 'RestCredential')]
     param (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $true)]
         [System.String]$VirtualIP,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $true)]
         [ValidateScript({
             if ($_.Scheme -ne "http" -and $_.Scheme -ne "https") {
                 throw New-Object System.FormatException("Parameter is expected to be in http:// or https:// format.")
@@ -30,47 +33,64 @@ function Enable-SdnVipTrace {
         })]
         [Uri]$NcUri,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $false)]
         [System.String]$OutputDirectory = "$(Get-WorkingDirectory)\NetworkTraces",
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate')]
+        [X509Certificate]$NcRestCertificate,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestCredential')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $NcRestCredential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $false)]
         [int]$MaxTraceSize = 1536
     )
 
     $networkTraceNodes = @()
     Reset-SdnDiagTraceMapping
 
+    $ncRestParams = @{
+        NcUri = $NcUri
+        ErrorAction = 'Stop'
+    }
+
+    switch ($PSCmdlet.ParameterSetName) {
+        'RestCertificate' {
+            $ncRestParams.Add('Certificate', $NcRestCertificate)
+        }
+        'RestCredential' {
+            $ncRestParams.Add('Credential', $NcRestCredential)
+        }
+    }
+
     try {
         # lets try and locate the resources associated with the public VIP address
         # the SdnPublicIpPoolUsageSummary is useful for this scenario, as it has the logic to scan both publicIpAddresses and loadBalancers
         # to locate the VIP IP we are looking for
-        $publicIpAddressUsage = Get-SdnPublicIPPoolUsageSummary -NcUri $NcUri -NcRestCredential $NcRestCredential
+        $publicIpAddressUsage = Get-SdnPublicIPPoolUsageSummary @ncRestParams
         $publicIpResource = $publicIpAddressUsage | Where-Object {$_.IPAddress -ieq $VirtualIP}
         if ($null -ieq $publicIpResource) {
             throw "Unable to locate resources associated to $VirtualIP"
         }
 
         # get the load balancer muxes, as we will need to enable tracing on them
-        $loadBalancerMuxes = Get-SdnLoadBalancerMux -NcUri $NcUri -Credential $NcRestCredential -ManagementAddressOnly
+        $loadBalancerMuxes = Get-SdnLoadBalancerMux @ncRestParams -ManagementAddressOnly
         $networkTraceNodes += $loadBalancerMuxes
 
         # we want to query the servers within the SDN fabric so we can get a list of the vfp switch ports across the hyper-v hosts
         # as we will use this reference to locate where the resources are located within the fabric
-        $servers = Get-SdnServer -NcUri $NcUri -Credential $NcRestCredential -ManagementAddressOnly
+        $servers = Get-SdnServer @ncRestParams -ManagementAddressOnly
         $Script:SdnDiagnostics_Common.Cache['VfpSwitchPorts'] = Get-SdnVfpVmSwitchPort -ComputerName $servers -Credential $Credential
 
         # determine the network interfaces associated with the public IP address
-        $associatedResource = Get-SdnResource -NcUri $NcUri -Credential $NcRestCredential -ResourceRef $publicIpResource.AssociatedResource
+        $associatedResource = Get-SdnResource @ncRestParams -ResourceRef $publicIpResource.AssociatedResource
         switch -Wildcard ($associatedResource.resourceRef) {
             "/loadBalancers/*" {
                 "{0} is associated with load balancer {1}" -f $VirtualIP, $associatedResource.resourceRef | Trace-Output
@@ -79,7 +99,7 @@ function Enable-SdnVipTrace {
                 # or may be the frontend IP configuration object so in either situation, we should just split the resourceRef string and query to get the
                 # parent load balancer object to ensure consistency
                 $parentResource = "{0}/{1}" -f $associatedResource.resourceRef.Split('/')[1], $associatedResource.resourceRef.Split('/')[2]
-                $loadBalancer = Get-SdnResource -NcUri $NcUri -Credential $NcRestCredential -ResourceRef $parentResource
+                $loadBalancer = Get-SdnResource @ncRestParams -ResourceRef $parentResource
 
                 $ipConfigurations = $loadBalancer.properties.backendAddressPools.properties.backendIPConfigurations.resourceRef
             }
@@ -96,7 +116,7 @@ function Enable-SdnVipTrace {
         }
 
         $ipConfigurations | ForEach-Object {
-            $ipConfig = Get-SdnResource -NcUri $NcUri -Credential $NcRestCredential -ResourceRef $_ -ErrorAction Stop
+            $ipConfig = Get-SdnResource @ncRestParams -ResourceRef $_
             if ($null -ieq $ipConfig) {
                 throw "Unable to locate resource for $($_)"
             }
@@ -106,7 +126,7 @@ function Enable-SdnVipTrace {
             # we need the mac address of the network interface to locate the vfp switch port
             # since the ipConfiguration is a subobject of the network interface, we need to split the resourceRef to get the network interface resource
             # since we know the resourceRefs are defined as /networkInterfaces/{guid}/ipConfigurations/{guid}, we can split on the '/' and get the 3rd element
-            $netInterface = Get-SdnResource -NcUri $NcUri -Credential $NcRestCredential -ResourceRef "/networkInterfaces/$($_.Split('/')[2])"
+            $netInterface = Get-SdnResource @ncRestParams -ResourceRef "/networkInterfaces/$($_.Split('/')[2])"
             $macAddress = Format-MacAddress -MacAddress $netInterface.properties.privateMacAddress -Dashes
             $vfpPort = $Script:SdnDiagnostics_Common.Cache['VfpSwitchPorts'] | Where-Object {$_.MacAddress -ieq $macAddress}
             if ($null -ieq $vfpPort) {

--- a/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
+++ b/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
@@ -62,11 +62,13 @@ function Debug-SdnFabricInfrastructure {
     }
 
     if ($PSBoundParameters.ContainsKey('NcRestCertificate')) {
-        $environmentInfo = Get-SdnInfrastructureInfo -NetworkController $NetworkController -Credential $Credential -NcRestCertificate $NcRestCertificate
+        $restCredParam = @{ NcRestCertificate = $NcRestCertificate }
     }
     else {
-        $environmentInfo = Get-SdnInfrastructureInfo -NetworkController $NetworkController -Credential $Credential -NcRestCredential $NcRestCredential
+        $restCredParam = @{ NcRestCredential = $NcRestCredential }
     }
+
+    $environmentInfo = Get-SdnInfrastructureInfo -NetworkController $NetworkController -Credential $Credential @restCredParam
     if($null -eq $environmentInfo){
         throw New-Object System.NullReferenceException("Unable to retrieve environment details")
     }
@@ -118,6 +120,7 @@ function Debug-SdnFabricInfrastructure {
             $restApiParams = @{
                 SdnEnvironmentObject    = $sdnFabricDetails
             }
+            $restApiParams += $restCredParam
 
             $computerCredParams = @{
                 SdnEnvironmentObject    = $sdnFabricDetails
@@ -128,15 +131,7 @@ function Debug-SdnFabricInfrastructure {
                 SdnEnvironmentObject    = $sdnFabricDetails
                 Credential              = $Credential
             }
-
-            if ($PSBoundParameters.ContainsKey('NcRestCertificate')) {
-                $restApiParams.Add('NcRestCertificate', $NcRestCertificate)
-                $computerCredAndRestApiParams.Add('NcRestCertificate', $NcRestCertificate)
-            }
-            else {
-                $restApiParams.Add('NcRestCredential', $NcRestCredential)
-                $computerCredAndRestApiParams.Add('NcRestCredential', $NcRestCredential)
-            }
+            $computerCredAndRestApiParams += $restCredParam
 
             # before proceeding with tests, ensure that the computer objects we are testing against are running the latest version of SdnDiagnostics
             Install-SdnDiagnostics -ComputerName $sdnFabricDetails.ComputerName -Credential $Credential

--- a/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
+++ b/src/modules/SdnDiag.Health/public/Debug-SdnFabricInfrastructure.ps1
@@ -10,8 +10,11 @@ function Debug-SdnFabricInfrastructure {
         The specific SDN role(s) to perform tests and validations for. If ommitted, defaults to all roles.
 	.PARAMETER Credential
 		Specifies a user account that has permission to perform this action. The default is the current user.
-	.PARAMETER NcRestCredential
-		Specifies a user account that has permission to access the northbound NC API interface. The default is the current user.
+    .PARAMETER NcRestCertificate
+        Specifies the client certificate that is used for a secure web request to Network Controller REST API.
+        Enter a variable that contains a certificate or a command or expression that gets the certificate.
+    .PARAMETER NcRestCredential
+        Specifies a user account that has permission to perform this action against the Network Controller REST API. The default is the current user.
     .EXAMPLE
         PS> Debug-SdnFabricInfrastructure
     .EXAMPLE
@@ -41,7 +44,11 @@ function Debug-SdnFabricInfrastructure {
         [Parameter(Mandatory = $false, ParameterSetName = 'ComputerName')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $NcRestCredential = [System.Management.Automation.PSCredential]::Empty
+        $NcRestCredential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Role')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ComputerName')]
+        [X509Certificate]$NcRestCertificate
     )
 
     if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ine 'ServiceFabric') {
@@ -105,7 +112,6 @@ function Debug-SdnFabricInfrastructure {
 
             $restApiParams = @{
                 SdnEnvironmentObject    = $sdnFabricDetails
-                NcRestCredential        = $NcRestCredential
             }
 
             $computerCredParams = @{
@@ -115,8 +121,16 @@ function Debug-SdnFabricInfrastructure {
 
             $computerCredAndRestApiParams = @{
                 SdnEnvironmentObject    = $sdnFabricDetails
-                NcRestCredential        = $NcRestCredential
                 Credential              = $Credential
+            }
+
+            if ($PSBoundParameters.ContainsKey('NcRestCertificate')) {
+                $restApiParams.Add('NcRestCertificate', $NcRestCertificate)
+                $computerCredAndRestApiParams.Add('NcRestCertificate', $NcRestCertificate)
+            }
+            else {
+                $restApiParams.Add('NcRestCredential', $NcRestCredential)
+                $computerCredAndRestApiParams.Add('NcRestCredential', $NcRestCredential)
             }
 
             # before proceeding with tests, ensure that the computer objects we are testing against are running the latest version of SdnDiagnostics

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
@@ -114,11 +114,13 @@ function Start-SdnMuxCertificateRotation {
     }
 
     if ($PSBoundParameters.ContainsKey('NcRestCertificate')) {
+        $restCredParam = @{ NcRestCertificate = $NcRestCertificate }
         $confirmStateParams.Add('Certificate', $NcRestCertificate)
         $ncRestParams.Add('NcRestCertificate', $NcRestCertificate)
         $putRestParams.Add('Certificate', $NcRestCertificate)
     }
     else {
+        $restCredParam = @{ NcRestCredential = $NcRestCredential }
         $confirmStateParams.Add('Credential', $NcRestCredential)
         $ncRestParams.Add('NcRestCredential', $NcRestCredential)
         $putRestParams.Add('Credential', $NcRestCredential)
@@ -137,7 +139,7 @@ function Start-SdnMuxCertificateRotation {
         }
 
         [System.IO.FileSystemInfo]$CertPath = Get-Item -Path $CertPath -ErrorAction Stop
-        $sdnFabricDetails = Get-SdnInfrastructureInfo -NetworkController $NetworkController -Credential $Credential -NcRestCredential $NcRestCredential -ErrorAction Stop
+        $sdnFabricDetails = Get-SdnInfrastructureInfo -NetworkController $NetworkController -Credential $Credential @restCredParam -ErrorAction Stop
         if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ine 'ServiceFabric') {
             throw New-Object System.NotSupportedException("This function is only supported on Service Fabric clusters.")
         }
@@ -191,7 +193,6 @@ function Start-SdnMuxCertificateRotation {
             $virtualServer = Get-SdnResource @ncRestParams -ResourceRef $obj.ResourceRef
             $encoding = [System.Convert]::ToBase64String($obj.Certificate.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
 
-            $endpoint = Get-SdnApiEndpoint -NcUri $sdnFabricDetails.NcUrl -ResourceRef $virtualServer.resourceRef
             if ($virtualServer.properties.certificate) {
                 $virtualServer.properties.certificate = $encoding
             }
@@ -200,9 +201,10 @@ function Start-SdnMuxCertificateRotation {
                 # this typically will occur if converting from CA issued certificate to self-signed certificate
                 $virtualServer.properties | Add-Member -MemberType NoteProperty -Name 'certificate' -Value $encoding -Force
             }
-
-            $putRestParams.Uri = $endpoint
             $putRestParams.Body = ($virtualServer | ConvertTo-Json -Depth 100)
+
+            $endpoint = Get-SdnApiEndpoint -NcUri $sdnFabricDetails.NcUrl -ResourceRef $virtualServer.resourceRef
+            $putRestParams.Uri = $endpoint
 
             $null = Invoke-RestMethodWithRetry @putRestParams
             if (-NOT (Confirm-ProvisioningStateSucceeded -Uri $putRestParams.Uri @confirmStateParams)) {

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
@@ -4,8 +4,11 @@ function Start-SdnMuxCertificateRotation {
         Performs a certificate rotation operation for the Load Balancer Muxes.
     .PARAMETER Credential
         Specifies a user account that has permission to perform this action on the Load Balancer Mux and Network Controller nodes. The default is the current user.
+    .PARAMETER NcRestCertificate
+        Specifies the client certificate that is used for a secure web request to Network Controller REST API.
+        Enter a variable that contains a certificate or a command or expression that gets the certificate.
     .PARAMETER NcRestCredential
-        Specifies a user account that has permission to access the northbound NC API interface. The default is the current user.
+        Specifies a user account that has permission to perform this action against the Network Controller REST API. The default is the current user.
     .PARAMETER CertPath
         Path directory where certificate(s) .pfx files are located for use with certificate rotation.
     .PARAMETER GenerateCertificate
@@ -40,6 +43,11 @@ function Start-SdnMuxCertificateRotation {
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $NcRestCredential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Pfx')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'GenerateCertificate')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'CertConfig')]
+        [X509Certificate]$NcRestCertificate,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Pfx')]
         [System.String]$CertPath,
@@ -88,8 +96,33 @@ function Start-SdnMuxCertificateRotation {
     }
 
     $array = @()
-    $headers = @{"Accept"="application/json"}
-    $content = "application/json; charset=UTF-8"
+
+    $ncRestParams = @{
+        NcUri = $null
+    }
+    $putRestParams = @{
+        Body = $null
+        Content = "application/json; charset=UTF-8"
+        Headers = @{"Accept"="application/json"}
+        Method = 'Put'
+        Uri = $null
+        UseBasicParsing = $true
+    }
+    $confirmStateParams = @{
+        TimeoutInSec = 600
+        UseBasicParsing = $true
+    }
+
+    if ($PSBoundParameters.ContainsKey('NcRestCertificate')) {
+        $confirmStateParams.Add('Certificate', $NcRestCertificate)
+        $ncRestParams.Add('NcRestCertificate', $NcRestCertificate)
+        $putRestParams.Add('Certificate', $NcRestCertificate)
+    }
+    else {
+        $confirmStateParams.Add('Credential', $NcRestCredential)
+        $ncRestParams.Add('NcRestCredential', $NcRestCredential)
+        $putRestParams.Add('Credential', $NcRestCredential)
+    }
 
     try {
         "Starting certificate rotation" | Trace-Output
@@ -109,7 +142,8 @@ function Start-SdnMuxCertificateRotation {
             throw New-Object System.NotSupportedException("This function is only supported on Service Fabric clusters.")
         }
 
-        $loadBalancerMuxes = Get-SdnLoadBalancerMux -NcUri $sdnFabricDetails.NcUrl -Credential $NcRestCredential -ErrorAction Stop
+        $ncRestParams.NcUri = $sdnFabricDetails.NcUrl
+        $loadBalancerMuxes = Get-SdnLoadBalancerMux @ncRestParams -ErrorAction Stop
 
         # before we proceed with anything else, we want to make sure that all the Network Controllers and MUXes within the SDN fabric are running the current version
         Install-SdnDiagnostics -ComputerName $sdnFabricDetails.NetworkController -ErrorAction Stop
@@ -127,7 +161,7 @@ function Start-SdnMuxCertificateRotation {
             # retrieve the corresponding virtualserver reference for each loadbalancermux
             # and invoke remote operation to the mux to generate the self-signed certificate that matches the managementAddress for x509 credentials
             foreach ($muxResource in $loadBalancerMuxes) {
-                $virtualServer = Get-SdnResource -NcUri $sdnFabricDetails.NcUrl -ResourceRef $muxResource.properties.virtualServer.resourceRef
+                $virtualServer = Get-SdnResource @ncRestParams -ResourceRef $muxResource.properties.virtualServer.resourceRef
                 $virtualServerConnection = $virtualServer.properties.connections | Where-Object { $_.credentialType -ieq "X509Certificate" -or $_.credentialType -ieq "X509CertificateSubjectName" }
                 $managementAddress = $virtualServerConnection.managementAddresses[0]
 
@@ -154,10 +188,10 @@ function Start-SdnMuxCertificateRotation {
         # to update the base64 encoding for the certificate that NC should use when communicating with the virtualServer resource
         foreach ($obj in $array) {
             "Updating certificate information for {0}" -f $obj.ResourceRef | Trace-Output
-            $virtualServer = Get-SdnResource -NcUri $sdnFabricDetails.NcUrl -Credential $NcRestCredential -ResourceRef $obj.ResourceRef
+            $virtualServer = Get-SdnResource @ncRestParams -ResourceRef $obj.ResourceRef
             $encoding = [System.Convert]::ToBase64String($obj.Certificate.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
 
-            $endpoint = Get-SdnApiEndpoint -NcUri $sdnFabricDetails.NcUrl  -ResourceRef $virtualServer.resourceRef
+            $endpoint = Get-SdnApiEndpoint -NcUri $sdnFabricDetails.NcUrl -ResourceRef $virtualServer.resourceRef
             if ($virtualServer.properties.certificate) {
                 $virtualServer.properties.certificate = $encoding
             }
@@ -166,10 +200,12 @@ function Start-SdnMuxCertificateRotation {
                 # this typically will occur if converting from CA issued certificate to self-signed certificate
                 $virtualServer.properties | Add-Member -MemberType NoteProperty -Name 'certificate' -Value $encoding -Force
             }
-            $jsonBody = $virtualServer | ConvertTo-Json -Depth 100
 
-            $null = Invoke-RestMethodWithRetry -Method 'Put' -UseBasicParsing -Uri $endpoint -Headers $headers -ContentType $content -Body $jsonBody -Credential $NcRestCredential
-            if (-NOT (Confirm-ProvisioningStateSucceeded -Uri $endpoint -Credential $NcRestCredential -UseBasicParsing)) {
+            $putRestParams.Uri = $endpoint
+            $putRestParams.Body = ($virtualServer | ConvertTo-Json -Depth 100)
+
+            $null = Invoke-RestMethodWithRetry @putRestParams
+            if (-NOT (Confirm-ProvisioningStateSucceeded -Uri $putRestParams.Uri @confirmStateParams)) {
                 throw New-Object System.Exception("ProvisioningState is not succeeded")
             }
             else {

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
@@ -96,7 +96,6 @@ function Start-SdnMuxCertificateRotation {
     }
 
     $array = @()
-
     $ncRestParams = @{
         NcUri = $null
     }

--- a/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
+++ b/src/modules/SdnDiag.LoadBalancerMux/public/Start-SdnMuxCertificateRotation.ps1
@@ -115,16 +115,15 @@ function Start-SdnMuxCertificateRotation {
 
     if ($PSBoundParameters.ContainsKey('NcRestCertificate')) {
         $restCredParam = @{ NcRestCertificate = $NcRestCertificate }
-        $confirmStateParams.Add('Certificate', $NcRestCertificate)
         $ncRestParams.Add('NcRestCertificate', $NcRestCertificate)
         $putRestParams.Add('Certificate', $NcRestCertificate)
     }
     else {
         $restCredParam = @{ NcRestCredential = $NcRestCredential }
-        $confirmStateParams.Add('Credential', $NcRestCredential)
         $ncRestParams.Add('NcRestCredential', $NcRestCredential)
         $putRestParams.Add('Credential', $NcRestCredential)
     }
+    $confirmStateParams += $restCredParam
 
     try {
         "Starting certificate rotation" | Trace-Output
@@ -207,7 +206,7 @@ function Start-SdnMuxCertificateRotation {
             $putRestParams.Uri = $endpoint
 
             $null = Invoke-RestMethodWithRetry @putRestParams
-            if (-NOT (Confirm-ProvisioningStateSucceeded -Uri $putRestParams.Uri @confirmStateParams)) {
+            if (-NOT (Confirm-ProvisioningStateSucceeded -NcUri $putRestParams.Uri @confirmStateParams)) {
                 throw New-Object System.Exception("ProvisioningState is not succeeded")
             }
             else {

--- a/src/modules/SdnDiag.NetworkController.SF/private/Start-SdnExpiredCertificateRotation.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/private/Start-SdnExpiredCertificateRotation.ps1
@@ -20,16 +20,15 @@ function Start-SdnExpiredCertificateRotation {
         Start-SdnExpiredCertificateRotation -NetworkController nc01
     #>
 
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [hashtable]
         $CertRotateConfig,
+
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $NcRestCredential = [System.Management.Automation.PSCredential]::Empty
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     $NcUpdateFolder = "$(Get-WorkingDirectory)\NcCertUpdate_{0}" -f (Get-FormattedDateTimeUTC)
@@ -122,15 +121,4 @@ function Start-SdnExpiredCertificateRotation {
     # Step 7 Restart
     Trace-Output -Message "Step 7 Restarting Service Fabric Cluster after configuration change"
     $clusterHealthy = Wait-ServiceFabricClusterHealthy -NcNodeList $NcNodeList -CertRotateConfig $CertRotateConfig -Credential $Credential -Restart
-
-<#     Trace-Output -Message "Step 7.2 Rotate Network Controller Certificate"
-    #$null = Invoke-CertRotateCommand -Command 'Set-NetworkController' -Credential $Credential -Thumbprint $NcRestCertThumbprint
-
-    # Step 8 Update REST CERT credential
-    Trace-Output -Message "Step 8 Update REST CERT credential"
-    # Step 8.1 Wait for NC App Healthy
-    Trace-Output -Message "Step 8.1 Wiating for Network Controller App Ready"
-    #Wait-NetworkControllerAppHealthy -Interval 60
-    Trace-Output -Message "Step 8.2 Updating REST CERT Credential object calling REST API" #>
-    #Update-NetworkControllerCredentialResource -NcUri "https://$($NcInfraInfo.NcRestName)" -NewRestCertThumbprint $NcRestCertThumbprint -Credential $NcRestCredential
 }

--- a/src/modules/SdnDiag.NetworkController/private/Get-PublicIpReference.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-PublicIpReference.ps1
@@ -1,5 +1,4 @@
 function Get-PublicIpReference {
-    <##>
     [CmdletBinding(DefaultParameterSetName = 'RestCredential')]
     param (
         [Parameter(Mandatory = $true)]
@@ -45,9 +44,9 @@ function Get-PublicIpReference {
         "Checking for any backend address pool associated with {0}" -f $IpConfiguration.resourceRef | Trace-Output -Level:Verbose
         if ($IpConfiguration.properties.loadBalancerBackendAddressPools) {
             "Located backend address pool associations for {0}" -f $IpConfiguration.resourceRef | Trace-Output -Level:Verbose
-            $loadBalancers = Get-SdnResource -Resource:LoadBalancers @restParams
             $allBackendPoolRefs = @($IpConfiguration.properties.loadBalancerBackendAddressPools.resourceRef)
 
+            $loadBalancers = Get-SdnResource -Resource:LoadBalancers @restParams
             $backendHash = [System.Collections.Hashtable]::new()
             foreach ($group in $loadBalancers.properties.backendAddressPools | Group-Object resourceRef) {
                 [void]$backendHash.Add($group.Name, $group.Group)
@@ -79,11 +78,11 @@ function Get-PublicIpReference {
         else {
             "Unable to locate any backend pools associated with {0}" -f $IpConfiguration.resourceRef | Trace-Output -Level:Verbose
         }
-
-        return $null
     }
     catch {
         $_ | Trace-Exception
         $_ | Write-Error
     }
+
+    return $null
 }

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnClusterType.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnClusterType.ps1
@@ -24,9 +24,9 @@ function Get-SdnClusterType {
     )
 
     $sb = {
-        # with failover cluster, the ApiService will run as a service within windows
+        # with failover cluster, the SDNApiService will run as a service within windows
         # so we can check if the service exists to determine if it is a failover cluster configuration regardless if running
-        $service = Get-Service -Name 'ApiService' -ErrorAction Ignore
+        $service = Get-Service -Name 'SDNApiService' -ErrorAction Ignore
         if ($service) {
             return 'FailoverCluster'
         }

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnDiscovery.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnDiscovery.ps1
@@ -4,23 +4,39 @@ function Get-SdnDiscovery {
         Calls to the Discovery API endpoint to determine versioning and feature details
     .PARAMETER NcUri
         Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
+    .PARAMETER Certificate
+        Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
 	.PARAMETER Credential
 		Specifies a user account that has permission to perform this action. The default is the current user.
     #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Credential')]
     param (
         [Parameter(Mandatory = $true)]
         [Uri]$NcUri,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Credential')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
+        [X509Certificate]$Certificate
     )
 
+    $params = @{
+        NcUri = $NcUri
+        Resource = 'Discovery'
+    }
+    if ($Certificate) {
+        $params.Add('Certificate', $Certificate)
+    }
+    else {
+        $params.Add('Credential', $Credential)
+    }
+
     try {
-        $result = Get-SdnResource -NcUri $NcUri -Resource 'Discovery' -Credential $Credential
+        $result = Get-SdnResource @params
         return $result
     }
     catch {

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnDiscovery.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnDiscovery.ps1
@@ -6,8 +6,8 @@ function Get-SdnDiscovery {
         Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
     .PARAMETER Certificate
         Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
-	.PARAMETER Credential
-		Specifies a user account that has permission to perform this action. The default is the current user.
+    .PARAMETER Credential
+        Specifies a user account that has permission to perform this action. The default is the current user.
     #>
 
     [CmdletBinding(DefaultParameterSetName = 'Credential')]

--- a/src/modules/SdnDiag.NetworkController/private/Get-SdnDiscovery.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Get-SdnDiscovery.ps1
@@ -4,39 +4,42 @@ function Get-SdnDiscovery {
         Calls to the Discovery API endpoint to determine versioning and feature details
     .PARAMETER NcUri
         Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
-    .PARAMETER Certificate
-        Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
-    .PARAMETER Credential
-        Specifies a user account that has permission to perform this action. The default is the current user.
+    .PARAMETER NcRestCertificate
+        Specifies the client certificate that is used for a secure web request to Network Controller REST API.
+        Enter a variable that contains a certificate or a command or expression that gets the certificate.
+    .PARAMETER NcRestCredential
+        Specifies a user account that has permission to perform this action against the Network Controller REST API. The default is the current user.
     #>
 
-    [CmdletBinding(DefaultParameterSetName = 'Credential')]
+    [CmdletBinding(DefaultParameterSetName = 'RestCredential')]
     param (
         [Parameter(Mandatory = $true)]
         [Uri]$NcUri,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Credential')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestCredential')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        $NcRestCredential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
-        [X509Certificate]$Certificate
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate')]
+        [X509Certificate]$NcRestCertificate
     )
 
-    $params = @{
+    $ncRestParams = @{
         NcUri = $NcUri
         Resource = 'Discovery'
     }
-    if ($Certificate) {
-        $params.Add('Certificate', $Certificate)
-    }
-    else {
-        $params.Add('Credential', $Credential)
+    switch ($PSCmdlet.ParameterSetName) {
+        'RestCertificate' {
+            $ncRestParams.Add('NcRestCertificate', $NcRestCertificate)
+        }
+        'RestCredential' {
+            $ncRestParams.Add('NcRestCredential', $NcRestCredential)
+        }
     }
 
     try {
-        $result = Get-SdnResource @params
+        $result = Get-SdnResource @ncRestParams
         return $result
     }
     catch {

--- a/src/modules/SdnDiag.NetworkController/private/Invoke-SdnNetworkControllerStateDump.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Invoke-SdnNetworkControllerStateDump.ps1
@@ -19,7 +19,7 @@ function Invoke-SdnNetworkControllerStateDump {
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Parameter(Mandatory = $false)]
-        [System.String]$CertificateThumbprint,
+        [X509Certificate]$Certificate,
 
         [Parameter(Mandatory = $false)]
         [int]$ExecutionTimeOut = 300,
@@ -42,9 +42,9 @@ function Invoke-SdnNetworkControllerStateDump {
         ResourceRef     = 'diagnostics/networkControllerState'
     }
 
-    if (-NOT [string]::IsNullOrEmpty($CertificateThumbprint)) {
-        $getParams.Add('CertificateThumbprint', $CertificateThumbprint)
-        $putParams.Add('CertificateThumbprint', $CertificateThumbprint)
+    if ($Certificate) {
+        $getParams.Add('Certificate', $Certificate)
+        $putParams.Add('Certificate', $Certificate)
     }
     else {
         $getParams.Add('Credential', $Credential)

--- a/src/modules/SdnDiag.NetworkController/private/Invoke-SdnNetworkControllerStateDump.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Invoke-SdnNetworkControllerStateDump.ps1
@@ -67,7 +67,7 @@ function Invoke-SdnNetworkControllerStateDump {
         $null = Invoke-WebRequestWithRetry @putParams
 
         # monitor until the provisionState for the object is not in 'Updating' state
-        if (-NOT (Confirm-ProvisioningStateSucceeded -Uri $putParams.Uri @confirmParams)) {
+        if (-NOT (Confirm-ProvisioningStateSucceeded -NcUri $putParams.Uri @confirmParams)) {
             throw New-Object System.Exception("Unable to generate IMOS dump")
         }
         else {

--- a/src/modules/SdnDiag.NetworkController/private/Update-NetworkControllerCredentialResource.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Update-NetworkControllerCredentialResource.ps1
@@ -46,12 +46,12 @@ function Update-NetworkControllerCredentialResource {
 
     switch ($PSCmdlet.ParameterSetName) {
         'RestCertificate' {
-            $confirmStateParams.Add('Certificate', $NcRestCertificate)
+            $confirmStateParams.Add('NcRestCertificate', $NcRestCertificate)
             $putParams.Add('Certificate', $NcRestCertificate)
             $ncRestParams.Add('NcRestCertificate', $NcRestCertificate)
         }
         'RestCredential' {
-            $confirmStateParams.Add('Credential', $NcRestCredential)
+            $confirmStateParams.Add('NcRestCredential', $NcRestCredential)
             $putParams.Add('Credential', $NcRestCredential)
             $ncRestParams.Add('NcRestCredential', $NcRestCredential)
         }
@@ -78,7 +78,7 @@ function Update-NetworkControllerCredentialResource {
             # and confirm the provisioning state is succeeded
             $null = Invoke-WebRequestWithRetry @putParams
             try {
-                Confirm-ProvisioningStateSucceeded -Uri $putParams.Uri @confirmStateParams
+                Confirm-ProvisioningStateSucceeded -NcUri $putParams.Uri @confirmStateParams
             }
             catch {
                 $_ | Trace-Exception

--- a/src/modules/SdnDiag.NetworkController/private/Update-NetworkControllerCredentialResource.ps1
+++ b/src/modules/SdnDiag.NetworkController/private/Update-NetworkControllerCredentialResource.ps1
@@ -10,6 +10,7 @@ function Update-NetworkControllerCredentialResource {
         Specifies a user account that has permission to perform this action. The default is the current user.
     #>
 
+    [CmdletBinding(DefaultParameterSetName = 'RestCredential')]
     param (
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -19,23 +20,48 @@ function Update-NetworkControllerCredentialResource {
         [System.String]
         $NewRestCertThumbprint,
 
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestCredential')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        $NcRestCredential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate')]
+        [X509Certificate]$NcRestCertificate
     )
+    $putParams = @{
+        Uri             = $null
+        Method          = 'Put'
+        Headers         = @{"Accept" = "application/json" }
+        Content         = "application/json; charset=UTF-8"
+        Body            = "{}"
+        UseBasicParsing = $true
+    }
+    $confirmStateParams = @{
+        TimeoutInSec = 600
+        UseBasicParsing = $true
+    }
+    $ncRestParams = @{
+        NcUri = $NcUri
+    }
 
-    $headers = @{"Accept"="application/json"}
-    $content = "application/json; charset=UTF-8"
-    $timeoutInMinutes = 10
-    $array = @()
+    switch ($PSCmdlet.ParameterSetName) {
+        'RestCertificate' {
+            $confirmStateParams.Add('Certificate', $NcRestCertificate)
+            $putParams.Add('Certificate', $NcRestCertificate)
+            $ncRestParams.Add('NcRestCertificate', $NcRestCertificate)
+        }
+        'RestCredential' {
+            $confirmStateParams.Add('Credential', $NcRestCredential)
+            $putParams.Add('Credential', $NcRestCredential)
+            $ncRestParams.Add('NcRestCredential', $NcRestCredential)
+        }
+    }
 
-    $servers = Get-SdnServer -NcUri $NcUri -Credential $Credential
+    $servers = Get-SdnServer @ncRestParams
     foreach ($object in $servers) {
         "Processing X509 connections for {0}" -f $object.resourceRef | Trace-Output
         foreach ($connection in $servers.properties.connections | Where-Object { $_.credentialType -ieq "X509Certificate" -or $_.credentialType -ieq "X509CertificateSubjectName" }) {
-            $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
-
-            $cred = Get-SdnResource -NcUri $NcUri -ResourceRef $connection.credential.resourceRef -Credential $Credential
+            $cred = Get-SdnResource @ncRestParams -ResourceRef $connection.credential.resourceRef
 
             # if for any reason the certificate thumbprint has been updated, then skip the update operation for this credential resource
             if ($cred.properties.value -ieq $NewRestCertThumbprint) {
@@ -45,40 +71,19 @@ function Update-NetworkControllerCredentialResource {
 
             "{0} will be updated from {1} to {2}" -f $cred.resourceRef, $cred.properties.value, $NewRestCertThumbprint | Trace-Output
             $cred.properties.value = $NewRestCertThumbprint
-            $credBody = $cred | ConvertTo-Json -Depth 100
+            $putParams.Body = $cred | ConvertTo-Json -Depth 100
+            $putParams.Uri = Get-SdnApiEndpoint -NcUri $NcUri -ResourceRef $cred.resourceRef
 
-            [System.String]$uri = Get-SdnApiEndpoint -NcUri $NcUri -ResourceRef $cred.resourceRef
-            $null = Invoke-WebRequestWithRetry -Method 'Put' -Uri $uri -Credential $Credential -UseBasicParsing `
-            -Headers $headers -ContentType $content -Body $credBody
-
-            while ($true) {
-                if ($stopWatch.Elapsed.TotalMinutes -ge $timeoutInMinutes) {
-                    $stopWatch.Stop()
-                    throw New-Object System.TimeoutException("Update of $($cred.resourceRef) did not complete within the alloted time")
-                }
-
-                $result = Invoke-RestMethodWithRetry -Method 'Get' -Uri $uri -Credential $Credential -UseBasicParsing
-                if ($result.properties.provisioningState -ieq 'Updating') {
-                    "Status: {0}" -f $result.properties.provisioningState | Trace-Output
-                    Start-Sleep -Seconds 15
-                }
-                elseif ($result.properties.provisioningState -ieq 'Failed') {
-                    $stopWatch.Stop()
-                    throw New-Object System.Exception("Failed to update $($cred.resourceRef)")
-                }
-                elseif ($result.properties.provisioningState -ieq 'Succeeded') {
-                    "Successfully updated {0}" -f $cred.resourceRef | Trace-Output
-                    break
-                }
-                else {
-                    $stopWatch.Stop()
-                    throw New-Object System.Exception("Failed to update $($cred.resourceRef) with $($result.properties.provisioningState)")
-                }
+            # update the credential resource with new certificate thumbprint
+            # and confirm the provisioning state is succeeded
+            $null = Invoke-WebRequestWithRetry @putParams
+            try {
+                Confirm-ProvisioningStateSucceeded -Uri $putParams.Uri @confirmStateParams
             }
-
-            $array += $result
+            catch {
+                $_ | Trace-Exception
+                $_ | Write-Error
+            }
         }
     }
-
-    return $array
 }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnAuditLog.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnAuditLog.ps1
@@ -7,15 +7,18 @@ function Get-SdnAuditLog {
         Directory the results will be saved to. If ommitted, will default to the current working directory.
     .PARAMETER NcUri
         Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
-    .PARAMETER NCRestCredential
-        Specifies a user account that has permission to access the northbound NC API interface. The default is the current user.
+    .PARAMETER NcRestCertificate
+        Specifies the client certificate that is used for a secure web request to Network Controller REST API.
+        Enter a variable that contains a certificate or a command or expression that gets the certificate.
+    .PARAMETER NcRestCredential
+        Specifies a user account that has permission to perform this action against the Network Controller REST API. The default is the current user.
     .PARAMETER ComputerName
-        Type the NetBIOS name, an IP address, or a fully qualified domain name of one or more remote compute
+        Type the NetBIOS name, an IP address, or a fully qualified domain name of one or more remote computers.
     .PARAMETER Credential
-        Specifies a user account that has permission to perform this action. The default is the current user.
+        Specifies a user account that has permission to access the Computers. The default is the current user.
     #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'RestCredential')]
     param (
         [Parameter(Mandatory = $false)]
         [System.String]$OutputDirectory = "$(Get-WorkingDirectory)\AuditLogs",
@@ -23,10 +26,13 @@ function Get-SdnAuditLog {
         [Parameter(Mandatory = $true)]
         [Uri]$NcUri,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestCredential')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $NcRestCredential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate')]
+        [X509Certificate]$NcRestCertificate,
 
         [Parameter(Mandatory = $false, ValueFromPipeline)]
         [System.String[]]$ComputerName,
@@ -37,9 +43,21 @@ function Get-SdnAuditLog {
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
+    $ncRestParams = @{
+        NcUri = $NcUri
+    }
+    switch ($PSCmdlet.ParameterSetName) {
+        'RestCertificate' {
+            $ncRestParams.Add('NcRestCertificate', $NcRestCertificate)
+        }
+        'RestCredential' {
+            $ncRestParams.Add('NcRestCredential', $NcRestCredential)
+        }
+    }
+
     # verify that the environment we are on supports at least v3 API and later
     # as described in https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-ncnbi/dc23b547-9ec4-4cb3-ab20-a6bfe01ddafb
-    $currentRestVersion = (Get-SdnResource -NcUri $NcUri.AbsoluteUri -Resource 'Discovery' -Credential $NcRestCredential).properties.currentRestVersion
+    $currentRestVersion = (Get-SdnDiscovery @ncRestParams).properties.currentRestVersion
     [int]$currentRestVersionInt = $currentRestVersion.Replace('V','').Replace('v','').Trim()
     if ($currentRestVersionInt -lt 3) {
         "Auditing requires API version 3 or later. Network Controller supports version {0}" -f $currentRestVersionInt | Trace-Output -Level:Warning
@@ -47,7 +65,7 @@ function Get-SdnAuditLog {
     }
 
     # check to see that auditing has been enabled
-    $auditSettingsConfig = Get-SdnResource -NcUri $NcUri.AbsoluteUri -Resource 'AuditingSettingsConfig' -ApiVersion $currentRestVersion -Credential $NcRestCredential
+    $auditSettingsConfig = Get-SdnResource @ncRestParams -Resource 'AuditingSettingsConfig' -ApiVersion $currentRestVersion
     if ([string]::IsNullOrEmpty($auditSettingsConfig.properties.outputDirectory)) {
         "Audit logging is not enabled" | Trace-Output
         return
@@ -59,7 +77,7 @@ function Get-SdnAuditLog {
     # if $ComputerName was not specified, then attempt to locate the servers within the SDN fabric
     # only add the servers where auditingEnabled has been configured as 'Firewall'
     if ($null -eq $ComputerName) {
-        $sdnServers = Get-SdnResource -Resource Servers -NcUri $NcUri.AbsoluteUri -Credential $NcRestCredential -ApiVersion $currentRestVersion `
+        $sdnServers = Get-SdnResource @ncRestParams -Resource Servers -ApiVersion $currentRestVersion `
         | Where-Object {$_.properties.auditingEnabled -ieq 'Firewall'}
 
         $ComputerName = ($sdnServers.properties.connections | Where-Object {$_.credentialType -ieq 'UsernamePassword'}).managementAddresses

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
@@ -8,6 +8,8 @@ function Get-SdnGateway {
         Specifies the unique identifier for the resource.
     .PARAMETER ResourceRef
         Specifies the resource reference for the resource.
+    .PARAMETER Certificate
+        Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
 	.PARAMETER Credential
 		Specifies a user account that has permission to perform this action. The default is the current user.
     .PARAMETER ManagementAddressOnly
@@ -42,6 +44,11 @@ function Get-SdnGateway {
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
+        [X509Certificate]$Certificate,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
@@ -54,7 +61,12 @@ function Get-SdnGateway {
 
     $params = @{
         NcUri = $NcUri
-        Credential = $Credential
+    }
+    if ($Certificate) {
+        $params.Add('Certificate', $Certificate)
+    }
+    else {
+        $params.Add('Credential', $Credential)
     }
 
     switch ($PSCmdlet.ParameterSetName) {

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
@@ -10,8 +10,8 @@ function Get-SdnGateway {
         Specifies the resource reference for the resource.
     .PARAMETER Certificate
         Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
-	.PARAMETER Credential
-		Specifies a user account that has permission to perform this action. The default is the current user.
+    .PARAMETER Credential
+        Specifies a user account that has permission to perform this action. The default is the current user.
     .PARAMETER ManagementAddressOnly
         Optional parameter to only return back the Management Address value.
     .EXAMPLE

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnGateway.ps1
@@ -8,24 +8,25 @@ function Get-SdnGateway {
         Specifies the unique identifier for the resource.
     .PARAMETER ResourceRef
         Specifies the resource reference for the resource.
-    .PARAMETER Certificate
-        Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
-    .PARAMETER Credential
-        Specifies a user account that has permission to perform this action. The default is the current user.
+    .PARAMETER NcRestCertificate
+        Specifies the client certificate that is used for a secure web request to Network Controller REST API.
+        Enter a variable that contains a certificate or a command or expression that gets the certificate.
+    .PARAMETER NcRestCredential
+        Specifies a user account that has permission to perform this action against the Network Controller REST API. The default is the current user.
     .PARAMETER ManagementAddressOnly
         Optional parameter to only return back the Management Address value.
     .EXAMPLE
-        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -Credential (Get-Credential)
+        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -NcRestCredential (Get-Credential)
     .EXAMPLE
-        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ManagementAddressOnly
+        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -NcRestCredential (Get-Credential) -ManagementAddressOnly
     .EXAMPLE
-        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceId 'f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e'
+        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -NcRestCredential (Get-Credential) -ResourceId 'f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e'
     .EXAMPLE
-        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceRef 'gateways/f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e'
+        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -NcRestCredential (Get-Credential) -ResourceRef 'gateways/f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e'
     .EXAMPLE
-        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceId 'f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e' -ManagementAddressOnly
+        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -NcRestCredential (Get-Credential) -ResourceId 'f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e' -ManagementAddressOnly
     .EXAMPLE
-        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceRef 'gateways/f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e' -ManagementAddressOnly
+        PS> Get-SdnGateway -NcUri 'https://NC.FQDN' -NcRestCredential (Get-Credential) -ResourceRef 'gateways/f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e' -ManagementAddressOnly
     #>
 
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -44,14 +45,14 @@ function Get-SdnGateway {
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
-        [X509Certificate]$Certificate,
+        [X509Certificate]$NcRestCertificate,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        $NcRestCredential = [System.Management.Automation.PSCredential]::Empty,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
@@ -59,31 +60,29 @@ function Get-SdnGateway {
         [switch]$ManagementAddressOnly
     )
 
-    $params = @{
+    $ncRestParams = @{
         NcUri = $NcUri
     }
-    if ($Certificate) {
-        $params.Add('Certificate', $Certificate)
+    if ($PSBoundParameters.ContainsKey('NcRestCertificate')) {
+        $ncRestParams.Add('NcRestCertificate', $NcRestCertificate)
     }
     else {
-        $params.Add('Credential', $Credential)
-    }
-
-    switch ($PSCmdlet.ParameterSetName) {
-        'ResourceId' {
-            $params.Add('Resource', 'Gateways')
-            $params.Add('ResourceId', $ResourceId)
-        }
-        'ResourceRef' {
-            $params.Add('ResourceRef', $ResourceRef)
-        }
-        default {
-            $params.Add('Resource', 'Gateways')
-        }
+        $ncRestParams.Add('NcRestCredential', $NcRestCredential)
     }
 
     try {
-        $result = Get-SdnResource @params
+        switch ($PSCmdlet.ParameterSetName) {
+            'ResourceId' {
+                $result = Get-SdnResource @ncRestParams -Resource 'Gateways' -ResourceId $ResourceId
+            }
+            'ResourceRef' {
+                $result = Get-SdnResource @ncRestParams -ResourceRef $ResourceRef
+            }
+            default {
+                $result = Get-SdnResource @ncRestParams -Resource 'Gateways'
+            }
+        }
+
         if ($result) {
             foreach($obj in $result){
                 if($obj.properties.provisioningState -ne 'Succeeded'){
@@ -94,7 +93,7 @@ function Get-SdnGateway {
             if($ManagementAddressOnly){
                 $connections = @()
                 foreach ($resource in $result) {
-                    $virtualServerMgmtAddress = Get-SdnVirtualServer -NcUri $NcUri.AbsoluteUri -ResourceRef $resource.properties.virtualserver.ResourceRef -ManagementAddressOnly -Credential $Credential
+                    $virtualServerMgmtAddress = Get-SdnVirtualServer @ncRestParams -ResourceRef $resource.properties.virtualserver.ResourceRef -ManagementAddressOnly
                     $connections += $virtualServerMgmtAddress
                 }
 

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnInternalLoadBalancer.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnInternalLoadBalancer.ps1
@@ -1,24 +1,24 @@
 function Get-SdnInternalLoadBalancer {
     <#
-        .SYNOPSIS
-            Performs lookups and joins between OVSDB resources, load balancers and virtual networks to create internal load balancer object mappings
-        .PARAMETER NcUri
-            Specifies the Network Controller URI to connect to.
-        .PARAMETER IPAddress
-            Specify the private IP address of the Internal Load Balancer.
-        .PARAMETER ProviderAddress
-            Specify the provider address IP that is associated with the Internal Load Balancer.
-        .PARAMETER Credential
-            Specifies a user account that has permission to the Hyper-V Hosts within the SDN Fabric. The default is the current user.
-        .PARAMETER NcRestCertificate
-            Specifies the client certificate that is used for a secure web request to Network Controller REST API.
-            Enter a variable that contains a certificate or a command or expression that gets the certificate.
-        .PARAMETER NcRestCredential
-            Specifies a user account that has permission to perform this action against the Network Controller REST API. The default is the current user.
-        .EXAMPLE
-            Get-SdnInternalLoadBalancer -NcUri https://nc.contoso.com -IPAddress 10.10.0.50
-        .EXAMPLE
-            Get-SdnInternalLoadBalancer -NcUri https://nc.contoso.com -NcRestCredential (Get-Credential)
+    .SYNOPSIS
+        Performs lookups and joins between OVSDB resources, load balancers and virtual networks to create internal load balancer object mappings
+    .PARAMETER NcUri
+        Specifies the Network Controller URI to connect to.
+    .PARAMETER IPAddress
+        Specify the private IP address of the Internal Load Balancer.
+    .PARAMETER ProviderAddress
+        Specify the provider address IP that is associated with the Internal Load Balancer.
+    .PARAMETER Credential
+        Specifies a user account that has permission to the Hyper-V Hosts within the SDN Fabric. The default is the current user.
+    .PARAMETER NcRestCertificate
+        Specifies the client certificate that is used for a secure web request to Network Controller REST API.
+        Enter a variable that contains a certificate or a command or expression that gets the certificate.
+    .PARAMETER NcRestCredential
+        Specifies a user account that has permission to perform this action against the Network Controller REST API. The default is the current user.
+    .EXAMPLE
+        Get-SdnInternalLoadBalancer -NcUri https://nc.contoso.com -IPAddress 10.10.0.50
+    .EXAMPLE
+        Get-SdnInternalLoadBalancer -NcUri https://nc.contoso.com -NcRestCredential (Get-Credential)
     #>
 
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -70,24 +70,24 @@ function Get-SdnInternalLoadBalancer {
 
     try {
         $servers = Get-SdnServer @ncRestParams -ManagementAddressOnly
-        $ovsdbAddressMappings = Get-SdnOvsdbAddressMapping -ComputerName $servers -Credential $Credential | Where-Object {$_.mappingType -eq 'learning_disabled'}
-        $loadBalancers = Get-SdnResource @ncRestParams -Resource LoadBalancers
-        $virtualNetworks = Get-SdnResource @ncRestParams -Resource VirtualNetworks
 
         # if this returns null, this is due to no tenant internal load balancers have been provisioned on the system
         # in which case all the further processing is not needed
+        $ovsdbAddressMappings = Get-SdnOvsdbAddressMapping -ComputerName $servers -Credential $Credential | Where-Object {$_.mappingType -eq 'learning_disabled'}
         if($null -eq $ovsdbAddressMappings){
             return $null
         }
 
         "Located {0} address mappings from OVSDB" -f $ovsdbAddressMappings.Count | Trace-Output -Level:Verbose
         # create a hash table based on the subnet instanceId contained within the virtual networks
+        $virtualNetworks = Get-SdnResource @ncRestParams -Resource VirtualNetworks
         foreach($group in $virtualNetworks.properties.subnets | Group-Object InstanceID){
             [void]$subnetHash.Add($group.Name, $group.Group)
         }
 
         "Located {0} subnets" -f $subnetHash.Count | Trace-Output -Level:Verbose
         # create a hash table based on the resourceRef of the frontendIPConfigurations within the load balancers
+        $loadBalancers = Get-SdnResource @ncRestParams -Resource LoadBalancers
         foreach($group in $loadBalancers.properties.frontendIPConfigurations | Group-Object resourceRef){
             [void]$frontendHash.Add($group.Name, $group.Group)
         }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnLoadBalancerMux.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnLoadBalancerMux.ps1
@@ -8,6 +8,8 @@ function Get-SdnLoadBalancerMux {
         Specifies the unique identifier for the resource.
     .PARAMETER ResourceRef
         Specifies the resource reference for the resource.
+    .PARAMETER Certificate
+        Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
 	.PARAMETER Credential
 		Specifies a user account that has permission to perform this action. The default is the current user.
     .PARAMETER ManagementAddressOnly
@@ -42,6 +44,11 @@ function Get-SdnLoadBalancerMux {
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
+        [X509Certificate]$Certificate,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
@@ -54,7 +61,12 @@ function Get-SdnLoadBalancerMux {
 
     $params = @{
         NcUri = $NcUri
-        Credential = $Credential
+    }
+    if ($Certificate) {
+        $params.Add('Certificate', $Certificate)
+    }
+    else {
+        $params.Add('Credential', $Credential)
     }
 
     switch ($PSCmdlet.ParameterSetName) {

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerState.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerState.ps1
@@ -7,16 +7,19 @@ function Get-SdnNetworkControllerState {
     .PARAMETER OutputDirectory
         Directory location to save results. By default it will create a new sub-folder called NetworkControllerState that the files will be copied to
 	.PARAMETER Credential
-		Specifies a user account that has permission to perform this action. The default is the current user.
-	.PARAMETER NcRestCredential
-		Specifies a user account that has permission to access the northbound NC API interface. The default is the current user.
+		Specifies a user account that has permission to Network Controller. The default is the current user.
+    .PARAMETER NcRestCertificate
+        Specifies the client certificate that is used for a secure web request to Network Controller REST API.
+        Enter a variable that contains a certificate or a command or expression that gets the certificate.
+    .PARAMETER NcRestCredential
+        Specifies a user account that has permission to perform this action against the Network Controller REST API. The default is the current user.
     .PARAMETER ExecutionTimeout
         Specify the execution timeout (seconds) on how long you want to wait for operation to complete before cancelling operation. If omitted, defaults to 300 seconds.
     .EXAMPLE
         PS> Get-SdnNcImosDumpFiles -NcUri "https://nc.contoso.com" -NetworkController $NetworkControllers -OutputDirectory "C:\Temp\CSS_SDN"
     #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'RestCredential')]
     param (
         [Parameter(Mandatory = $true)]
         [System.String]$NetworkController,
@@ -29,14 +32,30 @@ function Get-SdnNetworkControllerState {
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestCredential')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $NcRestCredential = [System.Management.Automation.PSCredential]::Empty,
 
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate')]
+        [X509Certificate]$NcRestCertificate,
+
         [Parameter(Mandatory = $false)]
         [int]$ExecutionTimeOut = 300
     )
+
+    $ncRestParams = @{
+        NcUri = $NcUri
+    }
+    switch ($PSCmdlet.ParameterSetName) {
+        'RestCertificate' {
+            $ncRestParams.Add('NcRestCertificate', $NcRestCertificate)
+        }
+        'RestCredential' {
+            $ncRestParams.Add('NcRestCredential', $NcRestCredential)
+        }
+    }
+
     try {
         "Collecting In Memory Object State (IMOS) for Network Controller" | Trace-Output
         $config = Get-SdnModuleConfiguration -Role:NetworkController
@@ -67,7 +86,7 @@ function Get-SdnNetworkControllerState {
 
         # invoke the call to generate the files
         # once the operation completes and returns true, then enumerate through the Network Controllers defined to collect the files
-        $result = Invoke-SdnNetworkControllerStateDump -NcUri $infraInfo.NcUrl -Credential $NcRestCredential -ExecutionTimeOut $ExecutionTimeOut
+        $result = Invoke-SdnNetworkControllerStateDump @ncRestParams -ExecutionTimeOut $ExecutionTimeOut
         if ($result) {
             foreach ($ncVM in $infraInfo.NetworkController) {
                 Copy-FileFromRemoteComputer -Path "$($config.properties.netControllerStatePath)\*" -ComputerName $ncVM -Destination $outputDir.FullName

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnResource.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnResource.ps1
@@ -14,10 +14,11 @@ function Get-SdnResource {
         Specify the unique Instance ID of the resource.
     .PARAMETER ApiVersion
         The API version to use when invoking against the NC REST API endpoint.
-    .PARAMETER Credential
-        Specifies a user account that has permission to perform this action. The default is the current user.
-    .PARAMETER Certificate
-        Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
+    .PARAMETER NcRestCertificate
+        Specifies the client certificate that is used for a secure web request to Network Controller REST API.
+        Enter a variable that contains a certificate or a command or expression that gets the certificate.
+    .PARAMETER NcRestCredential
+        Specifies a user account that has permission to perform this action against the Network Controller REST API. The default is the current user.
     .EXAMPLE
         PS> Get-SdnResource -NcUri "https://nc.$env:USERDNSDOMAIN" -Resource PublicIPAddresses
     .EXAMPLE
@@ -25,7 +26,7 @@ function Get-SdnResource {
     .EXAMPLE
         PS> Get-SdnResource -NcUri "https://nc.$env:USERDNSDOMAIN" -ResourceRef "/publicIPAddresses/d9266251-a3ba-4ac5-859e-2c3a7c70352a"
     .EXAMPLE
-        PS> Get-SdnResource -NcUri "https://nc.$env:USERDNSDOMAIN" -ResourceRef "/publicIPAddresses/d9266251-a3ba-4ac5-859e-2c3a7c70352a" -Credential (Get-Credential)
+        PS> Get-SdnResource -NcUri "https://nc.$env:USERDNSDOMAIN" -ResourceRef "/publicIPAddresses/d9266251-a3ba-4ac5-859e-2c3a7c70352a" -NcRestCredential (Get-Credential)
     #>
 
     [CmdletBinding()]
@@ -56,12 +57,12 @@ function Get-SdnResource {
         [Parameter(Mandatory = $false, ParameterSetName = 'InstanceID')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        $NcRestCredential = [System.Management.Automation.PSCredential]::Empty,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Resource')]
         [Parameter(Mandatory = $false, ParameterSetName = 'InstanceID')]
-        [X509Certificate]$Certificate
+        [X509Certificate]$NcRestCertificate
     )
 
     $restParams = @{
@@ -70,23 +71,23 @@ function Get-SdnResource {
         Method          = 'Get'
     }
 
-    if ($Certificate) {
-        $restParams.Add('Certificate', $Certificate)
+    if ($PSBoundParameters.ContainsKey('NcRestCertificate')) {
+        $restParams.Add('Certificate', $NcRestCertificate)
     }
     else {
-        $restParams.Add('Credential', $Credential)
+        $restParams.Add('Credential', $NcRestCredential)
     }
 
     switch ($PSCmdlet.ParameterSetName) {
         'InstanceId' {
-            [System.String]$uri = Get-SdnApiEndpoint -NcUri $NcUri.AbsoluteUri -ApiVersion $ApiVersion -ResourceName 'internalResourceInstances'
+            [System.String]$uri = Get-SdnApiEndpoint -NcUri $NcUri -ApiVersion $ApiVersion -ResourceName 'internalResourceInstances'
             [System.String]$uri = "{0}/{1}" -f $uri, $InstanceId.Trim()
         }
         'ResourceRef' {
-            [System.String]$uri = Get-SdnApiEndpoint -NcUri $NcUri.AbsoluteUri -ApiVersion $ApiVersion -ResourceRef $ResourceRef
+            [System.String]$uri = Get-SdnApiEndpoint -NcUri $NcUri -ApiVersion $ApiVersion -ResourceRef $ResourceRef
         }
         'Resource' {
-            [System.String]$uri = Get-SdnApiEndpoint -NcUri $NcUri.AbsoluteUri -ApiVersion $ApiVersion -ResourceName $Resource
+            [System.String]$uri = Get-SdnApiEndpoint -NcUri $NcUri -ApiVersion $ApiVersion -ResourceName $Resource
 
             if ($ResourceID) {
                 [System.String]$uri = "{0}/{1}" -f $uri, $ResourceId.Trim()

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnResource.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnResource.ps1
@@ -64,17 +64,17 @@ function Get-SdnResource {
         [X509Certificate]$Certificate
     )
 
-    $params = @{
+    $restParams = @{
         UseBasicParsing = $true
         ErrorAction     = 'Stop'
         Method          = 'Get'
     }
 
     if ($Certificate) {
-        $params.Add('Certificate', $Certificate)
+        $restParams.Add('Certificate', $Certificate)
     }
     else {
-        $params.Add('Credential', $Credential)
+        $restParams.Add('Credential', $Credential)
     }
 
     switch ($PSCmdlet.ParameterSetName) {
@@ -95,12 +95,12 @@ function Get-SdnResource {
     }
 
     "{0} {1}" -f $method, $uri | Trace-Output -Level:Verbose
-    $params.Add('Uri', $uri)
+    $restParams.Add('Uri', $uri)
 
     # gracefully handle System.Net.WebException responses such as 404 to throw warning
     # anything else we want to throw terminating exception and capture for debugging purposes
     try {
-        $result = Invoke-RestMethodWithRetry @params
+        $result = Invoke-RestMethodWithRetry @restParams
     }
     catch [System.Net.WebException] {
         if ($_.Exception.Response.StatusCode -eq 'NotFound') {

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnResource.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnResource.ps1
@@ -16,9 +16,8 @@ function Get-SdnResource {
         The API version to use when invoking against the NC REST API endpoint.
     .PARAMETER Credential
         Specifies a user account that has permission to perform this action. The default is the current user.
-    .PARAMETER CertificateThumbprint
-        Specifies the digital public key certificate (X509) of a user account that has permission to send the request. Enter the certificate thumbprint of the certificate.
-        To see the certificate thumbprint, use the Get-Item or Get-ChildItem command to find the certificate in Cert:\CurrentUser\My.
+    .PARAMETER Certificate
+        Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
     .EXAMPLE
         PS> Get-SdnResource -NcUri "https://nc.$env:USERDNSDOMAIN" -Resource PublicIPAddresses
     .EXAMPLE
@@ -62,7 +61,7 @@ function Get-SdnResource {
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Resource')]
         [Parameter(Mandatory = $false, ParameterSetName = 'InstanceID')]
-        [System.String]$CertificateThumbprint
+        [X509Certificate]$Certificate
     )
 
     $params = @{
@@ -71,8 +70,8 @@ function Get-SdnResource {
         Method          = 'Get'
     }
 
-    if (-NOT [string]::IsNullOrEmpty($CertificateThumbprint)) {
-        $params.Add('CertificateThumbprint', $CertificateThumbprint)
+    if ($Certificate) {
+        $params.Add('Certificate', $Certificate)
     }
     else {
         $params.Add('Credential', $Credential)

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnResource.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnResource.ps1
@@ -16,6 +16,9 @@ function Get-SdnResource {
         The API version to use when invoking against the NC REST API endpoint.
     .PARAMETER Credential
         Specifies a user account that has permission to perform this action. The default is the current user.
+    .PARAMETER CertificateThumbprint
+        Specifies the digital public key certificate (X509) of a user account that has permission to send the request. Enter the certificate thumbprint of the certificate.
+        To see the certificate thumbprint, use the Get-Item or Get-ChildItem command to find the certificate in Cert:\CurrentUser\My.
     .EXAMPLE
         PS> Get-SdnResource -NcUri "https://nc.$env:USERDNSDOMAIN" -Resource PublicIPAddresses
     .EXAMPLE
@@ -56,7 +59,9 @@ function Get-SdnResource {
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Resource')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InstanceID')]
         [System.String]$CertificateThumbprint
     )
 

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnResource.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnResource.ps1
@@ -104,16 +104,8 @@ function Get-SdnResource {
     }
     catch [System.Net.WebException] {
         if ($_.Exception.Response.StatusCode -eq 'NotFound') {
-
-            # if the resource is iDNSServer configuration, we want to return null instead of throwing a warning
-            # as this may be expected behavior if the iDNSServer is not configured
-            if ($_.Exception.Response.ResponseUri.AbsoluteUri -ilike '*/idnsserver/configuration') {
-                return $null
-            }
-            else {
-                "{0} ({1})" -f $_.Exception.Message, $_.Exception.Response.ResponseUri.AbsoluteUri | Write-Warning
-                return $null
-            }
+            "{0} ({1})" -f $_.Exception.Message, $_.Exception.Response.ResponseUri.AbsoluteUri | Write-Warning
+            return $null
         }
         else {
             throw $_

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
@@ -10,8 +10,8 @@ function Get-SdnServer {
         Specifies the resource reference for the resource.
     .PARAMETER Certificate
         Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
-	.PARAMETER Credential
-		Specifies a user account that has permission to perform this action. The default is the current user.
+    .PARAMETER Credential
+        Specifies a user account that has permission to perform this action. The default is the current user.
     .PARAMETER ManagementAddressOnly
         Optional parameter to only return back the Management Address value.
     .EXAMPLE

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
@@ -16,17 +16,17 @@ function Get-SdnServer {
     .PARAMETER ManagementAddressOnly
         Optional parameter to only return back the Management Address value.
     .EXAMPLE
-        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -Credential (Get-Credential)
+        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -NcRestCredential (Get-Credential)
     .EXAMPLE
-        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ManagementAddressOnly
+        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -NcRestCredential (Get-Credential) -ManagementAddressOnly
     .EXAMPLE
-        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceId 'f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e'
+        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -NcRestCredential (Get-Credential) -ResourceId 'f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e'
     .EXAMPLE
-        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceRef 'Servers/f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e'
+        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -NcRestCredential (Get-Credential) -ResourceRef 'Servers/f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e'
     .EXAMPLE
-        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceId 'f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e' -ManagementAddressOnly
+        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -NcRestCredential (Get-Credential) -ResourceId 'f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e' -ManagementAddressOnly
     .EXAMPLE
-        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -Credential (Get-Credential) -ResourceRef 'Servers/f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e' -ManagementAddressOnly
+        PS> Get-SdnServer -NcUri 'https://NC.FQDN' -NcRestCredential (Get-Credential) -ResourceRef 'Servers/f5e3b3e0-1b7a-4b9e-8b9e-5b5e3b3e0f5e' -ManagementAddressOnly
     #>
 
     [CmdletBinding(DefaultParameterSetName = 'Default')]

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
@@ -8,6 +8,8 @@ function Get-SdnServer {
         Specifies the unique identifier for the resource.
     .PARAMETER ResourceRef
         Specifies the resource reference for the resource.
+    .PARAMETER Certificate
+        Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
 	.PARAMETER Credential
 		Specifies a user account that has permission to perform this action. The default is the current user.
     .PARAMETER ManagementAddressOnly
@@ -42,6 +44,11 @@ function Get-SdnServer {
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
+        [X509Certificate]$Certificate,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
@@ -54,7 +61,13 @@ function Get-SdnServer {
 
     $params = @{
         NcUri = $NcUri
-        Credential = $Credential
+    }
+
+    if ($Certificate) {
+        $params.Add('Certificate', $Certificate)
+    }
+    else {
+        $params.Add('Credential', $Credential)
     }
 
     switch ($PSCmdlet.ParameterSetName) {

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnServer.ps1
@@ -8,10 +8,11 @@ function Get-SdnServer {
         Specifies the unique identifier for the resource.
     .PARAMETER ResourceRef
         Specifies the resource reference for the resource.
-    .PARAMETER Certificate
-        Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
-    .PARAMETER Credential
-        Specifies a user account that has permission to perform this action. The default is the current user.
+    .PARAMETER NcRestCertificate
+        Specifies the client certificate that is used for a secure web request to Network Controller REST API.
+        Enter a variable that contains a certificate or a command or expression that gets the certificate.
+    .PARAMETER NcRestCredential
+        Specifies a user account that has permission to perform this action against the Network Controller REST API. The default is the current user.
     .PARAMETER ManagementAddressOnly
         Optional parameter to only return back the Management Address value.
     .EXAMPLE
@@ -44,14 +45,14 @@ function Get-SdnServer {
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
-        [X509Certificate]$Certificate,
+        [X509Certificate]$NcRestCertificate,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        $NcRestCredential = [System.Management.Automation.PSCredential]::Empty,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
@@ -59,32 +60,29 @@ function Get-SdnServer {
         [switch]$ManagementAddressOnly
     )
 
-    $params = @{
+    $ncRestParams = @{
         NcUri = $NcUri
     }
-
-    if ($Certificate) {
-        $params.Add('Certificate', $Certificate)
+    if ($PSBoundParameters.ContainsKey('NcRestCertificate')) {
+        $ncRestParams.Add('NcRestCertificate', $NcRestCertificate)
     }
     else {
-        $params.Add('Credential', $Credential)
-    }
-
-    switch ($PSCmdlet.ParameterSetName) {
-        'ResourceId' {
-            $params.Add('Resource', 'Servers')
-            $params.Add('ResourceId', $ResourceId)
-        }
-        'ResourceRef' {
-            $params.Add('ResourceRef', $ResourceRef)
-        }
-        default {
-            $params.Add('Resource', 'Servers')
-        }
+        $ncRestParams.Add('NcRestCredential', $NcRestCredential)
     }
 
     try {
-        $result = Get-SdnResource @params
+        switch ($PSCmdlet.ParameterSetName) {
+            'ResourceId' {
+                $result = Get-SdnResource @ncRestParams -Resource 'Servers' -ResourceId $ResourceId
+            }
+            'ResourceRef' {
+                $result = Get-SdnResource @ncRestParams -ResourceRef $ResourceRef
+            }
+            default {
+                $result = Get-SdnResource @ncRestParams -Resource 'Servers'
+            }
+        }
+
         if ($result) {
             foreach($obj in $result){
                 if($obj.properties.provisioningState -ne 'Succeeded'){

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnSlbStateInformation.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnSlbStateInformation.ps1
@@ -8,9 +8,8 @@ function Get-SdnSlbStateInformation {
         Specifies the VIP address to return information for. If omitted, returns all VIPs.
 	.PARAMETER Credential
 		Specifies a user account that has permission to perform this action. The default is the current user.
-    .PARAMETER CertificateThumbprint
-        Specifies the digital public key certificate (X509) of a user account that has permission to send the request. Enter the certificate thumbprint of the certificate.
-        To see the certificate thumbprint, use the Get-Item or Get-ChildItem command to find the certificate in Cert:\CurrentUser\My.
+    .PARAMETER Certificate
+        Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
     .PARAMETER ExecutionTimeout
         Specify the timeout duration to wait before automatically terminated. If omitted, defaults to 600 seconds.
     .PARAMETER PollingInterval
@@ -38,8 +37,8 @@ function Get-SdnSlbStateInformation {
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'CertificateThumbprint')]
-        [System.String]$CertificateThumbprint,
+        [Parameter(Mandatory = $false, ParameterSetName = 'Certificate')]
+        [X509Certificate]$Certificate,
 
         [Parameter(Mandatory = $false)]
         [int]$ExecutionTimeOut = 600,
@@ -62,9 +61,9 @@ function Get-SdnSlbStateInformation {
         UseBasicParsing = $true
     }
 
-    if (-NOT [string]::IsNullOrEmpty($CertificateThumbprint)) {
-        $putParams.Add('CertificateThumbprint', $CertificateThumbprint)
-        $getParams.Add('CertificateThumbprint', $CertificateThumbprint)
+    if ($Certificate) {
+        $putParams.Add('Certificate', $Certificate)
+        $getParams.Add('Certificate', $Certificate)
     }
     else {
         $putParams.Add('Credential', $Credential)

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnSlbStateInformation.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnSlbStateInformation.ps1
@@ -58,7 +58,7 @@ function Get-SdnSlbStateInformation {
     }
 
     $getParams = @{
-        $uri            = $null
+        Uri             = $null
         UseBasicParsing = $true
     }
 

--- a/src/modules/SdnDiag.NetworkController/public/Invoke-SdnResourceDump.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Invoke-SdnResourceDump.ps1
@@ -4,19 +4,19 @@ function Invoke-SdnResourceDump {
         Performs API request to all available northbound endpoints for NC and dumps out the resources to json file.
     .PARAMETER NcUri
         Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
-    .PARAMETER Certificate
+    .PARAMETER NcRestCertificate
         Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
-	.PARAMETER Credential
+	.PARAMETER NcRestCredential
         Specifies a user account that has permission to perform this action. The default is the current user.
     .EXAMPLE
         PS> Invoke-SdnResourceDump
     .EXAMPLE
         PS> Invoke-SdnResourceDump -NcUri "https://nc.contoso.com"
     .EXAMPLE
-        PS> Invoke-SdnResourceDump -NcUri "https://nc.contoso.com" -Credential (Get-Credential)
+        PS> Invoke-SdnResourceDump -NcUri "https://nc.contoso.com" -NcRestCredential (Get-Credential)
     #>
 
-    [CmdletBinding(DefaultParameterSetName = 'Credential')]
+    [CmdletBinding(DefaultParameterSetName = 'RestCredential')]
     param (
         [Parameter(Mandatory = $true)]
         [Uri]$NcUri,
@@ -24,23 +24,25 @@ function Invoke-SdnResourceDump {
         [Parameter(Mandatory = $true)]
         [System.IO.FileInfo]$OutputDirectory,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Credential')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate')]
+        [X509Certificate]$NcRestCertificate,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestCredential')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
-
-        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
-        [X509Certificate]$Certificate
+        $NcRestCredential = [System.Management.Automation.PSCredential]::Empty
     )
 
     $params = @{
         NcUri = $NcUri
     }
-    if ($Certificate) {
-        $params.Add('Certificate', $Certificate)
-    }
-    else {
-        $params.Add('Credential', $Credential)
+    switch ($PSCmdlet.ParameterSetName) {
+        'RestCertificate' {
+            $params.Add('NcRestCertificate', $NcRestCertificate)
+        }
+        'RestCredential' {
+            $params.Add('NcRestCredential', $NcRestCredential)
+        }
     }
 
     try {

--- a/src/modules/SdnDiag.NetworkController/public/Invoke-SdnResourceDump.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Invoke-SdnResourceDump.ps1
@@ -4,6 +4,8 @@ function Invoke-SdnResourceDump {
         Performs API request to all available northbound endpoints for NC and dumps out the resources to json file.
     .PARAMETER NcUri
         Specifies the Uniform Resource Identifier (URI) of the network controller that all Representational State Transfer (REST) clients use to connect to that controller.
+    .PARAMETER Certificate
+        Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
 	.PARAMETER Credential
         Specifies a user account that has permission to perform this action. The default is the current user.
     .EXAMPLE
@@ -14,7 +16,7 @@ function Invoke-SdnResourceDump {
         PS> Invoke-SdnResourceDump -NcUri "https://nc.contoso.com" -Credential (Get-Credential)
     #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Credential')]
     param (
         [Parameter(Mandatory = $true)]
         [Uri]$NcUri,
@@ -22,11 +24,24 @@ function Invoke-SdnResourceDump {
         [Parameter(Mandatory = $true)]
         [System.IO.FileInfo]$OutputDirectory,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Credential')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
+        [X509Certificate]$Certificate
     )
+
+    $params = @{
+        NcUri = $NcUri
+    }
+    if ($Certificate) {
+        $params.Add('Certificate', $Certificate)
+    }
+    else {
+        $params.Add('Credential', $Credential)
+    }
 
     try {
         "Generating resource dump for Network Controller NB API endpoints" | Trace-Output
@@ -35,7 +50,7 @@ function Invoke-SdnResourceDump {
             $null = New-Item -Path $outputDir.FullName -ItemType Directory -Force
         }
 
-        $apiVersion = (Get-SdnDiscovery -NcUri $NcUri.AbsoluteUri -Credential $Credential).currentRestVersion
+        $apiVersion = (Get-SdnDiscovery @params).currentRestVersion
         if ($null -ieq $apiVersion) {
             $apiVersion = 'v1'
         }
@@ -46,6 +61,13 @@ function Invoke-SdnResourceDump {
         foreach ($key in $config.properties.apiResources.Keys) {
             $value = $config.Properties.apiResources[$key]
 
+            if ($params.ContainsKey('ResourceRef')) {
+                $params.ResourceRef = $value.uri
+            }
+            else {
+                $params.Add('ResourceRef', $value.uri)
+            }
+
             # skip any resources that are not designed to be exported
             if ($value.includeInResourceDump -ieq $false) {
                 continue
@@ -53,7 +75,7 @@ function Invoke-SdnResourceDump {
 
             [int]$minVersionInt = $value.minVersion.Replace('v','').Replace('V','')
             if ($minVersionInt -le $apiVersionInt) {
-                $sdnResource = Get-SdnResource -NcUri $NcUri.AbsoluteUri -ResourceRef $value.uri -Credential $Credential
+                $sdnResource = Get-SdnResource @params
                 if ($sdnResource) {
 
                     # parse the value if we are enumerating credentials property as we

--- a/src/modules/SdnDiag.NetworkController/public/Invoke-SdnResourceDump.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Invoke-SdnResourceDump.ps1
@@ -75,7 +75,18 @@ function Invoke-SdnResourceDump {
 
             [int]$minVersionInt = $value.minVersion.Replace('v','').Replace('V','')
             if ($minVersionInt -le $apiVersionInt) {
-                $sdnResource = Get-SdnResource @params
+
+                # because we do not know what resources are available, we need to catch any exceptions
+                # that may occur when trying to get the resource
+                # in events we log a warning, we just want to redirect the warning stream to null
+                try {
+                    $sdnResource = Get-SdnResource @params 3>$null
+                }
+                catch {
+                    $_ | Trace-Exception
+                    continue
+                }
+
                 if ($sdnResource) {
 
                     # parse the value if we are enumerating credentials property as we

--- a/src/modules/SdnDiag.NetworkController/public/Set-SdnResource.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Set-SdnResource.ps1
@@ -14,9 +14,8 @@ function Set-SdnResource {
         The API version to use when invoking against the NC REST API endpoint.
     .PARAMETER Credential
         Specifies a user account that has permission to perform this action. The default is the current user.
-    .PARAMETER CertificateThumbprint
-        Specifies the digital public key certificate (X509) of a user account that has permission to send the request. Enter the certificate thumbprint of the certificate.
-        To see the certificate thumbprint, use the Get-Item or Get-ChildItem command to find the certificate in Cert:\CurrentUser\My.
+    .PARAMETER Certificate
+        Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
     .EXAMPLE
         PS> Set-SdnResource -NcUri "https://nc.$env:USERDNSDOMAIN" -ResourceRef "/networkInterfaces/contoso-nic1" -Object $object
     .EXAMPLE
@@ -54,7 +53,7 @@ function Set-SdnResource {
 
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Resource')]
-        [System.String]$CertificateThumbprint
+        [X509Certificate]$Certificate
     )
 
     $restParams = @{
@@ -71,9 +70,9 @@ function Set-SdnResource {
         ErrorAction = 'Stop'
     }
 
-    if (-NOT [string]::IsNullOrEmpty($CertificateThumbprint)) {
-        $restParams.Add('CertificateThumbprint', $CertificateThumbprint)
-        $confirmParams.Add('CertificateThumbprint', $CertificateThumbprint)
+    if ($Certificate) {
+        $restParams.Add('Certificate', $Certificate)
+        $confirmParams.Add('Certificate', $Certificate)
     }
     else {
         $restParams.Add('Credential', $Credential)

--- a/src/modules/SdnDiag.NetworkController/public/Set-SdnResource.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Set-SdnResource.ps1
@@ -14,6 +14,9 @@ function Set-SdnResource {
         The API version to use when invoking against the NC REST API endpoint.
     .PARAMETER Credential
         Specifies a user account that has permission to perform this action. The default is the current user.
+    .PARAMETER CertificateThumbprint
+        Specifies the digital public key certificate (X509) of a user account that has permission to send the request. Enter the certificate thumbprint of the certificate.
+        To see the certificate thumbprint, use the Get-Item or Get-ChildItem command to find the certificate in Cert:\CurrentUser\My.
     .EXAMPLE
         PS> Set-SdnResource -NcUri "https://nc.$env:USERDNSDOMAIN" -ResourceRef "/networkInterfaces/contoso-nic1" -Object $object
     .EXAMPLE
@@ -49,7 +52,8 @@ function Set-SdnResource {
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Resource')]
         [System.String]$CertificateThumbprint
     )
 

--- a/src/modules/SdnDiag.NetworkController/public/Set-SdnResource.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Set-SdnResource.ps1
@@ -12,10 +12,11 @@ function Set-SdnResource {
         Specify the unique ID of the resource.
     .PARAMETER ApiVersion
         The API version to use when invoking against the NC REST API endpoint.
-    .PARAMETER Credential
-        Specifies a user account that has permission to perform this action. The default is the current user.
-    .PARAMETER Certificate
-        Specifies the client certificate that is used for a secure web request. Enter a variable that contains a certificate or a command or expression that gets the certificate.
+    .PARAMETER NcRestCertificate
+        Specifies the client certificate that is used for a secure web request to Network Controller REST API.
+        Enter a variable that contains a certificate or a command or expression that gets the certificate.
+    .PARAMETER NcRestCredential
+        Specifies a user account that has permission to perform this action against the Network Controller REST API. The default is the current user.
     .EXAMPLE
         PS> Set-SdnResource -NcUri "https://nc.$env:USERDNSDOMAIN" -ResourceRef "/networkInterfaces/contoso-nic1" -Object $object
     .EXAMPLE
@@ -49,11 +50,11 @@ function Set-SdnResource {
         [Parameter(Mandatory = $false, ParameterSetName = 'Resource')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty,
+        $NcRestCredential = [System.Management.Automation.PSCredential]::Empty,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Resource')]
-        [X509Certificate]$Certificate
+        [X509Certificate]$NcRestCertificate
     )
 
     $restParams = @{
@@ -63,35 +64,44 @@ function Set-SdnResource {
         ErrorAction = 'Stop'
     }
 
+    $putRestParams = @{
+        Uri     = $null
+        Method  = 'Put'
+        UseBasicParsing = $true
+        ErrorAction = 'Stop'
+        Body = $null
+        Headers = @{"Accept"="application/json"}
+        ContentType = "application/json; charset=UTF-8"
+    }
+
     $confirmParams = @{
-        Uri = $null
         TimeoutInSec = 300
         UseBasicParsing = $true
         ErrorAction = 'Stop'
     }
 
-    if ($Certificate) {
-        $restParams.Add('Certificate', $Certificate)
-        $confirmParams.Add('Certificate', $Certificate)
+    if ($PSBoundParameters.ContainsKey('NcRestCertificate')) {
+        $restParams.Add('Certificate', $NcRestCertificate)
+        $confirmParams.Add('Certificate', $NcRestCertificate)
     }
     else {
-        $restParams.Add('Credential', $Credential)
-        $confirmParams.Add('Credential', $Credential)
+        $restParams.Add('Credential', $NcRestCredential)
+        $confirmParams.Add('Credential', $NcRestCredential)
     }
 
     try {
         switch ($PSCmdlet.ParameterSetName) {
             'ResourceRef' {
-                [System.String]$uri = Get-SdnApiEndpoint -NcUri $NcUri.AbsoluteUri -ApiVersion $ApiVersion -ResourceRef $ResourceRef
+                [System.String]$uri = Get-SdnApiEndpoint -NcUri $NcUri -ApiVersion $ApiVersion -ResourceRef $ResourceRef
             }
             'Resource' {
-                [System.String]$uri = Get-SdnApiEndpoint -NcUri $NcUri.AbsoluteUri -ApiVersion $ApiVersion -ResourceName $Resource
+                [System.String]$uri = Get-SdnApiEndpoint -NcUri $NcUri -ApiVersion $ApiVersion -ResourceName $Resource
                 [System.String]$uri = "{0}/{1}" -f $uri, $ResourceId.Trim()
             }
         }
 
+        $putRestParams.Uri = $uri
         $restParams.Uri = $uri
-        $confirmParams.Uri = $uri
 
         # perform a query against the resource to ensure it exists
         # as we only support operations against existing resources within this function
@@ -112,16 +122,14 @@ function Set-SdnResource {
 
         $modifiedObject = Remove-PropertiesFromObject -Object $Object -PropertiesToRemove @('ConfigurationState','ProvisioningState')
         $jsonBody = $modifiedObject | ConvertTo-Json -Depth 100
+        $putRestParams.Body = $jsonBody
 
-        $restParams.Method = 'Put'
-        $restParams.Add('Body', $jsonBody )
-        $restParams.Add('Headers', @{"Accept"="application/json"})
-        $restParams.Add('ContentType', "application/json; charset=UTF-8")
-
-        if ($PSCmdlet.ShouldProcess($uri, "Invoke-RestMethod will be called with PUT to configure the properties of $uri`n`t$jsonBody")) {
-            $null = Invoke-RestMethodWithRetry @restParams
-            $resourceState = Confirm-ProvisioningStateSucceeded @confirmParams
-            return $resourceState
+        if ($PSCmdlet.ShouldProcess($uri, "Invoke-RestMethod will be called with PUT to configure the properties of $($putRestParams.Uri)`n`t$jsonBody")) {
+            $null = Invoke-RestMethodWithRetry @putRestParams
+            if (Confirm-ProvisioningStateSucceeded -Uri $putRestParams.Uri @confirmParams) {
+                $result = Invoke-RestMethodWithRetry @restParams
+                return $result
+            }
         }
     }
     catch [System.Net.WebException] {

--- a/src/modules/SdnDiag.NetworkController/public/Set-SdnResource.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Set-SdnResource.ps1
@@ -82,11 +82,11 @@ function Set-SdnResource {
 
     if ($PSBoundParameters.ContainsKey('NcRestCertificate')) {
         $restParams.Add('Certificate', $NcRestCertificate)
-        $confirmParams.Add('Certificate', $NcRestCertificate)
+        $confirmParams.Add('NcRestCertificate', $NcRestCertificate)
     }
     else {
         $restParams.Add('Credential', $NcRestCredential)
-        $confirmParams.Add('Credential', $NcRestCredential)
+        $confirmParams.Add('NcRestCredential', $NcRestCredential)
     }
 
     try {
@@ -126,7 +126,7 @@ function Set-SdnResource {
 
         if ($PSCmdlet.ShouldProcess($uri, "Invoke-RestMethod will be called with PUT to configure the properties of $($putRestParams.Uri)`n`t$jsonBody")) {
             $null = Invoke-RestMethodWithRetry @putRestParams
-            if (Confirm-ProvisioningStateSucceeded -Uri $putRestParams.Uri @confirmParams) {
+            if (Confirm-ProvisioningStateSucceeded -NcUri $putRestParams.Uri @confirmParams) {
                 $result = Invoke-RestMethodWithRetry @restParams
                 return $result
             }

--- a/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
+++ b/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
@@ -95,6 +95,7 @@ function Start-SdnServerCertificateRotation {
         }
     }
 
+    $array = @()
     $ncRestParams = @{
         NcUri = $null
     }

--- a/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
+++ b/src/modules/SdnDiag.Server/public/Start-SdnServerCertificateRotation.ps1
@@ -113,16 +113,16 @@ function Start-SdnServerCertificateRotation {
 
     if ($PSBoundParameters.ContainsKey('NcRestCertificate')) {
         $restCredParam = @{ NcRestCertificate = $NcRestCertificate }
-        $confirmStateParams.Add('Certificate', $NcRestCertificate)
         $ncRestParams.Add('NcRestCertificate', $NcRestCertificate)
         $putRestParams.Add('Certificate', $NcRestCertificate)
     }
     else {
         $restCredParam = @{ NcRestCredential = $NcRestCredential }
-        $confirmStateParams.Add('Credential', $NcRestCredential)
         $ncRestParams.Add('NcRestCredential', $NcRestCredential)
         $putRestParams.Add('Credential', $NcRestCredential)
     }
+    $confirmStateParams += $restCredParam
+
 
     try {
         "Starting certificate rotation" | Trace-Output
@@ -204,7 +204,7 @@ function Start-SdnServerCertificateRotation {
             $putRestParams.Uri = $endpoint
 
             $null = Invoke-RestMethodWithRetry @putRestParams
-            if (-NOT (Confirm-ProvisioningStateSucceeded -Uri $putRestParams.Uri @confirmStateParams)) {
+            if (-NOT (Confirm-ProvisioningStateSucceeded -NcUri $putRestParams.Uri @confirmStateParams)) {
                 throw New-Object System.Exception("ProvisioningState is not succeeded")
             }
             else {

--- a/src/modules/SdnDiag.Utilities/private/Confirm-ProvisioningStateSucceeded.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Confirm-ProvisioningStateSucceeded.ps1
@@ -27,7 +27,7 @@ function Confirm-ProvisioningStateSucceeded {
     )
 
     $params = @{
-        Uri              = $Uri
+        Uri              = $NcUri
         DisableKeepAlive = $DisableKeepAlive
         UseBasicParsing  = $UseBasicParsing
         Method           = 'Get'

--- a/src/modules/SdnDiag.Utilities/private/Confirm-ProvisioningStateSucceeded.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Confirm-ProvisioningStateSucceeded.ps1
@@ -4,17 +4,17 @@ function Confirm-ProvisioningStateSucceeded {
         Used to verify the resource within the NC NB API is succeeded
     #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'RestCredential')]
     param(
         [Parameter(Mandatory = $true)]
-        [System.Uri]$Uri,
+        [System.Uri]$NcUri,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestCredential')]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]$Credential,
+        [System.Management.Automation.Credential()]$NcRestCredential,
 
-        [Parameter(Mandatory = $false)]
-        [X509Certificate]$Certificate,
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestCertificate')]
+        [X509Certificate]$NcRestCertificate,
 
         [Parameter(Mandatory = $false)]
         [Switch]$DisableKeepAlive,
@@ -34,11 +34,13 @@ function Confirm-ProvisioningStateSucceeded {
         ErrorAction      = 'Stop'
     }
 
-    if ($Certificate) {
-        $params.Add('Certificate', $Certificate)
-    }
-    else {
-        $params.Add('Credential', $Credential)
+    switch ($PSCmdlet.ParameterSetName) {
+        'RestCertificate' {
+            $params.Add('Certificate', $NcRestCertificate)
+        }
+        'RestCredential' {
+            $params.Add('Credential', $NcRestCredential)
+        }
     }
 
     $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()

--- a/src/modules/SdnDiag.Utilities/private/Confirm-ProvisioningStateSucceeded.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Confirm-ProvisioningStateSucceeded.ps1
@@ -14,7 +14,7 @@ function Confirm-ProvisioningStateSucceeded {
         [System.Management.Automation.Credential()]$Credential,
 
         [Parameter(Mandatory = $false)]
-        [System.String]$CertificateThumbprint,
+        [X509Certificate]$Certificate,
 
         [Parameter(Mandatory = $false)]
         [Switch]$DisableKeepAlive,
@@ -34,8 +34,8 @@ function Confirm-ProvisioningStateSucceeded {
         ErrorAction      = 'Stop'
     }
 
-    if (-NOT [string]::IsNullOrEmpty($CertificateThumbprint)) {
-        $params.Add('CertificateThumbprint', $CertificateThumbprint)
+    if ($Certificate) {
+        $params.Add('Certificate', $Certificate)
     }
     else {
         $params.Add('Credential', $Credential)

--- a/src/modules/SdnDiag.Utilities/private/Invoke-RestMethodWithRetry.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Invoke-RestMethodWithRetry.ps1
@@ -1,6 +1,6 @@
 function Invoke-RestMethodWithRetry {
 
-    [CmdletBinding(DefaultParameterSetName = 'Credential')]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
         [System.Uri]$Uri,
@@ -23,10 +23,10 @@ function Invoke-RestMethodWithRetry {
         [Parameter(Mandatory = $false)]
         [Switch] $UseBasicParsing,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Certificate')]
+        [Parameter(Mandatory = $false)]
         [System.String]$CertificateThumbprint,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Credential')]
+        [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]$Credential,
 
@@ -36,10 +36,10 @@ function Invoke-RestMethodWithRetry {
         [Parameter(Mandatory = $false)]
         [Switch]$Retry,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Retry')]
+        [Parameter(Mandatory = $false)]
         [Int]$MaxRetry = 3,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Retry')]
+        [Parameter(Mandatory = $false)]
         [Int]$RetryIntervalInSeconds = 30
     )
 
@@ -63,17 +63,15 @@ function Invoke-RestMethodWithRetry {
         $params.Add('UseBasicParsing', $true)
     }
 
-    switch ($PSCmdlet.ParameterSetName) {
-        'Certificate' {
-            $params.Add('CertificateThumbprint', $CertificateThumbprint)
+    if (-NOT [string]::IsNullOrEmpty($CertificateThumbprint)) {
+        $params.Add('CertificateThumbprint', $CertificateThumbprint)
+    }
+    else {
+        if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
+            $params.Add('Credential', $Credential)
         }
-        'Credential' {
-            if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
-                $params.Add('Credential', $Credential)
-            }
-            else {
-                $params.Add('UseDefaultCredentials', $true)
-            }
+        else {
+            $params.Add('UseDefaultCredentials', $true)
         }
     }
 

--- a/src/modules/SdnDiag.Utilities/private/Invoke-RestMethodWithRetry.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Invoke-RestMethodWithRetry.ps1
@@ -1,4 +1,6 @@
 function Invoke-RestMethodWithRetry {
+
+    [CmdletBinding(DefaultParameterSetName = 'Credential')]
     param(
         [Parameter(Mandatory = $true)]
         [System.Uri]$Uri,
@@ -21,7 +23,10 @@ function Invoke-RestMethodWithRetry {
         [Parameter(Mandatory = $false)]
         [Switch] $UseBasicParsing,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Certificate')]
+        [System.String]$CertificateThumbprint,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Credential')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]$Credential,
 
@@ -58,11 +63,18 @@ function Invoke-RestMethodWithRetry {
         $params.Add('UseBasicParsing', $true)
     }
 
-    if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
-        $params.Add('Credential', $Credential)
-    }
-    else {
-        $params.Add('UseDefaultCredentials', $true)
+    switch ($PSCmdlet.ParameterSetName) {
+        'Certificate' {
+            $params.Add('CertificateThumbprint', $CertificateThumbprint)
+        }
+        'Credential' {
+            if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
+                $params.Add('Credential', $Credential)
+            }
+            else {
+                $params.Add('UseDefaultCredentials', $true)
+            }
+        }
     }
 
     $counter = 0

--- a/src/modules/SdnDiag.Utilities/private/Invoke-RestMethodWithRetry.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Invoke-RestMethodWithRetry.ps1
@@ -24,7 +24,7 @@ function Invoke-RestMethodWithRetry {
         [Switch] $UseBasicParsing,
 
         [Parameter(Mandatory = $false)]
-        [System.String]$CertificateThumbprint,
+        [X509Certificate]$Certificate,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
@@ -63,8 +63,8 @@ function Invoke-RestMethodWithRetry {
         $params.Add('UseBasicParsing', $true)
     }
 
-    if (-NOT [string]::IsNullOrEmpty($CertificateThumbprint)) {
-        $params.Add('CertificateThumbprint', $CertificateThumbprint)
+    if ($Certificate) {
+        $params.Add('Certificate', $Certificate)
     }
     else {
         if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {

--- a/src/modules/SdnDiag.Utilities/private/Invoke-RestMethodWithRetry.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Invoke-RestMethodWithRetry.ps1
@@ -1,6 +1,6 @@
 function Invoke-RestMethodWithRetry {
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Credential')]
     param(
         [Parameter(Mandatory = $true)]
         [System.Uri]$Uri,
@@ -23,10 +23,10 @@ function Invoke-RestMethodWithRetry {
         [Parameter(Mandatory = $false)]
         [Switch] $UseBasicParsing,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
         [X509Certificate]$Certificate,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Credential')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]$Credential,
 
@@ -55,23 +55,25 @@ function Invoke-RestMethodWithRetry {
         $params.Add('Body', $Body)
     }
 
-    if ($DisableKeepAlive.IsPresent) {
+    if ($DisableKeepAlive) {
         $params.Add('DisableKeepAlive', $true)
     }
 
-    if ($UseBasicParsing.IsPresent) {
+    if ($UseBasicParsing) {
         $params.Add('UseBasicParsing', $true)
     }
 
-    if ($Certificate) {
-        $params.Add('Certificate', $Certificate)
-    }
-    else {
-        if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
-            $params.Add('Credential', $Credential)
+    switch ($PSCmdlet.ParameterSetName) {
+        'Certificate' {
+            $params.Add('Certificate', $Certificate)
         }
-        else {
-            $params.Add('UseDefaultCredentials', $true)
+        'Credential' {
+            if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
+                $params.Add('Credential', $Credential)
+            }
+            else {
+                $params.Add('UseDefaultCredentials', $true)
+            }
         }
     }
 

--- a/src/modules/SdnDiag.Utilities/private/Invoke-WebRequestWithRetry.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Invoke-WebRequestWithRetry.ps1
@@ -1,6 +1,6 @@
 function Invoke-WebRequestWithRetry {
 
-    [CmdletBinding(DefaultParameterSetName = 'Credential')]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
         [System.Uri]$Uri,
@@ -23,23 +23,23 @@ function Invoke-WebRequestWithRetry {
         [Parameter(Mandatory = $false)]
         [Switch] $UseBasicParsing,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Certificate')]
+        [Parameter(Mandatory = $false)]
         [System.String]$CertificateThumbprint,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Credential')]
+        [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]$Credential,
 
         [Parameter(Mandatory = $false)]
         [int]$TimeoutInSec = 600,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Retry')]
+        [Parameter(Mandatory = $false)]
         [Switch]$Retry,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Retry')]
+        [Parameter(Mandatory = $false)]
         [Int]$MaxRetry = 3,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'Retry')]
+        [Parameter(Mandatory = $false)]
         [Int]$RetryIntervalInSeconds = 30
     )
 
@@ -63,17 +63,15 @@ function Invoke-WebRequestWithRetry {
         $params.Add('UseBasicParsing', $true)
     }
 
-    switch ($PSCmdlet.ParameterSetName) {
-        'Certificate' {
-            $params.Add('CertificateThumbprint', $CertificateThumbprint)
+    if (-NOT [string]::IsNullOrEmpty($CertificateThumbprint)) {
+        $params.Add('CertificateThumbprint', $CertificateThumbprint)
+    }
+    else {
+        if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
+            $params.Add('Credential', $Credential)
         }
-        'Credential' {
-            if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
-                $params.Add('Credential', $Credential)
-            }
-            else {
-                $params.Add('UseDefaultCredentials', $true)
-            }
+        else {
+            $params.Add('UseDefaultCredentials', $true)
         }
     }
 

--- a/src/modules/SdnDiag.Utilities/private/Invoke-WebRequestWithRetry.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Invoke-WebRequestWithRetry.ps1
@@ -24,7 +24,7 @@ function Invoke-WebRequestWithRetry {
         [Switch] $UseBasicParsing,
 
         [Parameter(Mandatory = $false)]
-        [System.String]$CertificateThumbprint,
+        [X509Certificate]$Certificate,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
@@ -63,8 +63,8 @@ function Invoke-WebRequestWithRetry {
         $params.Add('UseBasicParsing', $true)
     }
 
-    if (-NOT [string]::IsNullOrEmpty($CertificateThumbprint)) {
-        $params.Add('CertificateThumbprint', $CertificateThumbprint)
+    if ($Certificate) {
+        $params.Add('Certificate', $Certificate)
     }
     else {
         if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {

--- a/src/modules/SdnDiag.Utilities/private/Invoke-WebRequestWithRetry.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Invoke-WebRequestWithRetry.ps1
@@ -1,4 +1,6 @@
 function Invoke-WebRequestWithRetry {
+
+    [CmdletBinding(DefaultParameterSetName = 'Credential')]
     param(
         [Parameter(Mandatory = $true)]
         [System.Uri]$Uri,
@@ -21,7 +23,10 @@ function Invoke-WebRequestWithRetry {
         [Parameter(Mandatory = $false)]
         [Switch] $UseBasicParsing,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Certificate')]
+        [System.String]$CertificateThumbprint,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Credential')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]$Credential,
 
@@ -58,11 +63,18 @@ function Invoke-WebRequestWithRetry {
         $params.Add('UseBasicParsing', $true)
     }
 
-    if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
-        $params.Add('Credential', $Credential)
-    }
-    else {
-        $params.Add('UseDefaultCredentials', $true)
+    switch ($PSCmdlet.ParameterSetName) {
+        'Certificate' {
+            $params.Add('CertificateThumbprint', $CertificateThumbprint)
+        }
+        'Credential' {
+            if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
+                $params.Add('Credential', $Credential)
+            }
+            else {
+                $params.Add('UseDefaultCredentials', $true)
+            }
+        }
     }
 
     $counter = 0

--- a/src/modules/SdnDiag.Utilities/private/Invoke-WebRequestWithRetry.ps1
+++ b/src/modules/SdnDiag.Utilities/private/Invoke-WebRequestWithRetry.ps1
@@ -1,6 +1,6 @@
 function Invoke-WebRequestWithRetry {
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Credential')]
     param(
         [Parameter(Mandatory = $true)]
         [System.Uri]$Uri,
@@ -23,10 +23,10 @@ function Invoke-WebRequestWithRetry {
         [Parameter(Mandatory = $false)]
         [Switch] $UseBasicParsing,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
         [X509Certificate]$Certificate,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Credential')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]$Credential,
 
@@ -55,23 +55,25 @@ function Invoke-WebRequestWithRetry {
         $params.Add('Body', $Body)
     }
 
-    if ($DisableKeepAlive.IsPresent) {
+    if ($DisableKeepAlive) {
         $params.Add('DisableKeepAlive', $true)
     }
 
-    if ($UseBasicParsing.IsPresent) {
+    if ($UseBasicParsing) {
         $params.Add('UseBasicParsing', $true)
     }
 
-    if ($Certificate) {
-        $params.Add('Certificate', $Certificate)
-    }
-    else {
-        if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
-            $params.Add('Credential', $Credential)
+    switch ($PSCmdlet.ParameterSetName) {
+        'Certificate' {
+            $params.Add('Certificate', $Certificate)
         }
-        else {
-            $params.Add('UseDefaultCredentials', $true)
+        'Credential' {
+            if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
+                $params.Add('Credential', $Credential)
+            }
+            else {
+                $params.Add('UseDefaultCredentials', $true)
+            }
         }
     }
 


### PR DESCRIPTION
# Description
Summary of changes:
- Enabled x509 authentication to be used when validating against REST endpoint for NC API: `-NcRestCertificate`
- Standardized all functions that interact with REST endpoint to use the following parameter names:
    - `NcRestCredential`
    - `NcRestCertificate`
- Fixed logic handling for several functions
- Fixed issue with determining FCNC clusters

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [x] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.