### PR TITLE
Exclude testing ILB PA IPs from Logical Network testing

### DIFF
--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -2276,9 +2276,9 @@ function Test-SdnProviderNetwork {
         # since we are testing the provider network, we need to determine the subnet of the provider addresses
         # as the addressMappings may contain addresses that are not in the same subnet as the provider addresses
         # as we also get a similar type of PACA mapping for internal load balancer mappings
-        $subnetMask = Get-SubnetMaskFromCidr -Cidr $localProviderAddress[0].Cidr
-        $subnet = Get-NetworkAddressFromIP -IPv4Address $localProviderAddress[0].Address -IPv4Mask $subnetMask
-        $cidr = "$subnet/$subnetMask"
+        $subnetMask = Get-SubnetMaskFromCidr -Cidr $localProviderAddress[0].PrefixLength
+        $subnet = Get-NetworkAddressFromIP -IPv4Address $localProviderAddress[0].Address -SubnetMask $subnetMask
+        $cidr = "$subnet/$($localProviderAddress[0].PrefixLength)"
 
         $addressMapping = Get-SdnOvsdbAddressMapping
         if (-NOT ($null -eq $addressMapping -or $addressMapping.Count -eq 0)) {

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -2263,12 +2263,33 @@ function Test-SdnProviderNetwork {
 
     Confirm-IsServer
     $sdnHealthTest = New-SdnHealthTest
+    $filteredAddressMappings = @()
 
     try {
+        # get the provider addresses on the system
+        # if there are no provider addresses, we can skip this test
+        $localProviderAddress = Get-SdnProviderAddress
+        if ($null -ieq $localProviderAddress -or $localProviderAddress.Count -eq 0) {
+            return $sdnHealthTest
+        }
+
+        # since we are testing the provider network, we need to determine the subnet of the provider addresses
+        # as the addressMappings may contain addresses that are not in the same subnet as the provider addresses
+        # as we also get a similar type of PACA mapping for internal load balancer mappings
+        $subnetMask = Get-SubnetMaskFromCidr -Cidr $localProviderAddress[0].Cidr
+        $subnet = Get-NetworkAddressFromIP -IPv4Address $localProviderAddress[0].Address -IPv4Mask $subnetMask
+        $cidr = "$subnet/$subnetMask"
+
         $addressMapping = Get-SdnOvsdbAddressMapping
         if (-NOT ($null -eq $addressMapping -or $addressMapping.Count -eq 0)) {
             $providerAddreses = $addressMapping.ProviderAddress | Sort-Object -Unique
-            $connectivityResults = Test-SdnProviderAddressConnectivity -ProviderAddress $providerAddreses
+            foreach ($pAddress in $providerAddreses) {
+                if (Confirm-IpAddressInCidrRange -IpAddress $pAddress -Cidr $cidr) {
+                    $filteredAddressMappings += $pAddress
+                }
+            }
+
+            $connectivityResults = Test-SdnProviderAddressConnectivity -ProviderAddress $filteredAddressMappings
 
             foreach ($destination in $connectivityResults) {
                 $failureDetected = $false

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -2277,7 +2277,7 @@ function Test-SdnProviderNetwork {
         # as the addressMappings may contain addresses that are not in the same subnet as the provider addresses
         # as we also get a similar type of PACA mapping for internal load balancer mappings
         $subnetMask = Get-SubnetMaskFromCidr -Cidr $localProviderAddress[0].PrefixLength
-        $subnet = Get-NetworkAddressFromIP -IPv4Address $localProviderAddress[0].Address -SubnetMask $subnetMask
+        $subnet = Get-NetworkSubnetFromIP -IPv4Address $localProviderAddress[0].Address -SubnetMask $subnetMask
         $cidr = "$subnet/$($localProviderAddress[0].PrefixLength)"
 
         $addressMapping = Get-SdnOvsdbAddressMapping

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -2805,11 +2805,11 @@ function Get-NetworkAddressFromIP {
         [IPAddress]$IPv4Address,
 
         [Parameter(Mandatory = $false)]
-        [IPAddress]$Prefix
+        [IPAddress]$SubnetMask
     )
 
     $aAddress = $IPv4Address.GetAddressBytes()
-    $aMask = $IPv4Mask.GetAddressBytes()
+    $aMask = $SubnetMask.GetAddressBytes()
 
     $aNetwork = for ($i = 0; $i -lt 4; $i++) {
         $aAddress[$i] -band $aMask[$i]

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -159,6 +159,51 @@ function Confirm-IpAddressInRange {
     $from -le $ip -and $ip -le $to
 }
 
+function Confirm-IpAddressInCidrRange {
+    <#
+    .SYNOPSIS
+        Uses .NET to compare the IpAddress specified to see if it falls within the CIDR range specified.
+    .PARAMETER IpAddress
+        The IP Address that you want to validate.
+    .PARAMETER Cidr
+        The CIDR range that you want to validate against.
+    .EXAMPLE
+        PS> Confirm-IpAddressInCidrRange -IpAddress 192.168.0.10 -Cidr 192.168.0.0/24
+    #>
+
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.String]$IpAddress,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]$Cidr
+    )
+
+    # Split the CIDR into address and prefix
+    $parts = $Cidr -split '/'
+    $networkAddress = $parts[0]
+    $prefixLength = [int]$parts[1]
+
+    # Convert the addresses to IPAddress objects
+    $ip = [System.Net.IPAddress]::Parse($IpAddress).GetAddressBytes()
+    [array]::Reverse($ip)
+    $ip = [System.BitConverter]::ToUInt32($ip, 0)
+
+    $network = [System.Net.IPAddress]::Parse($networkAddress).GetAddressBytes()
+    [array]::Reverse($network)
+    $network = [System.BitConverter]::ToUInt32($network, 0)
+
+    # Calculate the subnet mask from the prefix length
+    $mask = [uint32]::MaxValue -shl (32 - $prefixLength)
+
+    # Calculate the network address and broadcast address
+    $networkAddress = $network -band $mask
+    $broadcastAddress = $networkAddress -bor -bnot $mask
+
+    # Check if the IP address falls within the range
+    return ($networkAddress -le $ip -and $ip -le $broadcastAddress)
+}
+
 function Confirm-IsAdmin {
     # ensure that the module is running as local administrator
     $elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
@@ -2751,3 +2796,45 @@ function Get-NugetArtifactPath {
         return [System.IO.Path]::GetDirectoryName($package.Source)
     }
 }
+
+function Get-NetworkAddressFromIP {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [IPAddress]$IPv4Address,
+
+        [Parameter(Mandatory = $false)]
+        [IPAddress]$Prefix
+    )
+
+    $aAddress = $IPv4Address.GetAddressBytes()
+    $aMask = $IPv4Mask.GetAddressBytes()
+
+    $aNetwork = for ($i = 0; $i -lt 4; $i++) {
+        $aAddress[$i] -band $aMask[$i]
+    }
+
+    return ($aNetwork -join ('.'))
+}
+
+function Get-SubnetMaskFromCidr {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [ValidateRange(0, 32)]
+        [int32]$Cidr
+    )
+
+    $binary = ('1' * $Cidr).PadRight(32, '0')
+
+    $Private:octets = New-Object -TypeName System.Collections.ArrayList
+    for ($i = 0; $i -lt 32; $i += 8) {
+        $bOctet = $binary.Substring($i, 8)
+        [void]$octets.Add( ([System.Convert]::ToInt32($bOctet, 2) ) )
+    }
+
+    return ( $octets -join ('.') )
+}
+
+

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -2797,7 +2797,7 @@ function Get-NugetArtifactPath {
     }
 }
 
-function Get-NetworkAddressFromIP {
+function Get-NetworkSubnetFromIP {
 
     [CmdletBinding()]
     param (


### PR DESCRIPTION
# Description
Summary of changes:
- Added filtering to ensure that ILB PA IPs are excluded from tests regarding PA IPs, as commonly will be on different VLANs.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.