### PR TITLE
skip health failure if no provider address configured for encap overhead test

### DIFF
--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -2101,7 +2101,7 @@ function Test-SdnEncapOverhead {
 
                     # in this scenario, encapoverhead is disabled and we do not have the expected jumbo packet value
                     # this will result in a failure on the test as it will result in packets being dropped if we exceed default MTU
-                    if ($_.JumboPacketValue -lt $jumboPacketExpectedValue -and $providerAddressConfigured -ieq $false) {
+                    if ($_.JumboPacketValue -lt $jumboPacketExpectedValue -and $providerAddressConfigured) {
                         $sdnHealthTest.Result = 'FAIL'
                         $sdnHealthTest.Remediation += "[$($_.NetAdapterInterfaceDescription)] Ensure the latest firmware and drivers are installed to support EncapOverhead. Configure JumboPacket to $jumboPacketExpectedValue if EncapOverhead is not supported."
                         $misconfigurationFound = $true

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -497,13 +497,13 @@ function UpdateFaultSet {
 
     foreach ($fault in $successFaults) {
         DeleteFaultBy -KeyFaultingObjectDescription $fault.KeyFaultingObjectDescription
-        $convFault = ConvertFaultToPsObject -healthFault $fault -faultType "Delete"
+        $convFault = ConvertFaultToPsObject -healthFault $fault -faultOpType "Delete"
         $healthTest.HealthFault += $convFault
     }
 
     foreach ($fault in $failureFaults) {
         CreateOrUpdateFault -Fault $fault
-        $convFault = ConvertFaultToPsObject -healthFault $fault -faultType "Create"
+        $convFault = ConvertFaultToPsObject -healthFault $fault -faultOpType "Create"
         $healthTest.HealthFault += $convFault
     }
 
@@ -2142,14 +2142,14 @@ function Test-SdnEncapOverhead {
 
                 if ($misconfigurationFound -eq $true) {
                     CreateorUpdateFault -Fault $sdnHealthFault
-                    $sdnHealthTest.HealthFault += ConvertFaultToPsObject -healthFault $sdnHealthFault -faultType "Create"
+                    $sdnHealthTest.HealthFault += ConvertFaultToPsObject -healthFault $sdnHealthFault -faultOpType "Create"
                 }
                 else {
                     Write-Verbose "No fault(s) on EncapOverhead, clearing any existing ones"
                     # clear all existing faults for host($FAULTNAME)
                     # todo: validate multiple hosts reporting the same fault
                     DeleteFaultBy -KeyFaultingObjectDescription $env:COMPUTERNAME -KeyFaultingObjectType $FAULTNAME
-                    $sdnHealthTest.HealthFault += ConvertFaultToPsObject -healthFault $sdnHealthFault -faultType "Delete"
+                    $sdnHealthTest.HealthFault += ConvertFaultToPsObject -healthFault $sdnHealthFault -faultOpType "Delete"
                 }
             }
         }


### PR DESCRIPTION
# Description
- update logical for testing encap overhead to compare if provider address has been configured on host, which is indication that workloads have been deployed

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [ ] I have tested and validated my code changes.