### PR TITLE
Misc Code Fixes 2025-03 

### DIFF
--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -1129,7 +1129,6 @@ function Start-SdnDataCollection {
     }
 
     $dataCollectionObject | Export-ObjectToFile -FilePath $OutputDirectory.FullName -Name 'SdnDataCollection_Summary' -FileType json -Depth 4 -ErrorAction Continue
-    Copy-Item -Path (Get-TraceOutputFile) -Destination $OutputDirectory.FullName -Force -ErrorAction Continue
 
     # we will return the object to the caller regardless if the data collection was successful or not
     $msg = "Sdn Data Collection completed with status of {0}" -f $dataCollectionObject.Result

--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -927,14 +927,13 @@ function Start-SdnDataCollection {
         }
 
         if ($nodesToRemove.Count -gt 0) {
-            $nodesToRemove | ForEach-Object {
-                "Removing {0} from data collection due to WinRM connectivity issues" -f $_.Name | Trace-Output -Level:Warning
-                [void]$dataCollectionNodes.Remove($_)
+            foreach ($node in $nodesToRemove) {
+                "{0} with role {1} removed from data collection due to WinRM connectivity issues" -f $node.Name, $node.Role | Trace-Output -Level:Warning
+                $dataCollectionNodes = $dataCollectionNodes | Where-Object { $_.Name -ne $node.Name }
             }
         }
         $Global:ProgressPreference = 'Continue'
 
-        $dataCollectionNodes = $dataCollectionNodes | Sort-Object -Property Name -Unique
         $groupedObjectsByRole = $dataCollectionNodes | Group-Object -Property Role
 
         # ensure SdnDiagnostics installed across the data nodes and versions are the same

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -2522,7 +2522,7 @@ function Test-SdnResourceConfigurationState {
     $array = @()
 
     try {
-        "Validating configuration state of {0}" -f $SdnEnvironmentObject.Role.ResourceName | Trace-Output
+        "Validating configuration state of {0}" -f $Resource | Trace-Output
 
         $sdnResources = Get-SdnResource @PSBoundParameters
         foreach ($object in $sdnResources) {

--- a/src/modules/SdnDiag.NetworkController.FC.psm1
+++ b/src/modules/SdnDiag.NetworkController.FC.psm1
@@ -53,6 +53,16 @@ function Get-NetworkControllerFCConfigState {
 
         [string]$regDir = Join-Path -Path $outDir -ChildPath "Registry"
         Export-RegistryKeyConfigDetails -Path $config.properties.regKeyPaths -OutputDirectory $regDir
+
+        Get-Cluster | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-ClusterFaultDomain | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-ClusterNode | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-ClusterGroup | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-ClusterNetwork | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-ClusterNetworkInterface | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-ClusterResource | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-ClusterResourceType | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-ClusterSharedVolume | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
     }
     catch {
         $_ | Trace-Exception

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -667,29 +667,9 @@ function Get-ServerConfigState {
         Get-SdnOvsdbPhysicalPort | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-SdnOvsdbUcastMacRemoteTable | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
 
-        # Get virtual machine details
-        "Gathering virtual machine configuration details" | Trace-Output -Level:Verbose
-        $virtualMachines = Get-VM
-        if ($virtualMachines) {
-            $virtualMachines | Export-ObjectToFile -FilePath $outDir -Name 'Get-VM' -FileType txt -Format List
-            $vmRootDir = New-Item -Path (Join-Path -Path $outDir -ChildPath "VM") -ItemType Directory -Force
-
-            foreach ($vm in $virtualMachines) {
-                $vmName = $vm.Name.ToString().Replace(" ", "_").Trim()
-                $vmDir = New-Item -Path (Join-Path -Path $vmRootDir.FullName -ChildPath $vm.VMId) -ItemType Directory -Force
-
-                $vm | Get-VMNetworkAdapter | Export-ObjectToFile -FilePath $vmDir.FullName -Prefix $vmName -Name 'Get-VMNetworkAdapter' -FileType txt -Format List
-                $vm | Get-VMNetworkAdapterAcl | Export-ObjectToFile -FilePath $vmDir.FullName -Prefix $vmName -Name 'Get-VMNetworkAdapterAcl' -FileType txt -Format List
-                $vm | Get-VMNetworkAdapterExtendedAcl | Export-ObjectToFile -FilePath $vmDir.FullName -Prefix $vmName -Name 'Get-VMNetworkAdapterExtendedAcl'-FileType txt -Format List
-                $vm | Get-VMNetworkAdapterIsolation | Export-ObjectToFile -FilePath $vmDir.FullName -Prefix $vmName -Name 'Get-VMNetworkAdapterIsolation' -FileType txt -Format List
-                $vm | Get-VMNetworkAdapterRoutingDomainMapping | Export-ObjectToFile -FilePath $vmDir.FullName -Prefix $vmName -Name 'Get-VMNetworkAdapterRoutingDomainMapping' -FileType txt -Format List
-                $vm | Get-VMNetworkAdapterTeamMapping | Export-ObjectToFile -FilePath $vmDir.FullName -Prefix $vmName -Name 'Get-VMNetworkAdapterTeamMapping' -FileType txt -Format List
-                $vm | Get-VMNetworkAdapterVLAN | Export-ObjectToFile -FilePath $vmDir.FullName -Prefix $vmName -Name 'Get-VMNetworkAdapterVLAN' -FileType txt -Format List
-            }
-        }
-
         # Gather Hyper-V network details
         "Gathering Hyper-V network configuration details" | Trace-Output -Level:Verbose
+        Get-VM | Export-ObjectToFile -FilePath $outDir -FileType csv -Force
         Get-NetAdapterVPort | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetAdapterVmqQueue | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-SdnNetAdapterEncapOverheadConfig | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
@@ -701,6 +681,7 @@ function Get-ServerConfigState {
         Get-VMSwitchTeam | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
 
         # enumerate the vm switches and gather details
+        "Gathering VMSwitch details" | Trace-Output -Level:Verbose
         $vmSwitch = Get-VMSwitch
         if ($vmSwitch) {
             $vmSwitchRootDir = New-Item -Path (Join-Path -Path $outDir -ChildPath "VMSwitch") -ItemType Directory -Force

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -2416,7 +2416,7 @@ function Wait-PSJob {
                 $stopWatch.Stop()
 
                 "[{0}] Job {1} has exceeded the timeout of {2} seconds. Stopping job." -f $Name, $job.Name, $ExecutionTimeOut | Trace-Output -Level:Warning
-                Get-Job -Name $Name | Stop-Job -Confirm:$false -State Failed
+                Get-Job -Name $Name | Stop-Job -Confirm:$false
             }
 
             # pause the loop per polling interval value

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -50,7 +50,7 @@ function Enable-SdnDiagTraceOutputLogging {
     #>
 
     [Environment]::SetEnvironmentVariable('SDN_DIAG_TRACE_ENABLED', $true, 'Machine')
-    return (Get-SdnDiagnosticTracing)
+    return (Get-SdnDiagTraceOutputLogging)
 }
 
 function Disable-SdnDiagTraceOutputLogging {

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -49,7 +49,7 @@ function Enable-SdnDiagTraceOutputLogging {
             Enables sdndiagnostics trace logging for the current machine.
     #>
 
-    [Environment]::SetEnvironmentVariable('SDN_DIAG_TRACE_ENABLED', $true, 'Machine')
+    [Environment]::SetEnvironmentVariable('SDN_DIAG_TRACE_ENABLED', $true)
     return (Get-SdnDiagTraceOutputLogging)
 }
 
@@ -59,7 +59,7 @@ function Disable-SdnDiagTraceOutputLogging {
             Disables sdndiagnostics trace logging for the current machine.
     #>
 
-    [Environment]::SetEnvironmentVariable('SDN_DIAG_TRACE_ENABLED', $false, 'Machine')
+    [Environment]::SetEnvironmentVariable('SDN_DIAG_TRACE_ENABLED', $false)
     return (Get-SdnDiagTraceOutputLogging)
 }
 
@@ -78,7 +78,7 @@ function Get-SdnDiagTraceOutputFile {
             Returns the sdndiagnostics trace log file. Even if the trace logging is disabled, this will return the path to the trace log file.
     #>
 
-    return ($Script:SdnDiagnostics_Utilities.Cache.TraceFilePath)
+    return (Get-TraceOutputFile)
 }
 
 function Confirm-DiskSpace {

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -374,7 +374,12 @@ function Confirm-RequiredFeaturesInstalled {
         }
         else {
             foreach($obj in $Name){
-                if(!(Get-WindowsFeature -Name $obj).Installed){
+                try {
+                    if(!(Get-WindowsFeature -Name $obj).Installed){
+                        return $false
+                    }
+                }
+                catch {
                     return $false
                 }
             }
@@ -2865,23 +2870,32 @@ function Get-EnvironmentMode {
 function Get-EnvironmentRole {
     $array = @('Common')
 
-    $featuresInstalled = Get-WindowsFeature | Where-Object {$_.Installed -ieq $true}
-    foreach ($feature in $featuresInstalled) {
-        if ($feature.Name -ieq 'NetworkController') {
-            $array += 'NetworkController'
+    try {
+        $featuresInstalled = Get-WindowsFeature | Where-Object {$_.Installed -ieq $true}
+        if ($null -eq $featuresInstalled) {
+            return $array
         }
 
-        if ($feature.Name -ieq 'Hyper-V') {
-            $array += 'Server'
-        }
+        foreach ($feature in $featuresInstalled) {
+            if ($feature.Name -ieq 'NetworkController') {
+                $array += 'NetworkController'
+            }
 
-        if ($feature.Name -ieq 'RemoteAccess') {
-            $array += 'Gateway'
-        }
+            if ($feature.Name -ieq 'Hyper-V') {
+                $array += 'Server'
+            }
 
-        if ($feature.Name -ieq 'SoftwareLoadBalancer') {
-            $array += 'LoadBalancerMux'
+            if ($feature.Name -ieq 'RemoteAccess') {
+                $array += 'Gateway'
+            }
+
+            if ($feature.Name -ieq 'SoftwareLoadBalancer') {
+                $array += 'LoadBalancerMux'
+            }
         }
+    }
+    catch {
+        # suppress any errors here, as we do not want to fail the script
     }
 
     return $array

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -367,25 +367,18 @@ function Confirm-RequiredFeaturesInstalled {
         [System.String[]]$Name
     )
 
+    if($null -eq $Name){
+        return $true
+    }
+
     try {
-
-        if($null -eq $Name){
-            return $true
-        }
-        else {
-            foreach($obj in $Name){
-                try {
-                    if(!(Get-WindowsFeature -Name $obj).Installed){
-                        return $false
-                    }
-                }
-                catch {
-                    return $false
-                }
+        foreach($obj in $Name){
+            if(-not (Get-WindowsFeature -Name $obj).Installed){
+                return $false
             }
-
-            return $true
         }
+
+        return $true
     }
     catch {
         $_ | Trace-Exception


### PR DESCRIPTION
# Description
This pull request includes multiple changes across various functions in different files to improve the functionality and efficiency of the codebase. The most important changes include modifications to data collection, configuration state validation, cluster state export, and trace logging.

### Data Collection and Configuration State Validation:

* [`src/SdnDiagnostics.psm1`](diffhunk://#diff-490865628c61b2e97c50f45b37d7086647c70b2444cbfb9c60cc8c682801356eL1132): Removed the `Copy-Item` command for trace output file in `Start-SdnDataCollection` function to streamline the process.
* [`src/modules/SdnDiag.Health.psm1`](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L2525-R2525): Updated the `Test-SdnResourceConfigurationState` function to use `$Resource` instead of `$SdnEnvironmentObject.Role.ResourceName` for configuration state validation.

### Cluster State Export:

* [`src/modules/SdnDiag.NetworkController.FC.psm1`](diffhunk://#diff-9d7dd8ad1b4e123a03f6440ee1a241e1831b43f5a5f981f98d018728966cfc48R56-R65): Added multiple `Get-Cluster` commands to export cluster configuration details to text files in the `Get-NetworkControllerFCConfigState` function.

### Trace Logging:

* [`src/modules/SdnDiag.Utilities.psm1`](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcL52-R53): Updated `Enable-SdnDiagTraceOutputLogging` and `Disable-SdnDiagTraceOutputLogging` functions to remove the 'Machine' scope from the `SetEnvironmentVariable` calls. [[1]](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcL52-R53) [[2]](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcL62-R62)
* [`src/modules/SdnDiag.Utilities.psm1`](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcL81-R81): Modified `Get-SdnDiagTraceOutputFile` function to directly return the result of `Get-TraceOutputFile`.

### Miscellaneous:

* [`src/modules/SdnDiag.Utilities.psm1`](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcL1528-R1526): Increased the `ExecutionTimeout` parameter from 600 to 900 seconds in `Invoke-PSRemoteCommand` and `Wait-PSJob` functions. [[1]](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcL1528-R1526) [[2]](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcL2392-R2390)
* [`src/modules/SdnDiag.Utilities.psm1`](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcL370-L384): Added error handling and logging improvements in various functions, including `Confirm-RequiredFeaturesInstalled`, `Wait-PSJob`, `Get-EnvironmentMode`, and `Get-EnvironmentRole`. [[1]](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcL370-L384) [[2]](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcL2415-L2420) [[3]](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcR2867-R2872) [[4]](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcR2890-R2893)

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.