### PR TITLE
Fix issue with Test-SdnExpressBGP

### DIFF
--- a/src/modules/Test-SdnExpressBgp.psm1
+++ b/src/modules/Test-SdnExpressBgp.psm1
@@ -694,24 +694,25 @@ function Test-SdnExpressBGP {
 
             $RestoreMuxState = $false
             $mux = Get-Service -Name 'SlbMux' -ErrorAction SilentlyContinue
-            if ($null -ne $mux) {
+            if ($mux) {
                 $muxstartup = $mux.starttype
                 $muxstatus = $mux.status
 
                 if (($muxstatus -ne "Stopped") -or ($Muxstartup -ne "Disabled")) {
                     if ($force) {
                         $RestoreMuxState = $true
-                        Set-Service -Name -startup Disabled
-                        stop-Service -Name
+                        Set-Service -Name 'SlbMux' -StartupType Disabled
+                        Stop-Service -Name 'SlbMux'
                     }
                     else {
-                        throw "SLB Mux service is active.  Use -force to temporarily disable it during test."
+                        throw "SLB Mux service is active. Use -force to temporarily disable it during test."
                     }
                 }
             }
             else {
-                $muxstate = $null
+                $muxStatus = $null
             }
+
 
             $IPEndpoint = New-object System.Net.IPEndPoint([IPAddress]$LocalIPAddress, 0)
             try {


### PR DESCRIPTION
# Description
This pull request includes a small but important update to the `Test-SdnExpressBGP` function in the `src/modules/Test-SdnExpressBgp.psm1` file. The changes improve code clarity and correctness by refining variable names and ensuring proper usage of the `Set-Service` and `Stop-Service` cmdlets.

Key changes:

* Simplified the null check for the `$mux` variable by replacing `$null -ne $mux` with `$mux` for better readability.
* Corrected the `Set-Service` and `Stop-Service` cmdlet usage by explicitly specifying the service name `'SlbMux'` and fixing the parameter name `-StartupType`.
* Renamed the `$muxstate` variable to `$muxStatus` for consistency with other variable naming conventions in the function.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.