### PR TITLE
Change the order in which VMNetworkAdapter info is collected

### DIFF
--- a/src/modules/SdnDiag.Common.psm1
+++ b/src/modules/SdnDiag.Common.psm1
@@ -535,6 +535,8 @@ function Get-CommonConfigState {
         Get-NetAdapterBinding | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetAdapterChecksumOffload | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetAdapterStatistics | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterVPort | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterVmqQueue | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
 
         ipconfig /allcompartments /all | Export-ObjectToFile -FilePath $outDir -Name 'ipconfig_allcompartments' -FileType txt -Force
         netsh winhttp show proxy | Export-ObjectToFile -FilePath $outDir -Name 'netsh_winhttp_show_proxy' -FileType txt -Force

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -705,11 +705,14 @@ function Get-ServerConfigState {
         # Gather Hyper-V network details
         "Gathering Hyper-V VM and VMNetworkAdapter configuration details" | Trace-Output -Level:Verbose
         Get-VM | Export-ObjectToFile -FilePath $outDir -FileType csv -Force
-        Get-VMNetworkAdapter -All | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-SdnVMNetworkAdapterPortProfile -All | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-VMNetworkAdapterIsolation | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-VMNetworkAdapterVLAN | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-VMNetworkAdapterRoutingDomainMapping | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+
+        # due to the number of properties returned from Get-VMNetworkAdapter, we need to export as a text file
+        # otherwise it takes several minutes to write the data to the file and risks a timeout
+        Get-VMNetworkAdapter -All | Export-ObjectToFile -FilePath $outDir -FileType txt -Format Table -Force
+        Get-SdnVMNetworkAdapterPortProfile -All | Export-ObjectToFile -FilePath $outDir -FileType txt -Format Table -Force
+        Get-VMNetworkAdapterIsolation | Export-ObjectToFile -FilePath $outDir -FileType txt -Format Table -Force
+        Get-VMNetworkAdapterVLAN | Export-ObjectToFile -FilePath $outDir -FileType txt -Format Table -Force
+        Get-VMNetworkAdapterRoutingDomainMapping | Export-ObjectToFile -FilePath $outDir -FileType txt -Format Table -Force
     }
     catch {
         $_ | Trace-Exception

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -667,21 +667,11 @@ function Get-ServerConfigState {
         Get-SdnOvsdbPhysicalPort | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-SdnOvsdbUcastMacRemoteTable | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
 
-        # Gather Hyper-V network details
-        "Gathering Hyper-V network configuration details" | Trace-Output -Level:Verbose
-        Get-VM | Export-ObjectToFile -FilePath $outDir -FileType csv -Force
-        Get-NetAdapterVPort | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterVmqQueue | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-SdnNetAdapterEncapOverheadConfig | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-SdnVMNetworkAdapterPortProfile -All | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-VMNetworkAdapterIsolation | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-VMNetworkAdapterVLAN | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-VMNetworkAdapterRoutingDomainMapping | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-VMSystemSwitchExtensionPortFeature -FeatureId "9940cd46-8b06-43bb-b9d5-93d50381fd56" | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-VMSwitchTeam | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-
         # enumerate the vm switches and gather details
         "Gathering VMSwitch details" | Trace-Output -Level:Verbose
+        Get-SdnNetAdapterEncapOverheadConfig | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-VMSwitchTeam | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-VMSystemSwitchExtensionPortFeature -FeatureId "9940cd46-8b06-43bb-b9d5-93d50381fd56" | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         $vmSwitch = Get-VMSwitch
         if ($vmSwitch) {
             $vmSwitchRootDir = New-Item -Path (Join-Path -Path $outDir -ChildPath "VMSwitch") -ItemType Directory -Force
@@ -711,6 +701,15 @@ function Get-ServerConfigState {
                 "Failed to execute {0}" -f $cmd | Trace-Output -Level:Error
             }
         }
+
+        # Gather Hyper-V network details
+        "Gathering Hyper-V VM and VMNetworkAdapter configuration details" | Trace-Output -Level:Verbose
+        Get-VM | Export-ObjectToFile -FilePath $outDir -FileType csv -Force
+        Get-VMNetworkAdapter -All | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-SdnVMNetworkAdapterPortProfile -All | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-VMNetworkAdapterIsolation | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-VMNetworkAdapterVLAN | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-VMNetworkAdapterRoutingDomainMapping | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
     }
     catch {
         $_ | Trace-Exception


### PR DESCRIPTION
# Description
This pull request includes changes to the `Get-CommonConfigState` and `Get-ServerConfigState` functions in the `SdnDiag.Common.psm1` and `SdnDiag.Server.psm1` files, respectively. The modifications aim to enhance the data collection process for network adapter and Hyper-V network details.

Changes in `Get-CommonConfigState`:

* Added commands to export VPort and VMQ Queue details.

Changes in `Get-ServerConfigState`:

* Reorganized and updated the gathering of Hyper-V network configuration details, including the reintroduction of commands to export VMNetworkAdapter and related details in a more efficient format. [[1]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL670-R674) [[2]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedR704-R715)


# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.