### PR TITLE
Remove Test-SdnNetworkControllerApiNameResolution from Debug tests

### DIFF
--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -1593,7 +1593,6 @@ function Debug-SdnServer {
             Test-SdnServiceState -ServiceName $services
             Test-SdnProviderNetwork
             Test-SdnHostAgentConnectionStateToApiService
-            Test-SdnNetworkControllerApiNameResolution -NcUri $NcUri
         )
 
         # enumerate all the tests performed so we can determine if any completed with WARN or FAIL
@@ -1633,7 +1632,6 @@ function Debug-SdnLoadBalancerMux {
             Test-SdnServiceState -ServiceName $services
             Test-SdnDiagnosticsCleanupTaskEnabled -TaskName 'SDN Diagnostics Task'
             Test-SdnMuxConnectionStateToSlbManager
-            Test-SdnNetworkControllerApiNameResolution -NcUri $NcUri
         )
 
         # enumerate all the tests performed so we can determine if any completed with WARN or FAIL


### PR DESCRIPTION
# Description
Summary of changes:
This pull request includes changes to the `src/modules/SdnDiag.Health.psm1` file to remove `Test-SdnNetworkControllerApiNameResolution` from the debug functions. 

The most important changes are:

* [`src/modules/SdnDiag.Health.psm1`](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L1596): Removed the call to `Test-SdnNetworkControllerApiNameResolution -NcUri $NcUri` from the `Debug-SdnServer` function.
* [`src/modules/SdnDiag.Health.psm1`](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L1636): Removed the call to `Test-SdnNetworkControllerApiNameResolution -NcUri $NcUri` from the `Debug-SdnLoadBalancerMux` function.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.