### PR TITLE
Misc Code Fixes 2025-03 6 

### DIFF
--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -967,13 +967,14 @@ function Start-SdnDataCollection {
 
         "Collect configuration state details" | Trace-Output
         $splat = @{
-            ComputerName = $dataCollectionNodes.Name
-            Credential   = $Credential
-            ScriptBlock  = $collectConfigStateSB
-            ArgumentList = @($tempDirectory.FullName)
-            AsJob        = $true
-            PassThru     = $true
-            Activity     = "Collect Configuration State"
+            ComputerName     = $dataCollectionNodes.Name
+            Credential       = $Credential
+            ScriptBlock      = $collectConfigStateSB
+            ArgumentList     = @($tempDirectory.FullName)
+            AsJob            = $true
+            PassThru         = $true
+            ExecutionTimeout = 1200 # 20 minutes
+            Activity         = "Collect Configuration State"
         }
         Invoke-PSRemoteCommand @splat
 
@@ -992,13 +993,14 @@ function Start-SdnDataCollection {
         if ($IncludeNetView) {
             "Collecting Get-NetView" | Trace-Output
             $splat = @{
-                ComputerName = $dataCollectionNodes.Name
-                Credential   = $Credential
-                ScriptBlock  = $collectNetViewSB
-                ArgumentList = @($tempDirectory.FullName)
-                AsJob        = $true
-                PassThru     = $true
-                Activity     = 'Collect Get-NetView'
+                ComputerName     = $dataCollectionNodes.Name
+                Credential       = $Credential
+                ScriptBlock      = $collectNetViewSB
+                ArgumentList     = @($tempDirectory.FullName)
+                AsJob            = $true
+                PassThru         = $true
+                ExecutionTimeout = 1200 # 20 minutes
+                Activity         = 'Collect Get-NetView'
             }
             $null = Invoke-PSRemoteCommand @splat
         }

--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -973,7 +973,7 @@ function Start-SdnDataCollection {
             ArgumentList     = @($tempDirectory.FullName)
             AsJob            = $true
             PassThru         = $true
-            ExecutionTimeout = 1200 # 20 minutes
+            ExecutionTimeout = 1800 # 30 minutes
             Activity         = "Collect Configuration State"
         }
         Invoke-PSRemoteCommand @splat
@@ -999,7 +999,7 @@ function Start-SdnDataCollection {
                 ArgumentList     = @($tempDirectory.FullName)
                 AsJob            = $true
                 PassThru         = $true
-                ExecutionTimeout = 1200 # 20 minutes
+                ExecutionTimeout = 1800 # 30 minutes
                 Activity         = 'Collect Get-NetView'
             }
             $null = Invoke-PSRemoteCommand @splat

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -1001,12 +1001,12 @@ function Export-ObjectToFile {
             # which we will want to remove from the object beofre exporting it out
             if ($FileType -ieq 'json') {
                 $objectTypeName = $obj.GetType().Name
-                switch -Wildcard ($objectTypeName) {
+                switch ($objectTypeName) {
                     'CimInstance' {
                         $obj = $obj | Remove-PropertiesFromObject -PropertiesToRemove 'CimClass','CimInstanceProperties','CimSystemProperties'
                         break
                     }
-                    'VMNetworkAdapter*' {
+                    'VMNetworkAdapter' {
                         $obj = $obj | Remove-PropertiesFromObject -PropertiesToRemove 'ParentAdapter','CimSession'
                         break
                     }


### PR DESCRIPTION
# Description
This pull request includes several changes to the `SdnDiagnostics` module to enhance data collection and improve code efficiency. The most important changes are related to adding execution timeouts, modifying the format of exported data, and optimizing the data collection process.

### Enhancements to data collection:

* [`src/SdnDiagnostics.psm1`](diffhunk://#diff-490865628c61b2e97c50f45b37d7086647c70b2444cbfb9c60cc8c682801356eR976): Added `ExecutionTimeout` parameter with a value of 1800 seconds (30 minutes) to the `Start-SdnDataCollection` function to prevent long-running tasks from hanging indefinitely. [[1]](diffhunk://#diff-490865628c61b2e97c50f45b37d7086647c70b2444cbfb9c60cc8c682801356eR976) [[2]](diffhunk://#diff-490865628c61b2e97c50f45b37d7086647c70b2444cbfb9c60cc8c682801356eR1002)

### Improvements to data export:

* [`src/modules/SdnDiag.Server.psm1`](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL709-R734): Changed the export format of `Get-VM` data from `Table` to `List` for better readability and consistency.
* [`src/modules/SdnDiag.Server.psm1`](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL742-R752): Reorganized and optimized the export process for VM network adapters by removing unnecessary properties and reordering operations for efficiency.

### Code efficiency:

* [`src/modules/SdnDiag.Utilities.psm1`](diffhunk://#diff-9e50bcf150b088e2c4df3d0768d8dcad4abf1338de3498749997682448a07bdcL1004-R1009): Simplified the `Export-ObjectToFile` function by removing wildcard usage in the switch statement and specifying exact type matches for better performance.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.