### PR TITLE
Remove health faults from tests

### DIFF
--- a/src/SdnDiagnostics.psd1
+++ b/src/SdnDiagnostics.psd1
@@ -53,6 +53,7 @@
         'Clear-SdnWorkingDirectory',
         'Copy-SdnFileFromComputer',
         'Copy-SdnFileToComputer',
+        'Clear-SdnHealthFault',
         'Confirm-SdnServiceFabricHealthy',
         'Convert-SdnEtwTraceToTxt',
         'Debug-SdnFabricInfrastructure',

--- a/src/modules/SdnDiag.Health.Config.psd1
+++ b/src/modules/SdnDiag.Health.Config.psd1
@@ -202,14 +202,4 @@
             Action = 'See if sufficient bandwidth is available for all VM''s if QOS reservation is used'
         }
     }
-
-    HealthFaultEnabled = $false
-    HealthFaultSupportedBuilds = @(
-        '23H2' # Build Number 25398
-        '24H2' # Build Number 26100
-    )
-    HealthFaultSupportedProducts = @(
-        'Azure Stack HCI'
-        'Windows Server 2025 Datacenter'
-    )
 }


### PR DESCRIPTION
# Description
This pull request introduces a new cmdlet and removes unused configuration settings related to health fault management in the SDN diagnostics module. The main focus is on expanding functionality and cleaning up obsolete configuration.

**Cmdlet addition:**

* Added the `Clear-SdnHealthFault` cmdlet to the exported commands in `src/SdnDiagnostics.psd1`, making it available for use in the module.

**Configuration cleanup:**

* Removed `HealthFaultEnabled`, `HealthFaultSupportedBuilds`, and `HealthFaultSupportedProducts` settings from `src/modules/SdnDiag.Health.Config.psd1`, eliminating unused health fault configuration parameters.

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [x] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.