### PR TITLE
Misc Code Fixes 2025-03 4

### DIFF
--- a/src/modules/SdnDiag.Common.psm1
+++ b/src/modules/SdnDiag.Common.psm1
@@ -511,7 +511,7 @@ function Get-CommonConfigState {
         "Gathering system details" | Trace-Output -Level:Verbose
         Get-Service | Export-ObjectToFile -FilePath $outDir -FileType csv -Force
         Get-Process | Export-ObjectToFile -FilePath $outDir -FileType csv -Force
-        Get-Volume | Export-ObjectToFile -FilePath $outDir -FileType txt -Format Table
+        Get-Volume | Export-ObjectToFile -FilePath $outDir -FileType txt -Format Table -Force
         Get-ComputerInfo | Export-ObjectToFile -FilePath $outDir -FileType txt
 
         # gather network related configuration details
@@ -519,15 +519,17 @@ function Get-CommonConfigState {
 
         # nettcpip module commands
         Get-NetCompartment | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetIPAddress | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetIPConfiguration | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetIPAddress -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetIPConfiguration -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetIPInterface -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetIPv4Protocol | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetIPv6Protocol | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetNeighbor -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -FileType csv -Force
+        Get-NetNeighbor -AddressFamily IPv6 -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetNeighbor_IPv6' -FileType txt -Format Table -Force
+        Get-NetNeighbor -AddressFamily IPv4 -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetNeighbor_IPv6' -FileType txt -Format Table -Force
         Get-NetOffloadGlobalSetting | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetPrefixPolicy | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetRoute -AddressFamily IPv4 -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -FileType csv -Force
+        Get-NetRoute -AddressFamily IPv6 -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetRoute_IPv6' -FileType txt -Format Table -Force
+        Get-NetRoute -AddressFamily IPv4 -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetRoute_IPv4' -FileType txt -Format Table -Force
         Get-NetTCPConnection | Select-Object LocalAddress, LocalPort, RemoteAddress, RemotePort, State, OwningProcess, @{n="ProcessName";e={(Get-Process -Id $_.OwningProcess -ErrorAction $ErrorActionPreference).ProcessName}} `
         | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetTCPConnection' -FileType csv -Force
         Get-NetTCPSetting | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
@@ -540,27 +542,27 @@ function Get-CommonConfigState {
 
         # netadapter module commands
         Get-NetAdapter -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterAdvancedProperty | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterBinding | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterChecksumOffload | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterDataPathConfiguration | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterEncapsulatedPacketTaskOffload | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterHardwareInfo | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterIPsecOffload | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterLso | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterPacketDirect| Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterPowerManagement | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterQos | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterRdma | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterRsc | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterRss | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterSriov | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterSriovVf | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterStatistics | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterUso | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterVmq | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterVmqQueue | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterVPort | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterAdvancedProperty -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterBinding -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterChecksumOffload -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterDataPathConfiguration -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterEncapsulatedPacketTaskOffload -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterHardwareInfo -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterIPsecOffload -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterLso -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterPacketDirect -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterPowerManagement -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterQos -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterRdma -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterRsc -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterRss -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterSriov -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterSriovVf -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterStatistics -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterUso -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterVmq -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterVmqQueue -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterVPort -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
 
         ipconfig /allcompartments /all | Export-ObjectToFile -FilePath $outDir -Name 'ipconfig_allcompartments' -FileType txt -Force
         netsh winhttp show proxy | Export-ObjectToFile -FilePath $outDir -Name 'netsh_winhttp_show_proxy' -FileType txt -Force

--- a/src/modules/SdnDiag.Common.psm1
+++ b/src/modules/SdnDiag.Common.psm1
@@ -517,26 +517,50 @@ function Get-CommonConfigState {
         # gather network related configuration details
         "Gathering network details" | Trace-Output -Level:Verbose
 
-        # declare -Force on these to ensure the files written as txt/csv to prevent automatic conversion to json
-        Get-NetRoute -AddressFamily IPv4 -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -FileType csv -Force
+        # nettcpip module commands
+        Get-NetCompartment | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetIPAddress | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetIPConfiguration | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetIPInterface -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetIPv4Protocol | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetIPv6Protocol | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetNeighbor -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -FileType csv -Force
+        Get-NetOffloadGlobalSetting | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetPrefixPolicy | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetRoute -AddressFamily IPv4 -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -FileType csv -Force
         Get-NetTCPConnection | Select-Object LocalAddress, LocalPort, RemoteAddress, RemotePort, State, OwningProcess, @{n="ProcessName";e={(Get-Process -Id $_.OwningProcess -ErrorAction $ErrorActionPreference).ProcessName}} `
         | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetTCPConnection' -FileType csv -Force
+        Get-NetTCPSetting | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetTransportFilter | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetUDPEndpoint | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetUDPSetting | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
 
-        Get-NetIPInterface | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        # netconnection module commands
         Get-NetConnectionProfile | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapter | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterSriov | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterSriovVf | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterRsc | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterHardwareInfo | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterRdma | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+
+        # netadapter module commands
+        Get-NetAdapter -IncludeHidden | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetAdapterAdvancedProperty | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetAdapterBinding | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetAdapterChecksumOffload | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterDataPathConfiguration | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterEncapsulatedPacketTaskOffload | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterHardwareInfo | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterIPsecOffload | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterLso | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterPacketDirect| Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterPowerManagement | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterQos | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterRdma | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterRsc | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterRss | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterSriov | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterSriovVf | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetAdapterStatistics | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetAdapterVPort | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterUso | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterVmq | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetAdapterVmqQueue | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
+        Get-NetAdapterVPort | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
 
         ipconfig /allcompartments /all | Export-ObjectToFile -FilePath $outDir -Name 'ipconfig_allcompartments' -FileType txt -Force
         netsh winhttp show proxy | Export-ObjectToFile -FilePath $outDir -Name 'netsh_winhttp_show_proxy' -FileType txt -Force

--- a/src/modules/SdnDiag.NetworkController.psm1
+++ b/src/modules/SdnDiag.NetworkController.psm1
@@ -655,32 +655,6 @@ function Invoke-SdnNetworkControllerStateDump {
     return $false
 }
 
-function Remove-PropertiesFromObject {
-    <#
-        .SYNSOPSIS
-        Removes properties from a PSObject.
-    #>
-
-    param(
-        [Parameter(Mandatory=$true)]
-        [PSObject]$Object,
-
-        [Parameter(Mandatory=$true)]
-        [string[]]$PropertiesToRemove
-    )
-
-    # Loop through each property of the object
-    foreach ($property in $Object.PSObject.Properties) {
-
-        # If the property is in the list of properties to remove, remove it
-        if ($property.Name -in $PropertiesToRemove) {
-            $Object.PSObject.Properties.Remove($property.Name)
-        }
-    }
-
-    return $Object
-}
-
 function Test-NetworkControllerIsHealthy {
     try {
         $null = Get-NetworkController -ErrorAction 'Stop'

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -1325,136 +1325,130 @@ function Get-VfpVMSwitchPort {
     #>
 
     $arrayList = [System.Collections.ArrayList]::new()
+    $vfpResults = vfpctrl /list-vmswitch-port
+    if([string]::IsNullOrEmpty($vfpResults)) {
+        $msg = "Unable to retrieve vmswitch ports from vfpctrl"
+        throw New-Object System.NullReferenceException($msg)
+    }
 
-    try {
-        $vfpResults = vfpctrl /list-vmswitch-port
-        if([string]::IsNullOrEmpty($vfpPortState)) {
-            $msg = "Unable to retrieve vmswitch ports from vfpctrl"
-            throw New-Object System.NullReferenceException($msg)
+    # if the line contains a failure, then throw an error and exit the function
+    # this is typically the first line in the output
+    if ($vfpResults[0] -ilike "ERROR:*") {
+        $msg = $vfpResults[0].Split(':')[1].Trim()
+        throw New-Object System.Exception($msg)
+    }
+
+    foreach ($line in $vfpResults) {
+        $line = $line.Trim()
+
+        if ([string]::IsNullOrEmpty($line)) {
+            continue
         }
 
-        # if the line contains a failure, then throw an error and exit the function
-        # this is typically the first line in the output
-        if ($vfpPortState[0] -ilike "ERROR:*") {
-            $msg = $vfpPortState[0].Split(':')[1].Trim()
-            throw New-Object System.Exception($msg)
-        }
+        # lines in the VFP output that contain : contain properties and values
+        # need to split these based on count of ":" to build key and values
+        # some values related to ingress packet drops have multiple ":" so need to account for that
+        # example: {property} : {reason} : {value}
+        # example: {property} : {value}
+        if ($line.Contains(":")) {
+            [System.String[]]$results = $line.Split(':').Trim()
+            if ($results.Count -eq 3) {
+                $key    = $results[1].Replace(' ','').Trim() # we want the key to align with the {reason}
+                $value  = $results[2].Trim()
 
-        foreach ($line in $vfpResults) {
-            $line = $line.Trim()
-
-            if ([string]::IsNullOrEmpty($line)) {
-                continue
-            }
-
-            # lines in the VFP output that contain : contain properties and values
-            # need to split these based on count of ":" to build key and values
-            # some values related to ingress packet drops have multiple ":" so need to account for that
-            # example: {property} : {reason} : {value}
-            # example: {property} : {value}
-            if ($line.Contains(":")) {
-                [System.String[]]$results = $line.Split(':').Trim()
-                if ($results.Count -eq 3) {
-                    $key    = $results[1].Replace(' ','').Trim() # we want the key to align with the {reason}
-                    $value  = $results[2].Trim()
-
-                    if ($results[0].Trim() -eq 'Ingress packet drops') {
-                        $object.NicStatistics.IngressDropReason.$key = $value
-                    }
-                    elseif($results[0].Trim() -eq 'Egress packet drops') {
-                        $object.NicStatistics.EgressDropReason.$key = $value
-                    }
+                if ($results[0].Trim() -eq 'Ingress packet drops') {
+                    $object.NicStatistics.IngressDropReason.$key = $value
                 }
-                elseif ($results.Count -eq 2) {
-                    $key    = $results[0].Trim() # we want the key to align with the {property}
-                    $value  = $results[1].Trim()
-
-                    switch ($key) {
-                        # all ports start with the port name property
-                        # so we will key off this property to know when to add the object to the array
-                        # and to create a new object
-                        'Port name' {
-                            if ($object) {
-                                [void]$arrayList.Add($object)
-                            }
-
-                            $object = [VfpVmSwitchPort]@{
-                                PortName = $value
-                            }
-
-                            continue
-                        }
-
-                        "SR-IOV Weight" { $object.SRIOVWeight = $value }
-                        "SR-IOV Usage" { $object.SRIOVUsage = $value }
-
-                        # populate the NicStatistics object
-                        'Bytes Sent' { $object.NicStatistics.BytesSent = $value }
-                        'Bytes Received' { $object.NicStatistics.BytesReceived = $value }
-                        'Ingress Packet Drops' { $object.NicStatistics.IngressPacketDrops = $value }
-                        'Egress Packet Drops' { $object.NicStatistics.EgressPacketDrops = $value }
-                        'Ingress VFP Drops' { $object.NicStatistics.IngressVfpDrops = $value }
-                        'Egress VFP Drops' { $object.NicStatistics.EgressVfpDrops = $value }
-
-                        # populate the VmNicStatistics object
-                        'Packets Sent' { $object.VmNicStatistics.PacketsSent = $value }
-                        'Packets Received' { $object.VmNicStatistics.PacketsReceived = $value }
-                        'Interrupts Received' { $object.VmNicStatistics.InterruptsReceived = $value }
-                        'Send Buffer Allocation Count' { $object.VmNicStatistics.SendBufferAllocationSize = $value }
-                        'Send Buffer Allocation Size' { $object.VmNicStatistics.SendBufferAllocationSize = $value }
-                        'Receive Buffer Allocation Count' { $object.VmNicStatistics.ReceiveBufferAllocationCount = $value }
-                        'Receive Buffer Allocation Size' { $object.VmNicStatistics.ReceiveBufferAllocationSize = $value }
-                        'Pending Link Change' { $object.VmNicStatistics.PendingLinkChange = $value }
-                        'Ring Buffer Full Errors' { $object.VmNicStatistics.RingBufferFullErrors = $value }
-                        'Pending Routed Packets' { $object.VmNicStatistics.PendingRoutedPackets = $value }
-                        'Insufficient Receive Buffers' { $object.VmNicStatistics.InsufficientReceiveBuffers = $value }
-                        'Insufficient Send Buffers' { $object.VmNicStatistics.InsufficientSendBuffers = $value }
-                        'Insufficient RNDIS Operations Buffers' { $object.VmNicStatistics.InsufficientRndisOperationsBuffers = $value }
-                        'Quota Exceeded Errors' { $object.VmNicStatistics.QuotaExceededErrors = $value }
-                        'Vsp Paused' { $object.VmNicStatistics.VspPaused = $value }
-
-                        # most of the property names, we can just trim and remove the white spaces
-                        # which will align to the class property names
-                        default {
-                            try {
-                                $key = $key.Replace(' ','').Trim()
-                                $object.$key = $value
-                            }
-                            catch {
-                                $object | Add-Member -MemberType NoteProperty -Name $key -Value $value
-                                continue
-                            }
-                        }
-                    }
+                elseif($results[0].Trim() -eq 'Egress packet drops') {
+                    $object.NicStatistics.EgressDropReason.$key = $value
                 }
             }
-            else {
-                switch -Wildcard ($line) {
-                    "Port is*" { $object.PortState = $line.Split(' ')[2].Replace('.','').Trim() }
-                    "MAC Learning is*" { $object.MacLearning = $line.Split(' ')[3].Replace('.','').Trim() }
-                    "NIC is*" { $object.NicState = $line.Split(' ')[2].Replace('.','').Trim() }
-                    "*list-vmswitch-port*" {
-                        # we have reached the end of the file at this point
-                        # and should add any remaining objects to the array
+            elseif ($results.Count -eq 2) {
+                $key    = $results[0].Trim() # we want the key to align with the {property}
+                $value  = $results[1].Trim()
+
+                switch ($key) {
+                    # all ports start with the port name property
+                    # so we will key off this property to know when to add the object to the array
+                    # and to create a new object
+                    'Port name' {
                         if ($object) {
                             [void]$arrayList.Add($object)
                         }
-                    }
-                    default {
-                        # the line does not contain anything we looking for
-                        # and we can skip it and proceed to next
+
+                        $object = [VfpVmSwitchPort]@{
+                            PortName = $value
+                        }
+
                         continue
+                    }
+
+                    "SR-IOV Weight" { $object.SRIOVWeight = $value }
+                    "SR-IOV Usage" { $object.SRIOVUsage = $value }
+
+                    # populate the NicStatistics object
+                    'Bytes Sent' { $object.NicStatistics.BytesSent = $value }
+                    'Bytes Received' { $object.NicStatistics.BytesReceived = $value }
+                    'Ingress Packet Drops' { $object.NicStatistics.IngressPacketDrops = $value }
+                    'Egress Packet Drops' { $object.NicStatistics.EgressPacketDrops = $value }
+                    'Ingress VFP Drops' { $object.NicStatistics.IngressVfpDrops = $value }
+                    'Egress VFP Drops' { $object.NicStatistics.EgressVfpDrops = $value }
+
+                    # populate the VmNicStatistics object
+                    'Packets Sent' { $object.VmNicStatistics.PacketsSent = $value }
+                    'Packets Received' { $object.VmNicStatistics.PacketsReceived = $value }
+                    'Interrupts Received' { $object.VmNicStatistics.InterruptsReceived = $value }
+                    'Send Buffer Allocation Count' { $object.VmNicStatistics.SendBufferAllocationSize = $value }
+                    'Send Buffer Allocation Size' { $object.VmNicStatistics.SendBufferAllocationSize = $value }
+                    'Receive Buffer Allocation Count' { $object.VmNicStatistics.ReceiveBufferAllocationCount = $value }
+                    'Receive Buffer Allocation Size' { $object.VmNicStatistics.ReceiveBufferAllocationSize = $value }
+                    'Pending Link Change' { $object.VmNicStatistics.PendingLinkChange = $value }
+                    'Ring Buffer Full Errors' { $object.VmNicStatistics.RingBufferFullErrors = $value }
+                    'Pending Routed Packets' { $object.VmNicStatistics.PendingRoutedPackets = $value }
+                    'Insufficient Receive Buffers' { $object.VmNicStatistics.InsufficientReceiveBuffers = $value }
+                    'Insufficient Send Buffers' { $object.VmNicStatistics.InsufficientSendBuffers = $value }
+                    'Insufficient RNDIS Operations Buffers' { $object.VmNicStatistics.InsufficientRndisOperationsBuffers = $value }
+                    'Quota Exceeded Errors' { $object.VmNicStatistics.QuotaExceededErrors = $value }
+                    'Vsp Paused' { $object.VmNicStatistics.VspPaused = $value }
+
+                    # most of the property names, we can just trim and remove the white spaces
+                    # which will align to the class property names
+                    default {
+                        try {
+                            $key = $key.Replace(' ','').Trim()
+                            $object.$key = $value
+                        }
+                        catch {
+                            $_ | Trace-Exception
+                            $object | Add-Member -MemberType NoteProperty -Name $key -Value $value
+                            continue
+                        }
                     }
                 }
             }
         }
+        else {
+            switch -Wildcard ($line) {
+                "Port is*" { $object.PortState = $line.Split(' ')[2].Replace('.','').Trim() }
+                "MAC Learning is*" { $object.MacLearning = $line.Split(' ')[3].Replace('.','').Trim() }
+                "NIC is*" { $object.NicState = $line.Split(' ')[2].Replace('.','').Trim() }
+                "*list-vmswitch-port*" {
+                    # we have reached the end of the file at this point
+                    # and should add any remaining objects to the array
+                    if ($object) {
+                        [void]$arrayList.Add($object)
+                    }
+                }
+                default {
+                    # the line does not contain anything we looking for
+                    # and we can skip it and proceed to next
+                    continue
+                }
+            }
+        }
+    }
 
-        return $arrayList
-    }
-    catch {
-        return $object
-        $_ | Trace-Exception
-    }
+    return $arrayList
 }
 
 function Get-SdnNetAdapterEncapOverheadConfig {

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -634,7 +634,7 @@ function Get-ServerConfigState {
 
         # Gather VFP port configuration details
         "Gathering VFP port details" | Trace-Output -Level:Verbose
-        foreach ($vm in (Get-WmiObject -na root\virtualization\v2 msvm_computersystem)) {
+        foreach ($vm in (Get-WmiObject -Namespace 'root\virtualization\v2' -Class 'msvm_computersystem')) {
             foreach ($vma in $vm.GetRelated("Msvm_SyntheticEthernetPort")) {
                 foreach ($port in $vma.GetRelated("Msvm_SyntheticEthernetPortSettingData").GetRelated("Msvm_EthernetPortAllocationSettingData").GetRelated("Msvm_EthernetSwitchPort")) {
                     $outputDir = New-Item -Path (Join-Path -Path $outDir -ChildPath "VFP\$($vm.ElementName)") -ItemType Directory -Force

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -2992,4 +2992,45 @@ function Get-SubnetMaskFromCidr {
     return ( $octets -join ('.') )
 }
 
+function Remove-PropertiesFromObject {
+    <#
+    .SYNOPSIS
+        Creates a PSCustomObject with the specified properties removed.
+    .PARAMETER Object
+        The object to remove properties from.
+    .PARAMETER PropertiesToRemove
+        The properties to remove from the object.
+    .EXAMPLE
+        $object = Get-Process | Select-Object -First 1
+        $object | Remove-PropertiesFromObject -PropertiesToRemove 'Handles', 'VM'
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        $Object,
 
+        [Parameter()]
+        [string[]]$PropertiesToRemove
+    )
+
+    begin {
+        $array = @()
+    }
+    process {
+        foreach ($obj in $Object) {
+            $customObject = [PSCustomObject]@{}
+            foreach ($property in $Object.PSObject.Properties) {
+                if  ($PropertiesToRemove -contains $property.Name) {
+                    continue
+                }
+
+                $customObject | Add-Member -MemberType NoteProperty -Name $property.Name -Value $property.Value
+            }
+
+            $array += $customObject
+        }
+    }
+    end {
+        return $array
+    }
+}


### PR DESCRIPTION
# Description
This pull request includes several changes across multiple PowerShell scripts to enhance network configuration data gathering and improve code maintainability.

### Enhancements to network configuration data gathering:

* [`src/modules/SdnDiag.Common.psm1`](diffhunk://#diff-9ab71f66f6e21719dc9527f01ea738656003bbbe631f4f1bd85ab1ab8a746f24L520-R563): Added various `Get-Net*` commands to gather more comprehensive network-related details and organized them by module (`nettcpip`, `netconnection`, `netadapter`).
* [`src/modules/SdnDiag.Server.psm1`](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL707-R753): Enhanced the `Get-ServerConfigState` function to export VM details in both CSV and JSON formats and added logic to handle VM network adapters more efficiently by removing redundant properties.

### Code maintainability improvements:

* [`src/modules/SdnDiag.NetworkController.psm1`](diffhunk://#diff-26f7a08ead3e5bf8f7eb9bc916e1240653352463c34fb7321d570202143203f8L658-L683): Removed the `Remove-PropertiesFromObject` function to reduce redundancy, as it was moved to a utility module.
* [`src/modules/SdnDiag.Utilities.psm1`](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcR2995-R3036): Added the `Remove-PropertiesFromObject` function to create a reusable utility for removing specified properties from objects.
* [`src/modules/SdnDiag.Server.psm1`](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL1328-R1375): Improved error handling and logging in the `Get-VfpVMSwitchPort` function by adding exception tracing and removing unnecessary try-catch blocks. [[1]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL1328-R1375) [[2]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL1454-L1458)

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.