### PR TITLE
Add Network Controller test to check for Network Adapter that matches RestInterface property

### DIFF
--- a/src/SdnDiagnostics.psd1
+++ b/src/SdnDiagnostics.psd1
@@ -164,6 +164,7 @@
         'Test-SdnMuxConnectionStateToRouter',
         'Test-SdnMuxConnectionStateToSlbManager',
         'Test-SdnNetworkControllerApiNameResolution',
+        'Test-SdnNetworkControllerNodeRestInterface',
         'Test-SdnResourceConfigurationState',
         'Test-SdnResourceProvisioningState',
         'Test-SdnServiceFabricApplicationHealth',

--- a/src/modules/SdnDiag.Health.Config.psd1
+++ b/src/modules/SdnDiag.Health.Config.psd1
@@ -48,7 +48,7 @@
         'Test-SdnNetworkControllerNodeRestInterface' = @{
             Description = "Network Controller node(s) are missing the Network Adapter that is required for the REST interface."
             Impact = "Failover of the NB API will not occur if the Network Controller node(s) are missing the Network Adapter that is required for the REST interface."
-            PublicDocUrl = ""
+            PublicDocUrl = "https://learn.microsoft.com/en-us/powershell/module/networkcontroller/set-networkcontrollernode"
         }
         'Test-SdnServiceFabricApplicationHealth' = @{
             Description = "Network Controller application with Service Fabric is not healthy."

--- a/src/modules/SdnDiag.Health.Config.psd1
+++ b/src/modules/SdnDiag.Health.Config.psd1
@@ -45,6 +45,11 @@
 
         # NETWORK CONTROLLER TESTS
 
+        'Test-SdnNetworkControllerNodeRestInterface' = @{
+            Description = "Network Controller node(s) are missing the Network Adapter that is required for the REST interface."
+            Impact = "Failover of the NB API will not occur if the Network Controller node(s) are missing the Network Adapter that is required for the REST interface."
+            PublicDocUrl = ""
+        }
         'Test-SdnServiceFabricApplicationHealth' = @{
             Description = "Network Controller application with Service Fabric is not healthy."
             Impact = "Network Controller services and functionality may be impacted."

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -2771,8 +2771,11 @@ function Test-SdnNetworkControllerNodeRestInterface {
     param()
 
     Confirm-IsNetworkController
-    $sdnHealthTest = New-SdnHealthTest
+    if ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType -ieq 'FailoverCluster') {
+        throw New-Object System.NotSupportedException("This function is not applicable to Failover Cluster Network Controller.")
+    }
 
+    $sdnHealthTest = New-SdnHealthTest
     try {
         $node = Get-SdnNetworkControllerNode -Name $env:COMPUTERNAME -ErrorAction Stop
         $netAdapter = Get-NetAdapter -Name $node.RestInterface -ErrorAction Ignore

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -2778,7 +2778,7 @@ function Test-SdnNetworkControllerNodeRestInterface {
         $netAdapter = Get-NetAdapter -Name $node.RestInterface -ErrorAction Ignore
         if ($null -eq $netAdapter) {
             $sdnHealthTest.Result = 'FAIL'
-            $sdnHealthTest.Remediation += "Ensure that the Network Adapter $($node.RestInterface) exists on the Network Controller node."
+            $sdnHealthTest.Remediation += "Ensure that the Network Adapter $($node.RestInterface) exists. Leverage 'Set-NetworkControllerNode to update the -RestInterface if original adapter is not available."
         }
     }
     catch {


### PR DESCRIPTION
# Description
Summary of changes:
- Add health test to check for Network Adapter that matches RestInterface property in Network Controller

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.