### PR TITLE
Enable operations to disable/enable sf cluster nodes as well as gracefully restart entire sf cluster

### DIFF
--- a/src/SdnDiagnostics.psd1
+++ b/src/SdnDiagnostics.psd1
@@ -53,7 +53,7 @@
         'Clear-SdnWorkingDirectory',
         'Copy-SdnFileFromComputer',
         'Copy-SdnFileToComputer',
-        'Confirm-SdnServiceFabricHealthy,'
+        'Confirm-SdnServiceFabricHealthy',
         'Convert-SdnEtwTraceToTxt',
         'Debug-SdnFabricInfrastructure',
         'Debug-SdnGateway',

--- a/src/SdnDiagnostics.psd1
+++ b/src/SdnDiagnostics.psd1
@@ -53,6 +53,7 @@
         'Clear-SdnWorkingDirectory',
         'Copy-SdnFileFromComputer',
         'Copy-SdnFileToComputer',
+        'Confirm-SdnServiceFabricHealthy,'
         'Convert-SdnEtwTraceToTxt',
         'Debug-SdnFabricInfrastructure',
         'Debug-SdnGateway',

--- a/src/SdnDiagnostics.psd1
+++ b/src/SdnDiagnostics.psd1
@@ -61,8 +61,10 @@
         'Debug-SdnServer',
         'Disable-SdnDiagTraceOutputLogging',
         'Disable-SdnRasGatewayTracing',
+        'Disable-SdnServiceFabricNode',
         'Enable-SdnDiagTraceOutputLogging',
         'Enable-SdnRasGatewayTracing',
+        'Enable-SdnServiceFabricNode',
         'Enable-SdnVipTrace',
         'Get-SdnAuditLog',
         'Get-SdnApiEndpoint'
@@ -143,6 +145,7 @@
         'New-SdnServerCertificate',
         'Remove-SdnExpressBgpHost',
         'Repair-SdnDiagnosticsScheduledTask',
+        'Restart-SdnServiceFabricClusterNodes',
         'Set-SdnCertificateAcl',
         'Set-SdnNetworkController',
         'Set-SdnResource',

--- a/src/modules/SdnDiag.NetworkController.SF.psm1
+++ b/src/modules/SdnDiag.NetworkController.SF.psm1
@@ -3327,7 +3327,7 @@ function Restart-SdnServiceFabricClusterNodes {
 
                 try {
                     $enableNodeOp = Enable-SdnServiceFabricNode @PSBoundParameters -NodeName $node.NodeName
-                    if ($enableNodeOp.NodeStatus -ieq 'Enabled') {
+                    if ($enableNodeOp.NodeStatus -ieq 'Up') {
                         break
                     }
                 }

--- a/src/modules/SdnDiag.NetworkController.SF.psm1
+++ b/src/modules/SdnDiag.NetworkController.SF.psm1
@@ -3337,7 +3337,8 @@ function Restart-SdnServiceFabricClusterNodes {
                 }
             }
 
-            Confirm-SdnServiceFabricHealthy @PSBoundParameters -Wait
+            # wait for cluster/app health to be ok before proceeding to the next node
+            $null = Confirm-SdnServiceFabricHealthy @PSBoundParameters -Wait
         }
     }
     catch {

--- a/src/modules/SdnDiag.NetworkController.SF.psm1
+++ b/src/modules/SdnDiag.NetworkController.SF.psm1
@@ -3027,7 +3027,7 @@ function Disable-SdnServiceFabricNode {
 
         $maxNodesToDisable = Get-MaxNodesToDisable -TotalNodes $totalClusterNodeCount
         if ($disabledNodeCount -ge $maxNodesToDisable) {
-            throw New-Object System.Exception("There are already $disabledNodeCount nodes disabled, cannot disable any more nodes in $totalClusterNodeCount node cluster without losing quorom")
+            throw New-Object System.Exception("There are already $disabledNodeCount nodes disabled. Cannot disable any more nodes in $totalClusterNodeCount node cluster without losing quorom")
         }
     }
 
@@ -3287,6 +3287,8 @@ function Restart-SdnServiceFabricClusterNodes {
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
+
+    $ErrorActionPreference = 'Stop'
 
     if (Test-ComputerNameIsLocal -ComputerName $NetworkController) {
         throw System.NotSupportedException("This function is not supported to be run on the Network Controller itself. Please retry this operation from a different node.")

--- a/src/modules/SdnDiag.NetworkController.SF.psm1
+++ b/src/modules/SdnDiag.NetworkController.SF.psm1
@@ -3061,7 +3061,7 @@ function Disable-SdnServiceFabricNode {
                 break
             }
             else {
-                "Node $($fabricNode.NodeName) is not disabled yet, waiting..." | Trace-Output
+                "Node $($fabricNode.NodeName) is not disabled. Waiting..." | Trace-Output
                 Start-Sleep -Seconds 15
             }
         }
@@ -3136,7 +3136,7 @@ function Enable-SdnServiceFabricNode {
                 break
             }
             else {
-                "Node $($fabricNode.NodeName) is not enabled yet, waiting..." | Trace-Output
+                "Node $($fabricNode.NodeName) is not enabled. Waiting..." | Trace-Output
                 Start-Sleep -Seconds 15
             }
         }
@@ -3319,12 +3319,11 @@ function Restart-SdnServiceFabricClusterNodes {
             $attempt = 0
             $maxAttempts = 10
             while ($true){
-                $attempt++
-
                 if ($attempt -gt $maxAttempts) {
                     throw New-Object System.Exception("Unable to enable node $($node.NodeName) after $maxAttempts attempts")
                 }
 
+                $attempt++
                 try {
                     $enableNodeOp = Enable-SdnServiceFabricNode @PSBoundParameters -NodeName $node.NodeName
                     if ($enableNodeOp.NodeStatus -ieq 'Up') {

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -3092,12 +3092,12 @@ function Test-ComputerIsAccessible {
 
                 $ping = Test-Connection -ComputerName $ComputerName -Count 1 -Quiet
                 if ($ping) {
-                    "{0} is accessible." -f $ComputerName | Trace-Output
+                    "{0} is accessible over the network." -f $ComputerName | Trace-Output
                     $stopWatch.Stop()
                     return $true
                 }
                 else {
-                    "{0} is not accessible. Attempting connection again in {1} seconds. Timeout: {2} seconds" -f $ComputerName, $Interval, $Timeout | Trace-Output
+                    "{0} is not accessible over the network. Attempting network connection again in {1} seconds. Timeout: {2} seconds" -f $ComputerName, $Interval, $Timeout | Trace-Output -Level:Warning
                     Start-Sleep -Seconds $Interval
                 }
             }

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -3072,7 +3072,10 @@ function Test-ComputerIsAccessible {
         [switch]$Wait,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Wait')]
-        [int]$Timeout = 300
+        [int]$Timeout = 300,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Wait')]
+        [int]$Interval = 10
     )
 
     switch ($PSCmdlet.ParameterSetName) {
@@ -3089,10 +3092,13 @@ function Test-ComputerIsAccessible {
 
                 $ping = Test-Connection -ComputerName $ComputerName -Count 1 -Quiet
                 if ($ping) {
+                    "{0} is accessible." -f $ComputerName | Trace-Output
+                    $stopWatch.Stop()
                     return $true
                 }
                 else {
-                    Start-Sleep -Seconds 10
+                    "{0} is not accessible. Attempting connection again in {1} seconds. Timeout: {2} seconds" -f $ComputerName, $Interval, $Timeout | Trace-Output
+                    Start-Sleep -Seconds $Interval
                 }
             }
         }

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -3047,3 +3047,56 @@ function Remove-PropertiesFromObject {
         return $array
     }
 }
+
+function Test-ComputerIsAccessible {
+    <#
+    .SYNOPSIS
+        Tests if a computer is accessible by pinging it.
+    .PARAMETER ComputerName
+        The name of the computer to test.
+    .PARAMETER Wait
+        Wait for the computer to become accessible.
+    .PARAMETER Timeout
+        The timeout in seconds to wait for the computer to become accessible. Default is 300 seconds.
+    .EXAMPLE
+        Test-ComputerIsAccessible -ComputerName 'contoso-nc01'
+    .EXAMPLE
+        Test-ComputerIsAccessible -ComputerName 'contoso-nc01' -Wait -Timeout 60
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$ComputerName,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Wait')]
+        [switch]$Wait,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Wait')]
+        [int]$Timeout = 300
+    )
+
+    switch ($PSCmdlet.ParameterSetName) {
+        'Default' {
+            $ping = Test-Connection -ComputerName $ComputerName -Count 1 -Quiet
+            return $ping
+        }
+        'Wait' {
+            $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
+            while ($true) {
+                if ($stopWatch.Elapsed.TotalSeconds -ge $Timeout) {
+                    return $false
+                }
+
+                $ping = Test-Connection -ComputerName $ComputerName -Count 1 -Quiet
+                if ($ping) {
+                    return $true
+                }
+                else {
+                    Start-Sleep -Seconds 10
+                }
+            }
+        }
+    }
+
+    return $false
+}


### PR DESCRIPTION
# Description
This pull request introduces several new cmdlets to enhance the functionality of the `SdnDiagnostics` module and adds a utility function to test network accessibility. Below is a summary of the most important changes:

### New cmdlets added to `SdnDiagnostics.psd1`:

* Added `Confirm-SdnServiceFabricHealthy` to validate the health of Service Fabric.
* Added `Disable-SdnServiceFabricNode` and `Enable-SdnServiceFabricNode` to manage Service Fabric nodes.
* Added `Restart-SdnServiceFabricClusterNodes` to restart cluster nodes in Service Fabric.

### New utility function added to `SdnDiag.Utilities.psm1`:

* Introduced `Test-ComputerIsAccessible` to check if a computer is reachable over the network. It supports both immediate checks and waiting for accessibility with a configurable timeout and interval.

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.