### PR TITLE
Fix issues with certificate rotation

### DIFF
--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -460,6 +460,11 @@ function Start-SdnCertificateRotation {
                     # ensure that we have the latest version of sdnDiagnostics module on the southbound devices
                     Install-SdnDiagnostics -ComputerName $southBoundNodes -Credential $Credential -ErrorAction Stop
 
+                    if ($selfSignedRestCertFile.Extension -ieq '.pfx') {
+                        $cerName = $selfSignedRestCertFile.Name.Replace('.pfx', '.cer').Replace('_','.')
+                        $selfSignedRestCertFile = Get-ChildItem -Path (Split-Path -Path $selfSignedRestCertFile.FullName -Parent) | Where-Object {$_.Name -ilike "*$cerName"}
+                    }
+
                     "[REST CERT] Installing self-signed certificate to {0}" -f ($southBoundNodes -join ', ') | Trace-Output
                     [System.String]$remoteFilePath = Join-Path -Path $CertPath.FullName -ChildPath $selfSignedRestCertFile.Name
                     Invoke-PSRemoteCommand -ComputerName $southBoundNodes -Credential $Credential -ScriptBlock {

--- a/src/modules/SdnDiag.NetworkController.SF/private/Invoke-CertRotateCommand.ps1
+++ b/src/modules/SdnDiag.NetworkController.SF/private/Invoke-CertRotateCommand.ps1
@@ -143,6 +143,12 @@ function Invoke-CertRotateCommand {
                     break
                 }
 
+                '*The I/O operation has been aborted because of either a thread exit or an application request*' {
+                    "Retryable exception caught`n`t$_" | Trace-Output -Level:Warning
+                    $waitBeforeRetry = $true
+                    break
+                }
+
                 default {
                     $stopWatch.Stop()
                     throw $_
@@ -155,20 +161,6 @@ function Invoke-CertRotateCommand {
                 $waitBeforeRetry = $true
             }
             else {
-                $stopWatch.Stop()
-                throw $_
-            }
-        }
-        catch [System.Management.Automation.ErrorRecord] {
-            switch -Wildcard ($_.Exception) {
-                '*The I/O operation has been aborted because of either a thread exit or an application request*' {
-                    "Retryable exception caught`n`t$_" | Trace-Output -Level:Warning
-                    $waitBeforeRetry = $true
-                    break
-                }
-            }
-
-            default {
                 $stopWatch.Stop()
                 throw $_
             }

--- a/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNodeCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/Get-SdnNetworkControllerNodeCertificate.ps1
@@ -30,7 +30,7 @@ function Get-SdnNetworkControllerNodeCertificate {
             switch ($networkControllerNode.FindCertificateBy) {
                 'FindBySubjectName' {
                     "`tFindBySubjectName: {0}" -f $networkControllerNode.NodeCertSubjectName | Trace-Output -Level:Verbose
-                    $certificate = Get-SdnCertificate -Path 'Cert:\LocalMachine\My' -Subject $networkControllerNode.NodeCertSubjectName
+                    $certificate = Get-SdnCertificate -Path 'Cert:\LocalMachine\My' -Subject "CN=$($networkControllerNode.NodeCertSubjectName)"
                 }
 
                 'FindByThumbprint' {

--- a/src/modules/SdnDiag.NetworkController/public/New-SdnNetworkControllerNodeCertificate.ps1
+++ b/src/modules/SdnDiag.NetworkController/public/New-SdnNetworkControllerNodeCertificate.ps1
@@ -60,7 +60,8 @@ function New-SdnNetworkControllerNodeCertificate {
             $CertPath = Get-Item -Path $Path
         }
 
-        $nodeCertSubject = (Get-SdnNetworkControllerNodeCertificate).Subject
+        # if we return multiple certificates, we want to select the first one as the subject should be the same
+        $nodeCertSubject = (Get-SdnNetworkControllerNodeCertificate)[0].Subject
         $certificate = New-SdnCertificate -Subject $nodeCertSubject -NotAfter $NotAfter
 
         # after the certificate has been generated, we want to export the certificate using the $CertPassword provided by the operator


### PR DESCRIPTION
# Description
Summary of changes:
- Fixed an issue when using `-CertPath` to specify directory, we do not properly identify the .cer file, resulting in us copying the .pfx file to SB nodes, which require a password that we are not passing.
- Change where we catch an exception in attempt to retry if generic error is thrown.
- Fixed an issue where multiple certificates with same subject are returned resulting in generation of new nc node certificate was failing due to mismatched types
- Fixed an issue where we were not passing `CN=` to `Get-SdnCertificate` resulting in cert rotation failing for environments that were using FindBySubjectName

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.