### PR TITLE
improve output of sdnresource dump

### DIFF
--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -951,7 +951,7 @@ function Start-SdnDataCollection {
 
             $slbStateInfo = Get-SdnSlbStateInformation @ncRestParams
             $slbStateInfo | ConvertTo-Json -Depth 100 | Out-File "$($OutputDirectory.FullName)\SlbState.Json"
-            Invoke-SdnResourceDump @ncRestParams -OutputDirectory $OutputDirectory.FullName
+            $null = Invoke-SdnResourceDump @ncRestParams -OutputDirectory $OutputDirectory.FullName
             Get-SdnNetworkControllerState -NetworkController $NetworkController -OutputDirectory $OutputDirectory.FullName -Credential $Credential @restCredParam
         }
 

--- a/src/modules/SdnDiag.NetworkController.psm1
+++ b/src/modules/SdnDiag.NetworkController.psm1
@@ -2459,6 +2459,11 @@ function Invoke-SdnResourceDump {
                 }
             }
         }
+
+        $files = Get-ChildItem -Path $outputDir.FullName
+        "Resource dump completed. {0} files exported to {1}" -f $files.Count, $outputDir.FullName | Trace-Output
+
+        return (Get-ChildItem -Path $outputDir.FullName)
     }
     catch {
         $_ | Trace-Exception


### PR DESCRIPTION
# Description
This pull request makes minor improvements to the SDN diagnostics scripts by enhancing logging and clarifying the handling of function output. The main changes focus on providing better feedback after resource dumps and ensuring that command outputs are not unnecessarily displayed.

Enhancements to resource dump feedback and output handling:

* Added a log message in `Invoke-SdnResourceDump` to indicate the number of files exported and the output directory, improving visibility into the results of the resource dump operation. (`src/modules/SdnDiag.NetworkController.psm1`)
* Suppressed unwanted output from `Invoke-SdnResourceDump` in `Start-SdnDataCollection` by assigning the result to `$null`, ensuring cleaner script output. (`src/SdnDiagnostics.psm1`)

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.