### PR TITLE
Ignore errors if no IPv6 results returned

### DIFF
--- a/src/modules/SdnDiag.Common.psm1
+++ b/src/modules/SdnDiag.Common.psm1
@@ -524,12 +524,12 @@ function Get-CommonConfigState {
         Get-NetIPInterface -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetIPv4Protocol | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetIPv4Protocol' -FileType txt -Format List
         Get-NetIPv6Protocol | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetIPv6Protocol' -FileType txt -Format List
-        Get-NetNeighbor -AddressFamily IPv6 -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetNeighbor_IPv6' -FileType txt -Format Table -Force
-        Get-NetNeighbor -AddressFamily IPv4 -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetNeighbor_IPv4' -FileType txt -Format Table -Force
+        Get-NetNeighbor -AddressFamily IPv6 -IncludeAllCompartments -ErrorAction Ignore | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetNeighbor_IPv6' -FileType txt -Format Table -Force
+        Get-NetNeighbor -AddressFamily IPv4 -IncludeAllCompartments -ErrorAction Ignore | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetNeighbor_IPv4' -FileType txt -Format Table -Force
         Get-NetOffloadGlobalSetting | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
         Get-NetPrefixPolicy | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List
-        Get-NetRoute -AddressFamily IPv6 -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetRoute_IPv6' -FileType txt -Format Table -Force
-        Get-NetRoute -AddressFamily IPv4 -IncludeAllCompartments | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetRoute_IPv4' -FileType txt -Format Table -Force
+        Get-NetRoute -AddressFamily IPv6 -IncludeAllCompartments -ErrorAction Ignore | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetRoute_IPv6' -FileType txt -Format Table -Force
+        Get-NetRoute -AddressFamily IPv4 -IncludeAllCompartments -ErrorAction Ignore | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetRoute_IPv4' -FileType txt -Format Table -Force
         Get-NetTCPConnection | Select-Object LocalAddress, LocalPort, RemoteAddress, RemotePort, State, OwningProcess, @{n="ProcessName";e={(Get-Process -Id $_.OwningProcess -ErrorAction $ErrorActionPreference).ProcessName}} `
         | Export-ObjectToFile -FilePath $outDir -Name 'Get-NetTCPConnection' -FileType csv -Force
         Get-NetTCPSetting | Export-ObjectToFile -FilePath $outDir -FileType txt -Format List


### PR DESCRIPTION
# Description
- `Get-Net*` cmdlets do not adhere to `$ErrorActionPreference` resulting in some cases, the data collection scripts to fail. Explicitly declared `-ErrorAction Ignore` on several cmdlets where error is returned if null results

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.