### PR TITLE
Misc Code Fixes 2025-03 - 2

### DIFF
--- a/src/modules/SdnDiag.Common.psm1
+++ b/src/modules/SdnDiag.Common.psm1
@@ -530,24 +530,17 @@ function Get-CommonConfigState {
         Get-NetAdapterSriovVf | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetAdapterRsc | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetAdapterHardwareInfo | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterRdma | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterAdvancedProperty | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterBinding | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterChecksumOffload | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterStatistics | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
 
         ipconfig /allcompartments /all | Export-ObjectToFile -FilePath $outDir -Name 'ipconfig_allcompartments' -FileType txt -Force
         netsh winhttp show proxy | Export-ObjectToFile -FilePath $outDir -Name 'netsh_winhttp_show_proxy' -FileType txt -Force
 
-        $netAdapter = Get-NetAdapter
-        if ($netAdapter) {
-            $netAdapterRootDir = New-Item -Path (Join-Path -Path $outDir -ChildPath 'NetAdapter') -ItemType Directory -Force
-            foreach ($adapter in $netAdapter) {
-                $prefix = $adapter.Name.ToString().Replace(' ','_').Trim()
-                $adapter | Get-NetAdapterAdvancedProperty -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterAdvancedProperty' -FileType txt -Format List
-                $adapter | Get-NetAdapterBinding -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterBinding' -FileType txt -Format List
-                $adapter | Get-NetAdapterChecksumOffload -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterChecksumOffload' -FileType txt -Format List
-                $adapter | Get-NetAdapterHardwareInfo -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterHardwareInfo' -FileType txt -Format List
-                $adapter | Get-NetAdapterRsc -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterRsc' -FileType txt -Format List
-                $adapter | Get-NetAdapterSriov -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterSriov' -FileType txt -Format List
-                $adapter | Get-NetAdapterStatistics -ErrorAction $ErrorActionPreference | Export-ObjectToFile -FilePath $netAdapterRootDir.FullName -Prefix $prefix -Name 'Get-NetAdapterStatistics' -FileType txt -Format List
-            }
-        }
+        Get-SmbClientNetworkInterface | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-SmbClientConfiguration | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
 
         # Gather DNS client settings
         Get-DnsClient | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -1817,10 +1817,12 @@ function New-PSRemotingSession {
 
     begin {
         $importRemoteModule = {
-            param([string]$arg0, $arg1)
+            param([string]$arg0, [bool]$arg1, [bool]$arg2)
             try {
                 Import-Module $arg0 -ErrorAction Stop
-                $Global:SdnDiagnostics.Config = $arg1
+                $Global:SdnDiagnostics.Config.ModuleName = $arg0
+                $Global:SdnDiagnostics.Config.DisableModuleSeeding = $arg1
+                $Global:SdnDiagnostics.Config.ImportModuleOnRemoteSession = $arg2
             }
             catch {
                 throw $_
@@ -1859,7 +1861,7 @@ function New-PSRemotingSession {
                     $moduleImported = Invoke-Command -Session $session -ScriptBlock $confirmRemoteModuleImported -ArgumentList @($ModuleName) -ErrorAction Stop
                     if (-NOT $moduleImported) {
                         "Importing module {0} on remote session {1}" -f $ModuleName, $session.Name | Trace-Output -Level:Verbose
-                        Invoke-Command -Session $session -ScriptBlock $importRemoteModule -ArgumentList @($ModuleName, $Global:SdnDiagnostics.Config) -ErrorAction Stop
+                        Invoke-Command -Session $session -ScriptBlock $importRemoteModule -ArgumentList @($ModuleName, $Global:SdnDiagnostics.Config.DisableModuleSeeding, $Global:SdnDiagnostics.Config.ImportModuleOnRemoteSession) -ErrorAction Stop
                     }
                 }
 

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -1816,8 +1816,11 @@ function New-PSRemotingSession {
     )
 
     begin {
+        [bool]$disableSeeding = $Global:SdnDiagnostics.Config.DisableModuleSeeding
+        [bool]$importModuleOnRemoteSession = $Global:SdnDiagnostics.Config.ImportModuleOnRemoteSession
+
         $importRemoteModule = {
-            param([string]$arg0, [bool]$arg1, [bool]$arg2)
+            param([string]$arg0, $arg1, $arg2)
             try {
                 Import-Module $arg0 -ErrorAction Stop
                 $Global:SdnDiagnostics.Config.ModuleName = $arg0
@@ -1861,7 +1864,7 @@ function New-PSRemotingSession {
                     $moduleImported = Invoke-Command -Session $session -ScriptBlock $confirmRemoteModuleImported -ArgumentList @($ModuleName) -ErrorAction Stop
                     if (-NOT $moduleImported) {
                         "Importing module {0} on remote session {1}" -f $ModuleName, $session.Name | Trace-Output -Level:Verbose
-                        Invoke-Command -Session $session -ScriptBlock $importRemoteModule -ArgumentList @($ModuleName, $Global:SdnDiagnostics.Config.DisableModuleSeeding, $Global:SdnDiagnostics.Config.ImportModuleOnRemoteSession) -ErrorAction Stop
+                        Invoke-Command -Session $session -ScriptBlock $importRemoteModule -ArgumentList @($ModuleName, $disableSeeding, $importModuleOnRemoteSession) -ErrorAction Stop
                     }
                 }
 
@@ -1914,7 +1917,7 @@ function New-PSRemotingSession {
                 "Created powershell session {0} to {1}" -f $session.Name, $objectName | Trace-Output -Level:Verbose
                 if ($ImportModuleOnRemoteSession) {
                     "Importing module {0} on remote session {1}" -f $ModuleName, $session.Name | Trace-Output -Level:Verbose
-                    Invoke-Command -Session $session -ScriptBlock $importRemoteModule -ArgumentList @($ModuleName, $Global:SdnDiagnostics.Config) -ErrorAction Stop
+                    Invoke-Command -Session $session -ScriptBlock $importRemoteModule -ArgumentList @($ModuleName, $disableSeeding, $importModuleOnRemoteSession) -ErrorAction Stop
                 }
 
                 # add the session to the array
@@ -2885,7 +2888,6 @@ function Get-EnvironmentRole {
             # if SDNApiService is running, we will assume that this is a Windows Server NC cluster
             if (Get-Service -Name 'SDNApiService' -ErrorAction Ignore) {
                 $array += 'NetworkController'
-                $array += 'Server'
             }
         }
 
@@ -2898,11 +2900,18 @@ function Get-EnvironmentRole {
         }
 
         # examine the features installed to determine if this is a Hyper-V host
-        # if we have Hyper-V installed we want to exclude the SoftwareLoadBalancer and RemoteAccess roles
-        # as these roles are not valid on Hyper-V hosts
+        # check to see if any virtual machines are running on the node
+        # if no virtual machines are on the system, we will check to see if any virtual switches are present
         if ($featuresInstalled.Name -icontains 'Hyper-V') {
-            if ($featuresInstalled.Name -inotcontains "SoftwareLoadBalancer" -and $featuresInstalled.Name -inotcontains "RemoteAccess") {
+            $virtualMachine = Get-CimInstance -Namespace 'root\virtualization\v2' -ClassName 'Msvm_ComputerSystem' -ErrorAction Ignore | Where-Object {$_.Caption -ieq  'Virtual Machine'}
+            if ($virtualMachine) {
                 $array += 'Server'
+            }
+            else {
+                $vSwitch = Get-CimInstance -Namespace "root\virtualization\v2" -Class "Msvm_VirtualEthernetSwitch" -ErrorAction Ignore
+                if ($vSwitch) {
+                    $array += 'Server'
+                }
             }
         }
     }

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -2900,19 +2900,16 @@ function Get-EnvironmentRole {
         }
 
         # examine the features installed to determine if this is a Hyper-V host
-        # check to see if any virtual machines are running on the node
-        # if no virtual machines are on the system, we will check to see if any virtual switches are present
+        # if the NetworkVirtualization feature is installed, we will assume that this is a Hyper-V host
+        # if the NetworkVirtualization feature is not installed, we will check to see if this is hosting virtual machines
         if ($featuresInstalled.Name -icontains 'Hyper-V') {
-            $virtualMachine = Get-CimInstance -Namespace 'root\virtualization\v2' -ClassName 'Msvm_ComputerSystem' -ErrorAction Ignore | Where-Object {$_.Caption -ieq  'Virtual Machine'}
-            if ($virtualMachine) {
+            if ($featuresInstalled.Name -icontains 'NetworkVirtualization') {
                 $array += 'Server'
             }
             else {
-                $vSwitch = Get-CimInstance -Namespace "root\virtualization\v2" -Class "Msvm_VirtualEthernetSwitch" -ErrorAction Ignore
-                if ($vSwitch) {
-                    if ((Get-EnvironmentMode) -ine 'AzureStackHub') {
-                        $array += 'Server'
-                    }
+                $virtualMachine = Get-CimInstance -Namespace 'root\virtualization\v2' -ClassName 'Msvm_ComputerSystem' -ErrorAction Ignore | Where-Object {$_.Caption -ieq  'Virtual Machine'}
+                if ($virtualMachine) {
+                    $array += 'Server'
                 }
             }
         }

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -2910,7 +2910,9 @@ function Get-EnvironmentRole {
             else {
                 $vSwitch = Get-CimInstance -Namespace "root\virtualization\v2" -Class "Msvm_VirtualEthernetSwitch" -ErrorAction Ignore
                 if ($vSwitch) {
-                    $array += 'Server'
+                    if ((Get-EnvironmentMode) -ine 'AzureStackHub') {
+                        $array += 'Server'
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description
This pull request includes several changes to the `src/modules/SdnDiag.Common.psm1` and `src/modules/SdnDiag.Utilities.psm1` files to enhance functionality and improve configuration handling. The most significant changes involve adding new network adapter information retrieval commands, updating the `New-PSRemotingSession` function to handle additional configuration parameters, and refining the environment role detection logic.

### Enhancements to network adapter information retrieval:
* Added commands to retrieve additional network adapter properties such as RDMA, advanced properties, bindings, checksum offload, and statistics in the `Get-CommonConfigState` function.
* Included commands to gather SMB client network interface and configuration details.

### Improvements to remote session configuration:
* Updated the `New-PSRemotingSession` function to include new configuration parameters `DisableModuleSeeding` and `ImportModuleOnRemoteSession`, and adjusted the `importRemoteModule` script block to handle these parameters. [[1]](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcR1819-R1828) [[2]](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcL1862-R1867) [[3]](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcL1915-R1920)

### Refinements to environment role detection:
* Modified the `Get-EnvironmentRole` function to refine the logic for determining if a system is a Hyper-V host by checking for the `NetworkVirtualization` feature and verifying if it hosts virtual machines.
* Removed redundant 'Server' role assignment when `SDNApiService` is running.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.