### PR TITLE
Enable function to test processing of VFP layers

### DIFF
--- a/src/SdnDiagnostics.psd1
+++ b/src/SdnDiagnostics.psd1
@@ -172,7 +172,8 @@
         'Test-SdnConfigurationState',
         'Test-SdnNonSelfSignedCertificateInTrustedRootStore',
         'Test-SdnClusterServiceState',
-        'Test-SdnServiceState'
+        'Test-SdnServiceState',
+        'Test-SdnVfpPortTuple'
     )
 
     # Variables to export from this module


### PR DESCRIPTION
# Description
Summary of changes:
This pull request introduces a new function to the `src/modules/SdnDiag.Server.psm1` file and updates the `src/SdnDiagnostics.psd1` file to include this new function. The most important changes are summarized below:

### Addition of new function:

* [`src/modules/SdnDiag.Server.psm1`](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedR3194-R3277): Added the `Test-SdnVfpPortTuple` function, which simulates the processing of a packet by the Virtual Filtering Platform (VFP) for a specific port. This function includes parameters for `PortName`, `Direction`, `SourceIP`, `SourcePort`, `DestinationIP`, `DestinationPort`, and `Protocol`, and provides examples of usage.

### Updates to module manifest:

* [`src/SdnDiagnostics.psd1`](diffhunk://#diff-17aaaa968cc894449c79b449c228b28d8a8990bde4000e59bcf24d8189671ee1L175-R176): Updated the `FunctionsToExport` section to include the new `Test-SdnVfpPortTuple` function.

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.