### PR TITLE
Fixed issue where multiple AzureStackCertificationAuthority certs reside on host

### DIFF
--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -2706,6 +2706,9 @@ function New-SdnServerCertificate {
 
                     # locate the AzureStackCertificationAuthority certificate within the root store
                     $certificate = Get-SdnCertificate -Path "Cert:\LocalMachine\Root" -Subject $newestCertificate.Issuer
+                    if ($certificate) {
+                        $certificate = $certificate | Sort-Object -Property NotBefore -Descending | Select-Object -First 1
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description
This pull request makes a targeted improvement to the `New-SdnServerCertificate` function by ensuring that, when multiple matching certificates are found in the root store, only the most recent one is selected. This change improves the reliability and correctness of certificate selection.

- Certificate selection logic:
  * In `New-SdnServerCertificate` (`src/modules/SdnDiag.Server.psm1`), after retrieving certificates that match the issuer, the code now sorts them by the `NotBefore` property in descending order and selects the most recent certificate.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.