### PR TITLE
Improvements and code fixes to certificate rotate

### DIFF
--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -444,6 +444,13 @@ function Start-SdnCertificateRotation {
 
                     "[REST CERT] Installing self-signed certificate to {0}" -f ($southBoundNodes -join ', ') | Trace-Output
                     [System.String]$remoteFilePath = Join-Path -Path $CertPath.FullName -ChildPath $selfSignedRestCertFile.Name
+                    Invoke-PSRemoteCommand -ComputerName $southBoundNodes -Credential $Credential -ScriptBlock {
+                        param($arg0)
+                        if (-NOT (Test-Path -Path $arg0 -PathType Container)) {
+                            $null = New-Item -Path $arg0 -ItemType Directory -Force
+                        }
+                    } -ArgumentList @($CertPath.FullName)
+
                     Copy-FileToRemoteComputer -ComputerName $southBoundNodes -Credential $Credential -Path $selfSignedRestCertFile.FullName -Destination $remoteFilePath
                     $null = Invoke-PSRemoteCommand -ComputerName $southBoundNodes -Credential $Credential -ScriptBlock {
                         param([Parameter(Position = 0)][String]$param1, [Parameter(Position = 1)][String]$param2)

--- a/src/modules/SdnDiag.NetworkController.SF/private/Invoke-CertRotateCommand.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/private/Invoke-CertRotateCommand.ps1
@@ -110,8 +110,8 @@ function Invoke-CertRotateCommand {
         # then invoke the command to start the certificate rotate
         try {
             if ($waitBeforeRetry) {
-                "Waiting 2 minutes before retrying operation..." | Trace-Output
-                Start-Sleep -Seconds 120
+                "Waiting 5 minutes before retrying operation..." | Trace-Output
+                Start-Sleep -Seconds 300
             }
 
             "Invoking {0} to configure thumbprint {1}" -f $Command, $cert.Thumbprint | Trace-Output
@@ -155,6 +155,20 @@ function Invoke-CertRotateCommand {
                 $waitBeforeRetry = $true
             }
             else {
+                $stopWatch.Stop()
+                throw $_
+            }
+        }
+        catch [System.Management.Automation.ErrorRecord] {
+            switch -Wildcard ($_.Exception) {
+                '*The I/O operation has been aborted because of either a thread exit or an application request*' {
+                    "Retryable exception caught`n`t$_" | Trace-Output -Level:Warning
+                    $waitBeforeRetry = $true
+                    break
+                }
+            }
+
+            default {
                 $stopWatch.Stop()
                 throw $_
             }

--- a/src/modules/SdnDiag.NetworkController.SF/private/Start-SdnExpiredCertificateRotation.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/private/Start-SdnExpiredCertificateRotation.ps1
@@ -84,6 +84,7 @@ function Start-SdnExpiredCertificateRotation {
     }
 
     # stop service fabric service
+    Trace-Output -Message "Stopping Service Fabric Service"
     $stopSfService = Invoke-PSRemoteCommand -ComputerName $NcNodeList.IpAddressOrFQDN -Credential $Credential -ScriptBlock $stopServiceFabricSB `
     -AsJob -PassThru -Activity 'Stopping Service Fabric Service on Network Controller' -ExecutionTimeOut 900
 

--- a/src/modules/SdnDiag.NetworkController.SF/private/Start-SdnExpiredCertificateRotation.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/private/Start-SdnExpiredCertificateRotation.ps1
@@ -47,18 +47,14 @@ function Start-SdnExpiredCertificateRotation {
     }
 
     $NcInfraInfo = Get-SdnNetworkControllerInfoOffline -Credential $Credential
-    Trace-Output -Message "Network Controller Infrastrucutre Info detected:"
-    Trace-Output -Message "ClusterCredentialType: $($NcInfraInfo.ClusterCredentialType)"
-    Trace-Output -Message "NcRestName: $($NcInfraInfo.NcRestName)"
-
+    Trace-Output -Message "Network Controller information detected detected:`n`tClusterCredentialType: {0}`n`tRestName: {1}" -f $NcInfraInfo.ClusterCredentialType, $NcInfraInfo.NcRestName
     $NcNodeList = $NcInfraInfo.NodeList
 
     if ($null -eq $NcNodeList -or $NcNodeList.Count -eq 0) {
-        Trace-Output -Message "Failed to get NC Node List from NetworkController: $(HostName)" -Level:Error
+        throw New-Object System.NullReferenceException("Failed to get NC Node List from NetworkController: $(HostName)")
     }
 
     Trace-Output -Message "NcNodeList: $($NcNodeList.IpAddressOrFQDN)"
-
     Trace-Output -Message "Validate CertRotateConfig"
     if(!(Test-SdnCertificateRotationConfig -NcNodeList $NcNodeList -CertRotateConfig $CertRotateConfig -Credential $Credential)){
         Trace-Output -Message "Invalid CertRotateConfig, please correct the configuration and try again" -Level:Error

--- a/src/modules/SdnDiag.NetworkController.SF/private/Start-SdnExpiredCertificateRotation.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/private/Start-SdnExpiredCertificateRotation.ps1
@@ -47,7 +47,7 @@ function Start-SdnExpiredCertificateRotation {
     }
 
     $NcInfraInfo = Get-SdnNetworkControllerInfoOffline -Credential $Credential
-    Trace-Output -Message "Network Controller information detected detected:`n`tClusterCredentialType: {0}`n`tRestName: {1}" -f $NcInfraInfo.ClusterCredentialType, $NcInfraInfo.NcRestName
+    Trace-Output -Message "Network Controller information detected:`n`tClusterCredentialType: {0}`n`tRestName: {1}" -f $NcInfraInfo.ClusterCredentialType, $NcInfraInfo.NcRestName
     $NcNodeList = $NcInfraInfo.NodeList
 
     if ($null -eq $NcNodeList -or $NcNodeList.Count -eq 0) {

--- a/src/modules/SdnDiag.NetworkController.SF/private/Wait-ServiceFabricClusterHealthy.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/private/Wait-ServiceFabricClusterHealthy.ps1
@@ -91,7 +91,7 @@ function Wait-ServiceFabricClusterHealthy {
                     }
                 }
                 if ($allServiceHealth -and $services.Count -gt 0) {
-                    "All service fabric service has been healthy" | Trace-Output -Level:Warning
+                    "All service fabric services marked healthy" | Trace-Output
                     return $allServiceHealth
                 }
 


### PR DESCRIPTION
# Description
Summary of changes:
- When calling `Stop-Service` for FabricHostSvc, now executing async to speed up processing across multiple network controllers.
- Fixed an issue where certificate is not copied to southbound devices due to directory not existing
- Cleaned up logging and corrected typo
- Updated to throw terminating exception if unable to locate nc node list, rather than just write an error.
- Add new retryable exception for Set-NetworkController as well as increase wait between retries to 5 minutes

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.