### PR TITLE
Add function to automate the repair of the port profile applied to vm network adapter

### DIFF
--- a/src/SdnDiagnostics.psd1
+++ b/src/SdnDiagnostics.psd1
@@ -146,6 +146,7 @@
         'New-SdnServerCertificate',
         'Remove-SdnExpressBgpHost',
         'Repair-SdnDiagnosticsScheduledTask',
+        'Repair-SdnVMNetworkAdapterPortProfile',
         'Restart-SdnServiceFabricClusterNodes',
         'Set-SdnCertificateAcl',
         'Set-SdnNetworkController',

--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -1205,3 +1205,4 @@ function Get-SdnLogFile {
         $_ | Write-Error
     }
 }
+

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -3547,9 +3547,9 @@ function Repair-SdnVMNetworkAdapterPortProfile {
             $repairRequired = $true
         }
 
-        # ensure that the profile data is set to 1 (VfpEnabled)
-        if ($currentPortProfileSettings.ProfileData -ne 1) {
-            "Current ProfileData [{0}] does not match expected ProfileData [1] (VfpEnabled)." -f $currentPortProfileSettings.ProfileData | Trace-Output -Level:Information
+        # ensure that the profile data matches what we expect
+        if ($currentPortProfileSettings.ProfileData -ne $repairPortProfileParams.ProfileData) {
+            "Current ProfileData [{0}] does not match expected ProfileData [{1}]." -f $currentPortProfileSettings.ProfileData, $repairPortProfileParams.ProfileData | Trace-Output -Level:Information
             $repairRequired = $true
         }
 

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -3425,24 +3425,15 @@ function Repair-SdnVMNetworkAdapterPortProfile {
         Repair-SdnVMNetworkAdapterPortProfile -VMName 'TestVM01' -MacAddress 001DD826100E -NcUri 'https://nc.contoso.com' -HyperVHost 'Contoso-N01'
     #>
 
-    [CmdletBinding(DefaultParameterSetName = 'RestCredential_Local')]
+    [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true, ParameterSetName = 'RestCredential_Local')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'RestCredential_Remote')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate_Local')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate_Remote')]
+        [Parameter(Mandatory = $true)]
         [System.String]$VMName,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'RestCredential_Local')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'RestCredential_Remote')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate_Local')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate_Remote')]
+        [Parameter(Mandatory = $true)]
         [System.String]$MacAddress,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'RestCredential_Local')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'RestCredential_Remote')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate_Local')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate_Remote')]
+        [Parameter(Mandatory = $true)]
         [ValidateScript({
             if ($_.Scheme -ne "http" -and $_.Scheme -ne "https") {
                 throw New-Object System.FormatException("Parameter is expected to be in http:// or https:// format.")
@@ -3451,26 +3442,26 @@ function Repair-SdnVMNetworkAdapterPortProfile {
         })]
         [Uri]$NcUri,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'RestCredential_Local')]
-        [Parameter(Mandatory = $false, ParameterSetName = 'RestCredential_Remote')]
+        [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $NcRestCredential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'RestCertificate_Local')]
-        [Parameter(Mandatory = $false, ParameterSetName = 'RestCertificate_Remote')]
+        [Parameter(Mandatory = $false)]
         [X509Certificate]$NcRestCertificate,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'RestCredential_Remote')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate_Remote')]
+        [Parameter(Mandatory = $true)]
         [System.String]$HyperVHost,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'RestCredential_Remote')]
-        [Parameter(Mandatory = $false, ParameterSetName = 'RestCertificate_Remote')]
+        [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty
     )
+
+    if ($PSBoundParameters.ContainsKey('NcRestCertificate') -and $PSBoundParameters.ContainsKey('NcRestCredential')) {
+        throw "NcRestCertificate and NcRestCredential are mutually exclusive"
+    }
 
     $repairRequired = $false
     $ncRestParams = @{

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -3496,7 +3496,7 @@ function Repair-SdnVMNetworkAdapterPortProfile {
 
         # we want to ensure that the network interface is not a load balancer mux interface
         # as we do not support this currently
-        if ($networkInterface.properties.loadBalancerMuxExternal -or $networkInterface.properties.gateway) {
+        if ($networkInterface.properties.loadBalancerMuxExternal -or $networkInterface.properties.loadBalancerMuxInternal -or $networkInterface.properties.gateway) {
             throw New-Object System.NotSupportedException("NetworkInterface $($networkInterface.resourceRef) with MAC Address $formattedMacAddress is a Gateway or LoadBalancerMux interface and cannot be repaired using this cmdlet.")
         }
 

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -3494,12 +3494,15 @@ function Repair-SdnVMNetworkAdapterPortProfile {
             $repairPortProfileParams.Add('HyperVHost', $HyperVHost)
             $repairPortProfileParams.Add('Credential', $Credential)
 
-            $currentPortProfileSettings = Get-SdnVMNetworkAdapterPortProfile -VMName $VMName -MacAddress $formattedMacAddress
+            $vmNetworkAdapters = Get-SdnVMNetworkAdapterPortProfile -VMName $VMName -ErrorAction Stop
+            $currentPortProfileSettings = $vmNetworkAdapters | Where-Object {$_.MacAddress -eq $formattedMacAddress}
         }
         else {
             $currentPortProfileSettings = Invoke-SdnCommand -ComputerName $HyperVHost -Credential $Credential -ScriptBlock {
                 param($vmName, $macAddress)
-                Get-SdnVMNetworkAdapterPortProfile -VMName $vmName -MacAddress $macAddress
+
+                $vmNetworkAdapters = Get-SdnVMNetworkAdapterPortProfile -VMName $vmName -MacAddress $macAddress
+                return ($vmNetworkAdapters | Where-Object {$_.MacAddress -eq $macAddress})
             } -ArgumentList @($VMName, $formattedMacAddress) -ErrorAction Stop
         }
         if ($null -ieq $currentPortProfileSettings) {

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -3420,20 +3420,29 @@ function Repair-SdnVMNetworkAdapterPortProfile {
     .PARAMETER HyperVHost
         Type the NetBIOS name, an IP address, or a fully qualified domain name of the computer that is hosting the virtual machine.
     .PARAMETER Credential
-        Specifies a user account that has permission to perform this action. The default is the current user. If omitted, the current user is used.
+        Specifies a user account that has permission to perform this action on the HyperVHost. The default is the current user. If omitted, the current user is used.
     .EXAMPLE
         Repair-SdnVMNetworkAdapterPortProfile -VMName 'TestVM01' -MacAddress 001DD826100E -NcUri 'https://nc.contoso.com' -HyperVHost 'Contoso-N01'
     #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'RestCredential_Local')]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCredential_Local')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCredential_Remote')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate_Local')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate_Remote')]
         [System.String]$VMName,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCredential_Local')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCredential_Remote')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate_Local')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate_Remote')]
         [System.String]$MacAddress,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCredential_Local')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCredential_Remote')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate_Local')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate_Remote')]
         [ValidateScript({
             if ($_.Scheme -ne "http" -and $_.Scheme -ne "https") {
                 throw New-Object System.FormatException("Parameter is expected to be in http:// or https:// format.")
@@ -3442,18 +3451,22 @@ function Repair-SdnVMNetworkAdapterPortProfile {
         })]
         [Uri]$NcUri,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestCredential_Local')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestCredential_Remote')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $NcRestCredential = [System.Management.Automation.PSCredential]::Empty,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestCertificate_Local')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestCertificate_Remote')]
         [X509Certificate]$NcRestCertificate,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCredential_Remote')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'RestCertificate_Remote')]
         [System.String]$HyperVHost,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestCredential_Remote')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'RestCertificate_Remote')]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential = [System.Management.Automation.PSCredential]::Empty


### PR DESCRIPTION
# Description
This pull request introduces a new cmdlet, `Repair-SdnVMNetworkAdapterPortProfile`, to the `SdnDiagnostics` module, along with its corresponding entry in the module manifest. Additionally, there is a minor formatting change in the `Get-SdnLogFile` function. Below are the most important changes grouped by theme:

### New Feature: `Repair-SdnVMNetworkAdapterPortProfile` Cmdlet
* Added a new cmdlet, `Repair-SdnVMNetworkAdapterPortProfile`, to repair port profiles applied to virtual machine network interfaces. The cmdlet includes parameters for specifying VM details, Network Controller URI, credentials, and host information. It retrieves the network interface from the Network Controller and applies the port profile to the VM network adapter. (`src/modules/SdnDiag.Server.psm1`, [src/modules/SdnDiag.Server.psm1R3401-R3503](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedR3401-R3503))
* Registered the new cmdlet in the module manifest (`src/SdnDiagnostics.psd1`).

### Minor Formatting Change
* Added a blank line for readability in the `Get-SdnLogFile` function. (`src/SdnDiagnostics.psm1`, [src/SdnDiagnostics.psm1R1208](diffhunk://#diff-490865628c61b2e97c50f45b37d7086647c70b2444cbfb9c60cc8c682801356eR1208))

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.