### PR TITLE
Add HostID test into Debug-SdnFabricInfrastructure

### DIFF
--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -752,6 +752,17 @@ function Start-SdnDataCollection {
         [bool]$ConvertETW = $true
     )
 
+    # if we are running in a remote session, we need to do some extra validation
+    if ($PSSenderInfo) {
+        # if we are running in a remote session and CredSSP is not enabled, then we need to ensure that
+        # the user has supplied -Credential to avoid double-hop authentication issues
+        if (-not (Get-WSManCredSSPState)) {
+            if ($Credential -ieq [System.Management.Automation.PSCredential]::Empty -or $null -ieq $Credential) {
+                throw New-Object System.NotSupportedException("Start-SdnDataCollection cannot be run in a remote session without supplying -Credential.")
+            }
+        }
+    }
+
     $ErrorActionPreference = 'Continue'
     $dataCollectionNodes = [System.Collections.ArrayList]::new() # need an arrayList so we can remove objects from this list
 

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -1100,7 +1100,7 @@ function Test-ServerHostId {
             }
 
             $sdnHealthTest.Properties = [PSCustomObject]@{
-                CurrentHostID = $remoteHostID
+                CurrentHostID = $remoteHostID.HostID
                 ExpectedHostID = $InstanceId
             }
         }


### PR DESCRIPTION
# Description
Summary of changes:
- Added `Test-ServerHostId` test to `Debug-SdnFabricInfrastructure` which will cross-compare the InstanceID from the servers resource with the registry key on the Hyper-V host.
- Added additional defensive coding to `Debug-SdnFabricInfrastructure` and `Start-SdnDataCollection` to ensure that if we are in a remote runspace session, that if CredSSP is not enabled, we have `-Credential` parameter defined otherwise terminate with critical error.

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.