### PR TITLE
Increase default logging level for Gateway tracing

### DIFF
--- a/src/modules/SdnDiag.Gateway.Config.psd1
+++ b/src/modules/SdnDiag.Gateway.Config.psd1
@@ -31,22 +31,23 @@
             IKE = @{
                 isOptional = $false
                 Providers = @(
-                    "{106b464d-8043-46b1-8cb8-e92a0cd7a560}"
+                    "{106b464d-8043-46b1-8cb8-e92a0cd7a560}" # IKEEXT WPP / BFE
                 )
-                Level = 4
+                Level = 255
                 Keywords = "0xFFFFFFFFFFFFFFFF"
             }
             Rasgateway = @{
                 isOptional = $false
                 Providers = @(
-                    "{EB171376-3B90-4169-BD76-2FB821C4F6FB}"
-                    "{24989972-0967-4E21-A926-93854033638E}"
-                    "{F3F35A3B-6D33-4C32-BC81-21513D8BD708}"
-                    "{58ac8283-c536-5244-63c2-eb41247e4a10}"
-                    "{2E67FCF3-C48E-4B2D-A689-A91D07EDB910}"
-                    "{9FD2B528-8D3D-42D0-8FDF-5B1998004278}"
+                    "{EB171376-3B90-4169-BD76-2FB821C4F6FB}" # BGP
+                    "{24989972-0967-4E21-A926-93854033638E}" # Microsoft-Windows-RRAS
+                    "{F3F35A3B-6D33-4C32-BC81-21513D8BD708}" # Microsoft-Windows-GatewayHealthMonitor
+                    "{58ac8283-c536-5244-63c2-eb41247e4a10}" # Microsoft-Windows-GatewayService
+                    "{2E67FCF3-C48E-4B2D-A689-A91D07EDB910}" # Microsoft-Windows-RasRoutingProtocols-BGP
+                    "{9FD2B528-8D3D-42D0-8FDF-5B1998004278}" # Microsoft.Windows.Networking.RAS.Routing.BGP
+                    "{B5325CD6-438E-4EC1-AA46-14F46F2570E4}" # Microsoft.Windows.Networking.RAS.RASServer.AgileVPN
                 )
-                Level = 4
+                Level = 255
                 Keywords = "0xFFFFFFFFFFFFFFFF"
             }
         }

--- a/src/modules/SdnDiag.LoadBalancerMux.Config.psd1
+++ b/src/modules/SdnDiag.LoadBalancerMux.Config.psd1
@@ -27,10 +27,10 @@
             SlbMux = @{
                 isOptional = $false
                 Providers = @(
-                    "{645b8679-5451-4c36-9857-a90e7dbf97bc}"
-                    "{6C2350F8-F827-4B74-AD0C-714A92E22576}"
-                    "{2E67FCF3-C48E-4B2D-A689-A91D07EDB910}"
-                    "{9FD2B528-8D3D-42D0-8FDF-5B1998004278}"
+                    "{645b8679-5451-4c36-9857-a90e7dbf97bc}" # Microsoft-Windows-SlbMuxDriver
+                    "{6C2350F8-F827-4B74-AD0C-714A92E22576}" # Microsoft-Windows-SlbMux
+                    "{2E67FCF3-C48E-4B2D-A689-A91D07EDB910}" # Microsoft-Windows-RasRoutingProtocols-BGP
+                    "{9FD2B528-8D3D-42D0-8FDF-5B1998004278}" # Microsoft.Windows.Networking.RAS.Routing.BGP
                 )
                 Level = $null
                 Keywords = $null

--- a/src/modules/SdnDiag.Server.Config.psd1
+++ b/src/modules/SdnDiag.Server.Config.psd1
@@ -44,6 +44,7 @@
                     "{dbc217a8-018f-4d8e-a849-acea31bc93f9}" # Microsoft.Windows.NetworkController.HostAgent.VSwitchPlugin
                     "{41DC7652-AAF6-4428-BBBB-CFBDA322F9F3}" # Microsoft.Windows.NetworkController.HostAgent.FirewallPlugin
                     "{F2605199-8A9B-4EBD-B593-72F32DEEC058}" # Microsoft.Windows.NetworkController.HostAgent.ServiceInsertionPlugin
+                    "{f6be3d13-c3d4-44bb-ad4d-3498b51f981e}" # Microsoft.Windows.NetworkController.HostAgent.GatewayPlugin
                 )
                 Level = 4
                 Keywords = "0xFFFFFFFFFFFFFFFF"

--- a/src/modules/SdnDiag.Server.Config.psd1
+++ b/src/modules/SdnDiag.Server.Config.psd1
@@ -39,11 +39,11 @@
             nchostagent = @{
                 isOptional = $false
                 Providers = @(
-                    "{28F7FB0F-EAB3-4960-9693-9289CA768DEA}"
-                    "{A6527853-5B2B-46E5-9D77-A4486E012E73}"
-                    "{dbc217a8-018f-4d8e-a849-acea31bc93f9}"
-                    "{41DC7652-AAF6-4428-BBBB-CFBDA322F9F3}"
-                    "{F2605199-8A9B-4EBD-B593-72F32DEEC058}"
+                    "{28F7FB0F-EAB3-4960-9693-9289CA768DEA}" # Microsoft.Windows.NetworkController.HostAgent.Service
+                    "{A6527853-5B2B-46E5-9D77-A4486E012E73}" # Microsoft.Windows.NetworkController.HostAgent.VNetPlugin
+                    "{dbc217a8-018f-4d8e-a849-acea31bc93f9}" # Microsoft.Windows.NetworkController.HostAgent.VSwitchPlugin
+                    "{41DC7652-AAF6-4428-BBBB-CFBDA322F9F3}" # Microsoft.Windows.NetworkController.HostAgent.FirewallPlugin
+                    "{F2605199-8A9B-4EBD-B593-72F32DEEC058}" # Microsoft.Windows.NetworkController.HostAgent.ServiceInsertionPlugin
                 )
                 Level = 4
                 Keywords = "0xFFFFFFFFFFFFFFFF"
@@ -51,8 +51,8 @@
             nvsp = @{
                 isOptional = $false
                 Providers = @(
-                    "{1F387CBC-6818-4530-9DB6-5F1058CD7E86}"
-                    "{6C28C7E5-331B-4437-9C69-5352A2F7F296}"
+                    "{1F387CBC-6818-4530-9DB6-5F1058CD7E86}" # Microsoft.Windows.Hyper-V.VmSwitchWpp
+                    "{6C28C7E5-331B-4437-9C69-5352A2F7F296}" # Microsoft-Windows-Hyper-V-VmsIf
                 )
                 Level = 4
                 Keywords = "0xFFFFFFFFFFFFFFFF"
@@ -60,7 +60,7 @@
             slbhostagent = @{
                 isOptional = $false
                 Providers = @(
-                    "{2380c5ee-ab89-4d14-b2e6-142200cb703c}"
+                    "{2380c5ee-ab89-4d14-b2e6-142200cb703c}" # Microsoft-Windows-SoftwareLoadBalancer-HostPlugin
                 )
                 Level = 4
                 Keywords = "0xFFFFFFFFFFFFFFFF"
@@ -68,8 +68,8 @@
             vfpext = @{
                 isOptional = $false
                 Providers = @(
-                    "{9F2660EA-CFE7-428F-9850-AECA612619B0}"
-                    "{67DC0D66-3695-47C0-9642-33F76F7BD7AD}"
+                    "{9F2660EA-CFE7-428F-9850-AECA612619B0}" # Microsoft-Windows-Hyper-V-VfpExt
+                    "{67DC0D66-3695-47C0-9642-33F76F7BD7AD}" # MicrosoftWindowsHyperVVmSwitch
                 )
                 Level = 4
                 Keywords = "0xFFFFFFFFFFFFFFFF"


### PR DESCRIPTION
# Description
This pull request updates configuration files for multiple modules in the SDN diagnostics system. The changes primarily involve adding descriptive comments for provider IDs and adjusting logging levels. These updates improve clarity and ensure consistent logging configurations across modules.

### Improvements to clarity:

* [`src/modules/SdnDiag.Gateway.Config.psd1`](diffhunk://#diff-c0bdf20534e81b95c382f9ab06fd5f1d8653a5200d1123731c3941e8316b5fc3L34-R50): Added descriptive comments for provider IDs under the `IKE` and `Rasgateway` sections to specify their associated services (e.g., IKEEXT WPP / BFE, BGP, Microsoft-Windows-RRAS).
* [`src/modules/SdnDiag.LoadBalancerMux.Config.psd1`](diffhunk://#diff-f5efbe475dce9955e5f42f22ce5f4eff21c9f347d002996d6146786921bbebedL30-R33): Added descriptive comments for provider IDs under the `SlbMux` section to specify their associated services (e.g., Microsoft-Windows-SlbMuxDriver, Microsoft-Windows-RasRoutingProtocols-BGP).
* [`src/modules/SdnDiag.Server.Config.psd1`](diffhunk://#diff-22a4aebb1d422eb85344298764ac70d4b6b2d1608ebfd1a011f360a420eb6de4L42-R72): Added descriptive comments for provider IDs under multiple sections (`nchostagent`, `nvsp`, `slbhostagent`, `vfpext`) to specify their associated services (e.g., Microsoft.Windows.NetworkController.HostAgent.Service, Microsoft-Windows-Hyper-V-VfpExt).

### Logging configuration updates:

* [`src/modules/SdnDiag.Gateway.Config.psd1`](diffhunk://#diff-c0bdf20534e81b95c382f9ab06fd5f1d8653a5200d1123731c3941e8316b5fc3L34-R50): Updated logging `Level` values from `4` to `255` for `IKE` and `Rasgateway` sections to ensure maximum verbosity.

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [x] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.