### PR TITLE
Update function params and helpers

### DIFF
--- a/src/modules/SdnDiag.NetworkController.psm1
+++ b/src/modules/SdnDiag.NetworkController.psm1
@@ -2038,12 +2038,10 @@ function Get-SdnResource {
 
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceRef')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'Resource')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'InstanceID')]
+        [Parameter(Mandatory = $true)]
         [Uri]$NcUri,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceRef')]
         [System.String]$ResourceRef,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Resource')]
@@ -2055,25 +2053,19 @@ function Get-SdnResource {
         [Parameter(Mandatory = $true, ParameterSetName = 'InstanceID')]
         [System.String]$InstanceId,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
-        [Parameter(Mandatory = $false, ParameterSetName = 'Resource')]
-        [Parameter(Mandatory = $false, ParameterSetName = 'InstanceID')]
+        [Parameter(Mandatory = $false)]
         [Switch]$ConvertToJson,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Resource')]
         [System.String]$ApiVersion = $Global:SdnDiagnostics.EnvironmentInfo.RestApiVersion,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
-        [Parameter(Mandatory = $false, ParameterSetName = 'Resource')]
-        [Parameter(Mandatory = $false, ParameterSetName = 'InstanceID')]
+        [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $NcRestCredential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
-        [Parameter(Mandatory = $false, ParameterSetName = 'Resource')]
-        [Parameter(Mandatory = $false, ParameterSetName = 'InstanceID')]
+        [Parameter(Mandatory = $false)]
         [X509Certificate]$NcRestCertificate
     )
 

--- a/src/modules/SdnDiag.NetworkController.psm1
+++ b/src/modules/SdnDiag.NetworkController.psm1
@@ -2017,6 +2017,8 @@ function Get-SdnResource {
         Specify the unique ID of the resource.
     .PARAMETER InstanceID
         Specify the unique Instance ID of the resource.
+    .PARAMETER ConvertToJson
+        Convert the output to JSON format.
     .PARAMETER ApiVersion
         The API version to use when invoking against the NC REST API endpoint.
     .PARAMETER NcRestCertificate
@@ -2052,6 +2054,11 @@ function Get-SdnResource {
 
         [Parameter(Mandatory = $true, ParameterSetName = 'InstanceID')]
         [System.String]$InstanceId,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Resource')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'InstanceID')]
+        [Switch]$ConvertToJson,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'ResourceRef')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Resource')]
@@ -2121,7 +2128,7 @@ function Get-SdnResource {
     # if multiple objects are returned, they will be nested under a property called value
     # so we want to do some manual work here to ensure we have a consistent behavior on data returned back
     if ($result.value) {
-        return $result.value
+        $result = $result.value
     }
 
     # in some instances if the API returns empty object, we will see it saved as 'nextLink' which is a empty string property
@@ -2130,7 +2137,12 @@ function Get-SdnResource {
         return $null
     }
 
-    return $result
+    if ($ConvertToJson) {
+        return ($result | ConvertTo-Json -Depth 10)
+    }
+    else {
+        return $result
+    }
 }
 
 function Get-SdnServer {

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -685,7 +685,7 @@ function Get-ServerConfigState {
         Get-NetAdapterVPort | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-NetAdapterVPort' -FileType txt -Format Table
         Get-NetAdapterVmqQueue | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-NetAdapterVmqQueue' -FileType txt -Format Table
         Get-SdnNetAdapterEncapOverheadConfig | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-SdnNetAdapterEncapOverheadConfig' -FileType txt -Format Table
-        Get-SdnVMNetworkAdapterPortProfile -AllVMs | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-SdnVMNetworkAdapterPortProfile' -FileType txt -Format Table
+        Get-SdnVMNetworkAdapterPortProfile -All | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-SdnVMNetworkAdapterPortProfile' -FileType txt -Format Table
         Get-VMNetworkAdapterIsolation | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-VMNetworkAdapterIsolation' -FileType txt -Format Table
         Get-VMNetworkAdapterVLAN | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-VMNetworkAdapterVLAN' -FileType txt -Format Table
         Get-VMNetworkAdapterRoutingDomainMapping | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'Get-VMNetworkAdapterRoutingDomainMapping' -FileType txt -Format Table
@@ -2535,6 +2535,11 @@ function Get-SdnVMNetworkAdapter {
         Import-Module -Name Hyper-V -Force -ErrorAction Stop
     }
 
+    # remove the credential parameter if it is empty to avoid passing it to the cmdlet
+    if ($Credential -eq [System.Management.Automation.PSCredential]::Empty) {
+        [void]$PSBoundParameters.Remove('Credential')
+    }
+
     try {
         $adapters = Get-VMNetworkAdapter @PSBoundParameters
         if ($PSBoundParameters.ContainsKey('MacAddress')) {
@@ -2563,10 +2568,10 @@ function Get-SdnVMNetworkAdapterPortProfile {
     .EXAMPLE
         Get-SdnVMNetworkAdapterPortProfile -VMName 'VM01'
     .EXAMPLE
-        Get-SdnVMNetworkAdapterPortProfile -AllVMs
+        Get-SdnVMNetworkAdapterPortProfile -All
     #>
 
-    [CmdletBinding(DefaultParameterSetName = 'SingleVM')]
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true, ParameterSetName = 'SingleVM')]
         [System.String]$VMName,
@@ -2577,8 +2582,7 @@ function Get-SdnVMNetworkAdapterPortProfile {
         [Parameter(Mandatory = $true, ParameterSetName = 'AllVMs')]
         [Switch]$All,
 
-        [Parameter(ParameterSetName = 'SingleVM', Mandatory = $false)]
-        [Parameter(ParameterSetName = 'AllVMs', Mandatory = $false)]
+        [Parameter(Mandatory = $false)]
         [switch]$HostVmNic
     )
 

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -840,7 +840,6 @@ function Get-VfpPortGroup {
                             $object.$key = $value
                         }
                         catch {
-                            "Unable to add {0} to object. Failing back to use NoteProperty." -f $key | Trace-Output -Level:Warning
                             $object | Add-Member -MemberType NoteProperty -Name $key -Value $value
                             continue
                         }
@@ -925,7 +924,6 @@ function Get-VfpPortLayer {
                             $object.$key = $value
                         }
                         catch {
-                            "Unable to add {0} to object. Failing back to use NoteProperty." -f $key | Trace-Output -Level:Warning
                             $object | Add-Member -MemberType NoteProperty -Name $key -Value $value
                             continue
                         }
@@ -1316,7 +1314,6 @@ function Get-VfpPortState {
                         $object.$propertyName = $propertyValue
                     }
                     catch {
-                        "Unable to add {0} to object. Failing back to use NoteProperty." -f $propertyName | Trace-Output -Level:Warning
                         $object | Add-Member -MemberType NoteProperty -Name $propertyName -Value $propertyValue
                         continue
                     }
@@ -1435,7 +1432,6 @@ function Get-VfpVMSwitchPort {
                                 $object.$key = $value
                             }
                             catch {
-                                "Unable to add {0} to object. Failing back to use NoteProperty." -f $key | Trace-Output -Level:Warning
                                 $object | Add-Member -MemberType NoteProperty -Name $key -Value $value
                                 continue
                             }
@@ -3186,14 +3182,13 @@ function Test-SdnProviderAddressConnectivity {
     try {
         $sourceProviderAddress = (Get-ProviderAddress).ProviderAddress
         if ($null -eq $sourceProviderAddress) {
-            "No provider addresses found" | Trace-Output -Level:Warning
             return $null
         }
 
         $compartmentId = (Get-NetCompartment | Where-Object { $_.CompartmentDescription -ieq 'PAhostVNic' }).CompartmentId
         if ($null -eq $compartmentId) {
             "No compartment that matches description PAhostVNic" | Trace-Output -Level:Warning
-            return
+            return $null
         }
 
         foreach ($srcAddress in $sourceProviderAddress) {

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -2495,6 +2495,9 @@ function Get-SdnVMNetworkAdapter {
         [string]$Name,
 
         [Parameter(Mandatory = $false)]
+        [string]$MacAddress,
+
+        [Parameter(Mandatory = $false)]
         [switch]$ManagementOS,
 
         [Parameter(Mandatory = $false)]
@@ -2516,7 +2519,7 @@ function Get-SdnVMNetworkAdapter {
             $adapters = $adapters | Where-Object { $_.MacAddress -eq $MacAddress }
         }
 
-        return ($adapters | Sort-Object -Property VMName)
+        return ($adapters | Sort-Object -Property Name)
     }
     catch {
         $_ | Trace-Exception

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -744,14 +744,14 @@ function Get-VfpPortGroup {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [GUID]$PortId,
+        [GUID]$PortName,
 
         [Parameter(Mandatory = $true)]
         [System.String]$Layer
     )
 
     $arrayList = [System.Collections.ArrayList]::new()
-    $vfpGroups = vfpctrl /list-group /port $PortId /layer $Layer
+    $vfpGroups = vfpctrl /list-group /port $PortName /layer $Layer
     if ($null -eq $vfpGroups){
         return $null
     }
@@ -860,18 +860,18 @@ function Get-VfpPortLayer {
     <#
     .SYNOPSIS
         Enumerates the layers contained within Virtual Filtering Platform (VFP) for specified for the port.
-    .PARAMETER PortId
-        The Port ID GUID for the network interface
+    .PARAMETER PortName
+        The Port Name for the network interface
     #>
 
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [GUID]$PortId
+        [GUID]$PortName
     )
 
     $arrayList = [System.Collections.ArrayList]::new()
-    $vfpLayers = vfpctrl /list-layer /port $PortId
+    $vfpLayers = vfpctrl /list-layer /port $PortName
     if ($null -eq $vfpLayers){
         return $null
     }
@@ -949,8 +949,8 @@ function Get-VfpPortRule {
     <#
     .SYNOPSIS
         Enumerates the rules contained within the specific group within Virtual Filtering Platform (VFP) layer specified for the port.
-    .PARAMETER PortId
-        The Port ID GUID for the network interface.
+    .PARAMETER PortName
+        The Port name for the network interface.
     .PARAMETER Layer
         Specify the target layer.
     .PARAMETER Group
@@ -960,7 +960,7 @@ function Get-VfpPortRule {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [GUID]$PortId,
+        [GUID]$PortName,
 
         [Parameter(Mandatory = $true)]
         [System.String]$Layer,
@@ -970,7 +970,7 @@ function Get-VfpPortRule {
     )
 
     $arrayList = [System.Collections.ArrayList]::new()
-    $vfpRules = vfpctrl /list-rule /port $PortId /layer $Layer /group $Group
+    $vfpRules = vfpctrl /list-rule /port $PortName /layer $Layer /group $Group
     if ($null -eq $vfpRules){
         return $null
     }
@@ -1842,8 +1842,8 @@ function Get-SdnOvsdbPhysicalPort {
     <#
     .SYNOPSIS
         Gets the physical port table results from OVSDB MS_VTEP database.
-    .PARAMETER PortId
-        The port ID of the physical port to return.
+    .PARAMETER PortName
+        The port name of the physical port to return.
     .PARAMETER Name
         The name of the physical port to return. This is the InstanceID the Network Interface object from Network Controller.
     .PARAMETER VMName
@@ -1862,8 +1862,8 @@ function Get-SdnOvsdbPhysicalPort {
 
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
-        [Parameter(Mandatory = $false, ParameterSetName = 'PortId')]
-        [GUID]$PortId,
+        [Parameter(Mandatory = $false, ParameterSetName = 'PortName')]
+        [GUID]$PortName,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Name')]
         [GUID]$Name,
@@ -1874,14 +1874,14 @@ function Get-SdnOvsdbPhysicalPort {
         [Parameter(Mandatory = $false, ParameterSetName = 'MacAddress')]
         [System.String]$MacAddress,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'PortId')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'PortName')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Name')]
         [Parameter(Mandatory = $false, ParameterSetName = 'VMName')]
         [Parameter(Mandatory = $false, ParameterSetName = 'MacAddress')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
         [string[]]$ComputerName,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'PortId')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'PortName')]
         [Parameter(Mandatory = $false, ParameterSetName = 'Name')]
         [Parameter(Mandatory = $false, ParameterSetName = 'VMName')]
         [Parameter(Mandatory = $false, ParameterSetName = 'MacAddress')]
@@ -1901,7 +1901,7 @@ function Get-SdnOvsdbPhysicalPort {
 
         # once we have the results, filter based on the parameter set
         switch ($PSCmdlet.ParameterSetName) {
-            'PortId' { return ($result | Where-Object { $_.vm_nic_port_id -eq $PortId }) }
+            'PortName' { return ($result | Where-Object { $_.vm_nic_port_id -eq $PortName }) }
             'Name' { return ($result | Where-Object { $_.Name -eq $Name }) }
             'VMName' { return ($result | Where-Object { $_.vm_nic_vm_name -eq $VMName }) }
             'MacAddress' {
@@ -2082,8 +2082,8 @@ function Get-SdnVfpPortGroup {
     <#
     .SYNOPSIS
         Enumerates the groups contained within the specific Virtual Filtering Platform (VFP) layer specified for the port.
-    .PARAMETER PortId
-        The Port ID GUID for the network interface.
+    .PARAMETER PortName
+        The port name for the network interface.
     .PARAMETER Layer
         Specify the target layer.
     .PARAMETER Direction
@@ -2097,24 +2097,24 @@ function Get-SdnVfpPortGroup {
     .PARAMETER Credential
         Specifies a user account that has permission to perform this action. The default is the current user.
     .EXAMPLE
-        PS> Get-SdnVfpPortGroup -PortId '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER'
+        PS> Get-SdnVfpPortGroup -PortName '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER'
     .EXAMPLE
-        PS> Get-SdnVfpPortGroup -PortId '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER' -Name 'SLB_GROUP_NAT_IPv4_IN'
+        PS> Get-SdnVfpPortGroup -PortName '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER' -Name 'SLB_GROUP_NAT_IPv4_IN'
     .EXAMPLE
-        PS> Get-SdnVfpPortGroup -PortId '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER' -Direction 'IN'
+        PS> Get-SdnVfpPortGroup -PortName '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER' -Direction 'IN'
     .EXAMPLE
-        PS> Get-SdnVfpPortGroup -PortId '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER' -Type 'IPv4'
+        PS> Get-SdnVfpPortGroup -PortName '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER' -Type 'IPv4'
     .EXAMPLE
-        PS> Get-SdnVfpPortGroup -PortId '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER' -Direction 'IN' -Type 'IPv4'
+        PS> Get-SdnVfpPortGroup -PortName '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER' -Direction 'IN' -Type 'IPv4'
     .EXAMPLE
-        PS> Get-SdnVfpPortGroup -PortId '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER' -ComputerName 'RemoteComputer' -Credential (Get-Credential)
+        PS> Get-SdnVfpPortGroup -PortName '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER' -ComputerName 'RemoteComputer' -Credential (Get-Credential)
     #>
 
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
         [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Default')]
-        [GUID]$PortId,
+        [GUID]$PortName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Default')]
@@ -2144,15 +2144,15 @@ function Get-SdnVfpPortGroup {
 
     try {
         $params = @{
-            PortId = $PortId
+            PortName = $PortName
             Layer = $Layer
         }
 
         if ($PSBoundParameters.ContainsKey('ComputerName')) {
             $results = Invoke-PSRemoteCommand -ComputerName $ComputerName -Credential $Credential -ScriptBlock {
                 param ([guid]$arg0, [string]$arg1)
-                Get-VfpPortGroup -PortId $arg0 -Layer $arg1
-            } -ArgumentList @($params.PortId, $params.Layer)
+                Get-VfpPortGroup -PortName $arg0 -Layer $arg1
+            } -ArgumentList @($params.PortName, $params.Layer)
         }
         else {
             $results = Get-VfpPortGroup @params
@@ -2188,8 +2188,8 @@ function Get-SdnVfpPortLayer {
     <#
     .SYNOPSIS
         Enumerates the layers contained within Virtual Filtering Platform (VFP) for specified for the port.
-    .PARAMETER PortId
-        The Port ID GUID for the network interface
+    .PARAMETER PortName
+        The Port name for the network interface
     .PARAMETER Name
         Returns the specific layer name. If omitted, will return all layers within VFP.
     .PARAMETER ComputerName
@@ -2199,14 +2199,14 @@ function Get-SdnVfpPortLayer {
     .EXAMPLE
         PS> Get-SdnVfpPortLayer
     .EXAMPLE
-        PS> Get-SdnVfpPortLayer -PortId '2152523D-333F-4082-ADE4-107D8CA75F5B'
+        PS> Get-SdnVfpPortLayer -PortName '2152523D-333F-4082-ADE4-107D8CA75F5B'
     .EXAMPLE
-        PS> Get-SdnVfpPortLayer -PortId '2152523D-333F-4082-ADE4-107D8CA75F5B' -ComputerName SDN-HOST01 -Credential (Get-Credential)
+        PS> Get-SdnVfpPortLayer -PortName '2152523D-333F-4082-ADE4-107D8CA75F5B' -ComputerName SDN-HOST01 -Credential (Get-Credential)
     #>
-    [CmdletBinding(DefaultParameterSetName = 'Default')]
+    [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
-        [GUID]$PortId,
+        [Parameter(Mandatory = $true, ParameterSetName = 'PortName')]
+        [GUID]$PortName,
 
         [Parameter(Mandatory = $false)]
         [System.String]$Name,
@@ -2222,14 +2222,14 @@ function Get-SdnVfpPortLayer {
 
     try {
         $params = @{
-            PortId = $PortId
+            PortName = $PortName
         }
 
         if ($PSBoundParameters.ContainsKey('ComputerName')) {
             $results = Invoke-PSRemoteCommand -ComputerName $ComputerName -Credential $Credential -ScriptBlock {
                 param([guid]$arg0)
-                Get-VfpPortLayer -PortId $arg0
-            } -ArgumentList @($params.PortId)
+                Get-VfpPortLayer -PortName $arg0
+            } -ArgumentList @($params.PortName)
         }
         else {
             $results = Get-VfpPortLayer @params
@@ -2251,8 +2251,8 @@ function Get-SdnVfpPortRule {
     <#
     .SYNOPSIS
         Enumerates the rules contained within the specific group within Virtual Filtering Platform (VFP) layer specified for the port.
-    .PARAMETER PortId
-        The Port ID GUID for the network interface.
+    .PARAMETER PortName
+        The port name for the network interface.
     .PARAMETER Layer
         Specify the target layer.
     .PARAMETER Group
@@ -2264,15 +2264,15 @@ function Get-SdnVfpPortRule {
     .PARAMETER Credential
         Specifies a user account that has permission to perform this action. The default is the current user.
     .EXAMPLE
-        PS> Get-SdnVfpPortRule -PortId '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER' -Group 'SLB_GROUP_NAT_IPv4_IN'
+        PS> Get-SdnVfpPortRule -PortName '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER' -Group 'SLB_GROUP_NAT_IPv4_IN'
     .EXAMPLE
-        PS> Get-SdnVfpPortRule -PortId '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER' -Group 'SLB_GROUP_NAT_IPv4_IN' -Name 'SLB_DEFAULT_RULE'
+        PS> Get-SdnVfpPortRule -PortName '2152523D-333F-4082-ADE4-107D8CA75F5B' -Layer 'SLB_NAT_LAYER' -Group 'SLB_GROUP_NAT_IPv4_IN' -Name 'SLB_DEFAULT_RULE'
     #>
 
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [GUID]$PortId,
+        [GUID]$PortName,
 
         [Parameter(Mandatory = $true)]
         [System.String]$Layer,
@@ -2294,7 +2294,7 @@ function Get-SdnVfpPortRule {
 
     try {
         $params = @{
-            PortId = $PortId
+            PortName = $PortName
             Layer = $Layer
             Group = $Group
         }
@@ -2302,8 +2302,8 @@ function Get-SdnVfpPortRule {
         if ($PSBoundParameters.ContainsKey('ComputerName')) {
             $results = Invoke-PSRemoteCommand -ComputerName $ComputerName -Credential $Credential -ScriptBlock {
                 param([guid]$arg0, [string]$arg1, [string]$arg2)
-                Get-VfpPortRule -PortId $arg0 -Layer $arg1 -Group $arg2
-            } -ArgumentList @($params.PortId, $params.Layer, $params.Group)
+                Get-VfpPortRule -PortName $arg0 -Layer $arg1 -Group $arg2
+            } -ArgumentList @($params.PortName, $params.Layer, $params.Group)
         }
         else {
             $results = Get-VfpPortRule @params
@@ -2403,7 +2403,7 @@ function Get-SdnVfpVmSwitchPort {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
         [Parameter(Mandatory = $false, ParameterSetName = 'Port')]
-        [System.String]$PortName,
+        [GUID]$PortName,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'VMID')]
         [System.String]$VMID,
@@ -2837,24 +2837,24 @@ function Show-SdnVfpPortConfig {
     <#
     .SYNOPSIS
         Enumerates the VFP layers, groups and rules contained within Virtual Filtering Platform (VFP) for the specified port.
-    .PARAMETER PortId
-        The Port ID GUID for the network interface.
+    .PARAMETER PortName
+        The port name for the network interface.
     .PARAMETER Direction
         Specify the direction
     .PARAMETER Type
         Specifies an array of IP address families. The cmdlet gets the configuration that matches the address families
     .EXAMPLE
-        PS Show-SdnVfpPortConfig -PortId 8440FB77-196C-402E-8564-B0EF9E5B1931
+        PS Show-SdnVfpPortConfig -PortName 8440FB77-196C-402E-8564-B0EF9E5B1931
     .EXAMPLE
-        PS> Show-SdnVfpPortConfig -PortId 8440FB77-196C-402E-8564-B0EF9E5B1931 -Direction IN
+        PS> Show-SdnVfpPortConfig -PortName 8440FB77-196C-402E-8564-B0EF9E5B1931 -Direction IN
     .EXAMPLE
-        PS> Show-SdnVfpPortConfig -PortId 8440FB77-196C-402E-8564-B0EF9E5B1931 -Direction IN -Type IPv4
+        PS> Show-SdnVfpPortConfig -PortName 8440FB77-196C-402E-8564-B0EF9E5B1931 -Direction IN -Type IPv4
     #>
 
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
         [Parameter(Mandatory = $true, ParameterSetName = 'Default')]
-        [GUID]$PortId,
+        [GUID]$PortName,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
         [ValidateSet('IPv4','IPv6')]
@@ -2866,9 +2866,9 @@ function Show-SdnVfpPortConfig {
     )
 
     try {
-        $vfpLayers = Get-SdnVfpPortLayer -PortId $PortId
+        $vfpLayers = Get-SdnVfpPortLayer -PortName $PortName
         if ($null -eq $vfpLayers) {
-            "Unable to locate PortId {0}" -f $PortId | Trace-Output -Level:Error
+            "Unable to locate PortName {0}" -f $PortName | Trace-Output -Level:Error
             return $null
         }
 
@@ -2876,10 +2876,10 @@ function Show-SdnVfpPortConfig {
             "== Layer: {0} ==" -f $layer.LAYER | Write-Host -ForegroundColor:Magenta
 
             if ($Direction) {
-                $vfpGroups = Get-SdnVfpPortGroup -PortId $PortId -Layer $layer.LAYER -Direction $Direction
+                $vfpGroups = Get-SdnVfpPortGroup -PortName $PortName -Layer $layer.LAYER -Direction $Direction
             }
             else {
-                $vfpGroups = Get-SdnVfpPortGroup -PortId $PortId -Layer $layer.LAYER
+                $vfpGroups = Get-SdnVfpPortGroup -PortName $PortName -Layer $layer.LAYER
             }
 
             if ($Type) {
@@ -2888,7 +2888,7 @@ function Show-SdnVfpPortConfig {
 
             foreach ($group in $vfpGroups) {
                 "== Group: {0} ==" -f $group.GROUP | Write-Host -ForegroundColor:Yellow
-                Get-SdnVfpPortRule -PortId $PortId -Layer $layer.LAYER -Group $group.GROUP | Format-Table -AutoSize
+                Get-SdnVfpPortRule -PortName $PortName -Layer $layer.LAYER -Group $group.GROUP | Format-Table -AutoSize
             }
         }
     }


### PR DESCRIPTION
# Description
Summary of changes:
This pull request includes several changes to the `src/modules/SdnDiag.NetworkController.psm1` and `src/modules/SdnDiag.Server.psm1` files to enhance functionality and improve error handling. The key changes include adding a new parameter to convert output to JSON, modifying parameter attributes, and improving error handling in various functions.

Enhancements to functionality:

* [`src/modules/SdnDiag.NetworkController.psm1`](diffhunk://#diff-26f7a08ead3e5bf8f7eb9bc916e1240653352463c34fb7321d570202143203f8R2020-R2021): Added a new `ConvertToJson` parameter to the `Get-SdnResource` function to allow conversion of output to JSON format. [[1]](diffhunk://#diff-26f7a08ead3e5bf8f7eb9bc916e1240653352463c34fb7321d570202143203f8R2020-R2021) [[2]](diffhunk://#diff-26f7a08ead3e5bf8f7eb9bc916e1240653352463c34fb7321d570202143203f8R2056-R2068) [[3]](diffhunk://#diff-26f7a08ead3e5bf8f7eb9bc916e1240653352463c34fb7321d570202143203f8R2132-R2138)

Modifications to parameter attributes:

* [`src/modules/SdnDiag.NetworkController.psm1`](diffhunk://#diff-26f7a08ead3e5bf8f7eb9bc916e1240653352463c34fb7321d570202143203f8L2039-R2044): Changed the `NcUri` and `ResourceRef` parameters to be mandatory in the `Get-SdnResource` function.

Improvements to error handling:

* [`src/modules/SdnDiag.Server.psm1`](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL747-R765): Updated multiple functions (`Get-VfpPortGroup`, `Get-VfpPortLayer`, `Get-VfpPortRule`, `Get-VfpPortState`, `Get-VfpVMSwitchPort`, `Get-SdnOvsdbPhysicalPort`) to improve error handling by throwing exceptions with detailed messages when errors occur. [[1]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL747-R765) [[2]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL863-R887) [[3]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL952-R957) [[4]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL1249-R1262) [[5]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL1333-R1354) [[6]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL1845-R1865) [[7]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL2085-R2105) [[8]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL2191-R2211)

Parameter name standardization:

* [`src/modules/SdnDiag.Server.psm1`](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL747-R765): Standardized the parameter name from `PortId` to `PortName` across multiple functions to maintain consistency. [[1]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL747-R765) [[2]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL863-R887) [[3]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL952-R957) [[4]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL1845-R1865) [[5]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL2085-R2105) [[6]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL2191-R2211)

Change in function behavior:

* [`src/modules/SdnDiag.NetworkController.psm1`](diffhunk://#diff-26f7a08ead3e5bf8f7eb9bc916e1240653352463c34fb7321d570202143203f8L2124-R2123): Modified the `Get-SdnResource` function to handle multiple returned objects by updating the `$result` variable instead of returning it directly.

# Change type
- [x] Bug fix (non-breaking change)
- [x] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [x] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.