### PR TITLE
enable support for azurestackcertificationauthority certs

### DIFF
--- a/src/modules/SdnDiag.Common.psm1
+++ b/src/modules/SdnDiag.Common.psm1
@@ -267,15 +267,15 @@ function Copy-CertificateToFabric {
             }
         }
 
-        # for ServerNodes, we must distribute the server certificate and install to the cert:\localmachine\root directory on each of the
-        # network controller nodes
+        # for ServerNodes, we must distribute the server certificate and install to the
+        # cert:\localmachine\root directory on each of the network controller nodes
         'ServerNode' {
             foreach ($controller in $FabricDetails.NetworkController) {
-                # if the certificate being passed is self-signed, we will need to copy the certificate to the other controller nodes
+                # if the certificate being passed is self-signed, or issued by AzureStackCertificationAuthority we will need to copy the certificate to the other controller nodes
                 # within the fabric and install under localmachine\root as appropriate
-                if (Confirm-IsCertSelfSigned -Certificate $certData) {
-                    "Importing certificate [Subject: {0} Thumbprint:{1}] to {2}" -f `
-                    $certData.Subject, $certData.Thumbprint, $controller | Trace-Output
+                $isSelfSigned = Confirm-IsCertSelfSigned -Certificate $certData
+                if ($isSelfSigned -or $certData.Issuer -ieq 'CN=AzureStackCertificationAuthority') {
+                    "Importing certificate [Subject: {0} Thumbprint:{1}] to {2}" -f $certData.Subject, $certData.Thumbprint, $controller | Trace-Output
 
                     [System.String]$remoteFilePath = Join-Path -Path $certFileInfo.Directory.FullName -ChildPath $certFileInfo.Name
                     $null = Invoke-PSRemoteCommand -ComputerName $controller -Credential $Credential -ScriptBlock {

--- a/src/modules/SdnDiag.Common.psm1
+++ b/src/modules/SdnDiag.Common.psm1
@@ -153,7 +153,7 @@ function Copy-CertificateToFabric {
     switch ($PSCmdlet.ParameterSetName) {
         'LoadBalancerMuxNode' {
             foreach ($controller in $FabricDetails.NetworkController) {
-                # if the certificate being passed is self-signed, we will need to copy the certificate to the other controller nodes
+                # if the certificate being passed is self-signed, we will need to copy the certificate to the network controller nodes
                 # within the fabric and install under localmachine\root as appropriate
                 if (Confirm-IsCertSelfSigned -Certificate $certData) {
                     "Importing certificate [Subject: {0} Thumbprint:{1}] to {2}" -f `


### PR DESCRIPTION
# Description
This pull request introduces several improvements and bug fixes related to certificate handling and rotation for SDN Server and Load Balancer Mux scenarios, with a focus on supporting Azure Stack HCI environments and the AzureStackCertificationAuthority. The changes clarify certificate distribution logic, update resource management during certificate rotation, and improve detection and usage of certificates issued by AzureStackCertificationAuthority.

### Certificate Handling and Distribution

* Updated logic in `Copy-CertificateToFabric` to also distribute certificates issued by `AzureStackCertificationAuthority` (not just self-signed) to network controller nodes, ensuring proper installation and trust for Azure Stack HCI environments.
* Improved comments and corrected terminology to clarify certificate distribution steps for both LoadBalancerMuxNode and ServerNode scenarios.

### Certificate Generation and Selection

* Enhanced `New-SdnServerCertificate` to detect and use the most recent certificate issued by `AzureStackCertificationAuthority` for Azure Stack HCI systems, avoiding unnecessary self-signed certificate generation when a valid authority certificate is present.

### Certificate Rotation Logic

* Refactored certificate rotation functions (`Start-SdnMuxCertificateRotation` and `Start-SdnServerCertificateRotation`) to streamline REST API parameter handling, remove unused code, and ensure updates only occur when certificate changes are needed. [[1]](diffhunk://#diff-8b1f41eba916fc0a86f95c4ab4e5c8c23ce217faa05f9aef2f3564bb60577c2cL611-L637) [[2]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL3028-L3055)
* Updated rotation logic to properly encode and update certificates only when necessary, and to skip encoding updates for certificates issued by `AzureStackCertificationAuthority`, preventing redundant or incorrect updates for authority-issued certificates. [[1]](diffhunk://#diff-8b1f41eba916fc0a86f95c4ab4e5c8c23ce217faa05f9aef2f3564bb60577c2cL702-R715) [[2]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL3119-R3154)

### Environment Validation

* Replaced feature-based server validation in `New-SdnServerCertificate` with a direct call to `Confirm-IsServer`, simplifying the check for running on a supported server environment.

These changes collectively improve certificate lifecycle management, enhance compatibility with Azure Stack HCI, and ensure robust handling of both self-signed and authority-issued certificates.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.