### PR TITLE
Exclude 0.0.0.0 address from analysis of Test-SdnMuxConnectionStateToSlbManager

### DIFF
--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -2870,7 +2870,7 @@ function Test-SdnMuxConnectionStateToSlbManager {
     $sdnHealthTest = New-SdnHealthTest
 
     try {
-        $tcpConnection = Get-NetTCPConnection -LocalPort 8560 -ErrorAction Ignore
+        $tcpConnection = Get-NetTCPConnection -LocalPort 8560 -ErrorAction Ignore | Where-Object {$_.LocalAddress -ine "0.0.0.0"}
         if ($null -eq $tcpConnection -or $tcpConnection.State -ine 'Established') {
             $sdnHealthTest.Result = 'FAIL'
             $sdnHealthTest.Remediation += "Move SlbManager service primary role to another node. Examine the TCP / TLS connectivity for the SlbManager service."


### PR DESCRIPTION
# Description
This pull request makes a targeted improvement in the `Test-SdnMuxConnectionStateToSlbManager` function within the `src/modules/SdnDiag.Health.psm1` file. The change ensures that only specific TCP connections are considered by filtering out connections with a local address of `0.0.0.0`.

### Improvement to TCP connection filtering:

* Updated the `$tcpConnection` assignment in `Test-SdnMuxConnectionStateToSlbManager` to include a `Where-Object` clause, filtering out connections where `LocalAddress` is `0.0.0.0`. This makes the connection check more precise and avoids potential false positives.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.