### PR TITLE
Add health test to check for multiple switches that have VFP extension enabled

### DIFF
--- a/src/SdnDiagnostics.psd1
+++ b/src/SdnDiagnostics.psd1
@@ -116,6 +116,7 @@
         'Get-SdnVfpVmSwitchPort',
         'Get-SdnVMNetworkAdapter',
         'Get-SdnVMNetworkAdapterPortProfile',
+        'Get-SdnVMSwitch',
         'Get-SdnVfpPortGroup',
         'Get-SdnVfpPortLayer',
         'Get-SdnVfpPortRule',

--- a/src/SdnDiagnostics.psd1
+++ b/src/SdnDiagnostics.psd1
@@ -173,6 +173,7 @@
         'Test-SdnNonSelfSignedCertificateInTrustedRootStore',
         'Test-SdnClusterServiceState',
         'Test-SdnServiceState',
+        'Test-SdnVfpEnabledVMSwitch',
         'Test-SdnVfpPortTuple'
     )
 

--- a/src/modules/SdnDiag.Health.Config.psd1
+++ b/src/modules/SdnDiag.Health.Config.psd1
@@ -98,6 +98,11 @@
             Impact = "Policy configuration failures may be reported by Network Controller when applying policies to the Hyper-v host. In addition, network traffic may be impacted."
             PublicDocUrl = ""
         }
+        'Test-SdnVfpEnabledVMSwitch'= @{
+            Description = "Multiple VFP enabled virtual switches detected on the Hyper-V host(s)."
+            Impact = "Policy configuration failures may be reported by Network Controller when applying policies to the Hyper-v host."
+            PublicDocUrl = ""
+        }
         'Test-VMNetAdapterDuplicateMacAddress' = @{
             Description = "Duplicate MAC address detected with the data plane on the Hyper-V host(s)."
             Impact = "Policy configuration failures may be reported by Network Controller when applying policies to the Hyper-v host. In addition, network traffic may be impacted for the interfaces that are duplicated."

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -2373,6 +2373,46 @@ function Test-SdnHostAgentConnectionStateToApiService {
     return $sdnHealthTest
 }
 
+function Test-SdnVfpEnabledVMSwitch {
+    <#
+        .SYNOPSIS
+            Enumerates the VMSwitches on the system and validates that only one VMSwitch is configured with VFP.
+    #>
+
+    [CmdletBinding()]
+    param()
+
+    Confirm-IsServer
+    $sdnHealthTest = New-SdnHealthTest
+    $i = 0
+
+    try {
+        $vmSwitches = Get-VMSwitch
+
+        # only progress if we have more than one VMSwitch
+        if ($vmSwitches.Count -ge 2) {
+            foreach ($vmSwitch in $vmSwitches) {
+                $extensions = $vmSwitch | Get-VMSwitchExtension
+                $vfpExtension = $extensions | Where-Object { $_.Name -eq 'Microsoft Azure VFP Switch Extension' }
+                if ($vfpExtension.Enabled -eq $true) {
+                    $i++
+                }
+            }
+        }
+
+        if ($i -gt 1) {
+            $sdnHealthTest.Result = 'FAIL'
+            $sdnHealthTest.Remediation += "TODO"
+        }
+    }
+    catch {
+        $_ | Trace-Exception
+        $sdnHealthTest.Result = 'FAIL'
+    }
+
+    return $sdnHealthTest
+}
+
 ###################################
 ###### NC HEALTH VALIDATIONS ######
 ###################################

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -2387,19 +2387,9 @@ function Test-SdnVfpEnabledVMSwitch {
     $sdnHealthTest = New-SdnHealthTest
 
     try {
-        # enumerate the VMSwitches on the system and validate that only one VMSwitch is configured with VFP
-        $vmSwitches = Get-VMSwitch
-
-        $i = 0
-        foreach ($vmSwitch in $vmSwitches) {
-            $vfpExtension = $vmSwitch.Extensions | Where-Object { $_.Name -eq 'Microsoft Azure VFP Switch Extension' }
-            if ($vfpExtension.Enabled -eq $true) {
-                $i++
-            }
-        }
-
         # if there is more than one VMSwitch configured with VFP, this is a failure
-        if ($i -gt 1) {
+        $vmSwitches = Get-SdnVMSwitch -VfpEnabled
+        if ($vmSwitches.Count -gt 1) {
             $sdnHealthTest.Result = 'FAIL'
         }
     }

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -1457,22 +1457,29 @@ function Get-SdnNetAdapterEncapOverheadConfig {
     <#
     .SYNOPSIS
         Retrieves the EncapOverhead and JumboPacket properties of each network interface attached to a vfp enabled vmswitch
+    .PARAMETER Name
+        Specifies the name of the virtual switch to be retrieved.
+    .PARAMETER Id
+        Specifies the ID of the virtual switch to be retrieved.
     .EXAMPLE
         PS> Get-SdnNetAdapterEncapOverheadConfig
     #>
 
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [string]$Id
+    )
+
+    $switchArrayList = @()
+
     try {
-        $switchArrayList = @()
-
-        # filter to only look at vSwitches where the Microsoft Azure VFP Switch Extension is installed
-        # once we have the vSwitches, then need to then filter and only look at switches where VFP is enabled
-        $vfpSwitch = Get-VMSwitch | Where-Object {$_.Extensions.Name -ieq 'Microsoft Azure VFP Switch Extension'}
+        # enumerate each of the vmswitches that are vfp enabled
+        $vfpSwitch = Get-SdnVMSwitch @PSBoundParameters -VfpEnabled
         foreach ($switch in $vfpSwitch) {
-            $vfpExtension = $switch.Extensions | Where-Object {$_.Name -ieq 'Microsoft Azure VFP Switch Extension'}
-            if ($vfpExtension.Enabled -ieq $false) {
-                continue
-            }
-
             $interfaceArrayList = @()
             $supportsEncapOverhead = $false
             $encapOverheadValue = $null
@@ -1498,6 +1505,7 @@ function Get-SdnNetAdapterEncapOverheadConfig {
 
                 $object = [PSCustomObject]@{
                     Switch                         = $switch.Name
+                    Id                             = $switch.Id
                     NetAdapterInterfaceDescription = $physicalNicIfDesc
                     EncapOverheadEnabled           = $supportsEncapOverhead
                     EncapOverheadValue             = $encapOverheadValue
@@ -3274,4 +3282,63 @@ function Test-SdnVfpPortTuple {
         $_ | Trace-Exception
         $_ | Write-Error
     }
+}
+
+function Get-SdnVMSwitch {
+    <#
+    .SYNOPSIS
+        Gets virtual switches from the hypervisor.
+    .PARAMETER Name
+        Specifies the name of the virtual switch to be retrieved.
+    .PARAMETER Id
+        Specifies the ID of the virtual switch to be retrieved.
+    .PARAMETER VfpEnabled
+        Specifies whether the virtual switch has VFP enabled.
+    .EXAMPLE
+        PS> Get-SdnVMSwitch -Name 'Virtual Switch'
+    .EXAMPLE
+        PS> Get-SdnVMSwitch -Id '8440FB77-196C-402E-8564-B0EF9E5B1931'
+    .EXAMPLE
+        PS> Get-SdnVMSwitch -VfpEnabled
+    #>
+
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [string]$Id,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Id')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Name')]
+        [switch]$VfpEnabled
+    )
+
+    Confirm-IsServer
+    if ($PSBoundParameters.ContainsKey('VfpEnabled')) {
+        [void]$PSBoundParameters.Remove('VfpEnabled')
+    }
+
+    $array = @()
+    try {
+        $vmSwitch = Get-VMSwitch @PSBoundParameters
+        foreach ($switch in $vmSwitch) {
+            $vfpExtension = $vmSwitch.Extensions | Where-Object { $_.Name -eq 'Microsoft Azure VFP Switch Extension' }
+            if ($vfpExtension.Enabled -ieq $true) {
+                $array += $switch
+            }
+        }
+    }
+    catch {
+        $_ | Trace-Exception
+        $_ | Write-Error
+    }
+
+    if ($array.Count -gt 1) {
+        "Multiple switches detected with VFP enabled" | Trace-Output -Level:Warning
+    }
+
+    return $array
 }


### PR DESCRIPTION
# Description
Summary of changes:
This pull request primarily introduces new functionality related to Virtual Filtering Platform (VFP) enabled virtual switches in the SDN diagnostics module. The most significant changes include the addition of a new cmdlet, updates to existing cmdlets, and enhancements to the diagnostics configuration.

### New Functionality:
* Added `Get-SdnVMSwitch` cmdlet to retrieve virtual switches from the hypervisor with an option to filter by VFP enabled switches.
* Introduced `Test-SdnVfpEnabledVMSwitch` cmdlet to check that only one VFP enabled virtual switch is configured on the system.

### Enhancements to Existing Cmdlets:
* Updated `Get-SdnNetAdapterEncapOverheadConfig` to support filtering by switch name or ID and to use the new `Get-SdnVMSwitch` cmdlet for retrieving VFP enabled switches. [[1]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedR1460-L1475) [[2]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedR1508)

### Configuration and Diagnostics Updates:
* Added new entries for `Get-SdnVMSwitch` and `Test-SdnVfpEnabledVMSwitch` in the `src/SdnDiagnostics.psd1` file. [[1]](diffhunk://#diff-17aaaa968cc894449c79b449c228b28d8a8990bde4000e59bcf24d8189671ee1R119) [[2]](diffhunk://#diff-17aaaa968cc894449c79b449c228b28d8a8990bde4000e59bcf24d8189671ee1R177)
* Included `Test-SdnVfpEnabledVMSwitch` in the diagnostics configuration file with description and impact details.
* Integrated `Test-SdnVfpEnabledVMSwitch` into the `Debug-SdnServer` function to be part of the diagnostic tests.

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.