### PR TITLE
Define ErrorAction when checking for DisplayVersion registry

### DIFF
--- a/src/modules/SdnDiag.Health.Config.psd1
+++ b/src/modules/SdnDiag.Health.Config.psd1
@@ -190,8 +190,8 @@
 
     HealthFaultEnabled = $false
     HealthFaultSupportedBuilds = @(
+        '23H2' # Build Number 25398
         '24H2' # Build Number 26100
-        '23H2'
     )
     HealthFaultSupportedProducts = @(
         'Azure Stack HCI'

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -16,8 +16,8 @@ New-Variable -Name 'SdnDiagnostics_Health' -Scope 'Script' -Force -Value @{
 
 # confirm that the current system is supported to generate health faults
 try {
-    $displayVersion = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -Name 'DisplayVersion'
-    $productName = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -Name 'ProductName'
+    $displayVersion = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -Name 'DisplayVersion' -ErrorAction Stop
+    $productName = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -Name 'ProductName' -ErrorAction Stop
     if ($productName.ProductName -iin $script:SdnDiagnostics_Health.Config.HealthFaultSupportedProducts){
         $productSupported = $true
     }


### PR DESCRIPTION
# Description
Summary of changes:
This pull request includes updates to the `SdnDiag.Health` module to enhance error handling and correct the supported builds list.

Improvements to error handling:

* [`src/modules/SdnDiag.Health.psm1`](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L19-R20): Added `-ErrorAction Stop` to `Get-ItemProperty` calls to ensure the script stops on errors, improving robustness.

Corrections to supported builds:

* [`src/modules/SdnDiag.Health.Config.psd1`](diffhunk://#diff-4f2fe3aa484c1dfed0c40d4df3c9bfd2754ed18ef9c743c19b2ce003db10af2bR193-L194): Updated the `HealthFaultSupportedBuilds` list to correctly include build '23H2' with its build number '25398'.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.