### PR TITLE
gracefully handle if servermanager not present

### DIFF
--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -2883,8 +2883,15 @@ function Get-EnvironmentRole {
     $array = @('Common')
 
     try {
-        $featuresInstalled = Get-WindowsFeature | Where-Object {$_.Installed -ieq $true}
-        if ($null -eq $featuresInstalled) {
+        # due to some weird functionality in the Get-WindowsFeature cmdlet, we need to check to see if the cmdlet exists
+        # and if it does, we will check to see if the features are installed
+        if (Get-Command -Name Get-WindowsFeature -ErrorAction Ignore) {
+            $featuresInstalled = Get-WindowsFeature -ErrorAction Ignore | Where-Object {$_.Installed -ieq $true}
+            if ($null -eq $featuresInstalled) {
+                return $array
+            }
+        }
+        else {
             return $array
         }
 


### PR DESCRIPTION
# Description
This pull request updates the `Get-EnvironmentRole` function in `src/modules/SdnDiag.Utilities.psm1` to handle scenarios where the `Get-WindowsFeature` cmdlet may not be available. The change ensures that the function gracefully handles environments lacking this cmdlet by returning a default value.

### Key changes:

* **Improved error handling for `Get-WindowsFeature`:**
  - Added a check using `Get-Command` to verify the existence of the `Get-WindowsFeature` cmdlet before attempting to use it. If the cmdlet does not exist, the function now returns the default array `@('Common')` without attempting further operations.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.