### PR TITLE
Fix diagnostics health test

### DIFF
--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -2470,14 +2470,14 @@ function Test-SdnServiceFabricNodeStatus {
     $sdnHealthTest = New-SdnHealthTest
 
     try {
-        $ncNodes = Get-SdnServiceFabricNode -NodeName $env:COMPUTERNAME -ErrorAction Stop
-        if ($null -eq $ncNodes) {
+        $ncNode = Get-SdnServiceFabricNode -NodeName $env:COMPUTERNAME -ErrorAction Stop
+        if ($null -eq $ncNode) {
             $sdnHealthTest.Result = 'FAIL'
         }
         else {
-            if ($ncNodes.Status -ine 'Up') {
+            if ($ncNode.NodeStatus -ine 'Up' -or $ncNode.HealthState -ine 'Ok') {
                 $sdnHealthTest.Result = 'FAIL'
-                $sdnHealthTest.Remediation = 'Examine the Service Fabric Nodes for Network Controller to determine why the node is not Up.'
+                $sdnHealthTest.Remediation = 'Examine the Service Fabric Nodes for Network Controller to determine why the node is not Up or Healthy.'
             }
         }
     }


### PR DESCRIPTION
# Description
This pull request includes changes to the `src/modules/SdnDiag.Health.psm1` file to update the property names used in health check functions. The most important changes include modifying the connection state and node status checks to use the correct property names.

Updates to property names:

* [`src/modules/SdnDiag.Health.psm1`](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L2357-R2357): In the `Test-SdnHostAgentConnectionStateToApiService` function, changed the property checked from `ConnectionState` to `State` to correctly determine if the connection is established.
* [`src/modules/SdnDiag.Health.psm1`](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L2478-R2478): In the `Test-SdnServiceFabricNodeStatus` function, changed the property checked from `NodeStatus` to `Status` to correctly determine if the node is up.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.