### PR TITLE
Pass trace params as array rather than splatted hashtable

### DIFF
--- a/src/modules/SdnDiag.Common.psm1
+++ b/src/modules/SdnDiag.Common.psm1
@@ -2179,7 +2179,7 @@ function Start-SdnNetshTrace {
     try {
         if ($PSCmdlet.ParameterSetName -eq 'Remote') {
             $traceParams.Add('Role', $Role)
-            Invoke-PSRemoteCommand -ComputerName $ComputerName -Credential $Credential -ScriptBlock { Start-SdnNetshTrace } -ArgumentList @traceParams
+            Invoke-PSRemoteCommand -ComputerName $ComputerName -Credential $Credential -ScriptBlock { Start-SdnNetshTrace } -ArgumentList $traceParams
         }
         else {
             $traceProviderString = Get-TraceProviders -Role $Role -Providers $Providers -AsString


### PR DESCRIPTION
# Description
Summary of changes:
This pull request includes a minor change to the `Start-SdnNetshTrace` function in the `src/modules/SdnDiag.Common.psm1` file. The change corrects the way the `ArgumentList` parameter is passed to the `Invoke-PSRemoteCommand` cmdlet.

* [`src/modules/SdnDiag.Common.psm1`](diffhunk://#diff-9ab71f66f6e21719dc9527f01ea738656003bbbe631f4f1bd85ab1ab8a746f24L2182-R2182): Changed the `ArgumentList` parameter from `@traceParams` to `$traceParams` in the `Invoke-PSRemoteCommand` cmdlet within the `Start-SdnNetshTrace` function.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.