### PR TITLE
Improve output generated for Debug-SdnFabricInfrastructure

### DIFF
--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -223,7 +223,7 @@ function New-SdnHealthTest {
 
     $object = [PSCustomObject]@{
         Name           = $Name
-        Result         = 'PASS' # default to PASS. Allowed values are PASS, WARN, FAIL
+        Result         = 'PASS' # default to PASS. Allowed values are PASS, WARNING, FAIL
         OccurrenceTime = [System.DateTime]::UtcNow
         Properties     = @()
         Remediation    = @()
@@ -239,9 +239,10 @@ function New-SdnRoleHealthReport {
     )
 
     $object = [PSCustomObject]@{
+
         Role           = $Role
         ComputerName   = $env:COMPUTERNAME
-        Result         = 'PASS' # default to PASS. Allowed values are PASS, WARN, FAIL
+        Result         = 'PASS' # default to PASS. Allowed values are PASS, WARNING, FAIL
         OccurrenceTime = [System.DateTime]::UtcNow
         HealthTest     = @() # array of New-SdnHealthTest objects
     }
@@ -258,7 +259,7 @@ function New-SdnFabricHealthReport {
     $object = [PSCustomObject]@{
         OccurrenceTime = [System.DateTime]::UtcNow
         Role           = $Role
-        Result         = 'PASS' # default to PASS. Allowed values are PASS, WARN, FAIL
+        Result         = 'PASS' # default to PASS. Allowed values are PASS, WARNING, FAIL
         RoleTest       = @() # array of New-SdnRoleHealthReport objects
     }
 
@@ -289,8 +290,21 @@ function Write-HealthValidationInfo {
         [String]$Name,
 
         [Parameter(Mandatory = $false)]
-        [String[]]$Remediation
+        [String[]]$Remediation,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('WARNING', 'FAIL')]
+        [string]$Severity
     )
+
+    switch ($Severity) {
+        'WARNING' { 
+            $foregroundColor = 'Yellow'
+        }
+        'FAIL' { 
+            $foregroundColor = 'Red'
+        }
+    }
 
     $details = Get-HealthData -Property 'HealthValidations' -Id $Name
 
@@ -300,10 +314,11 @@ function Write-HealthValidationInfo {
     $outputString += "`r`n`r`n"
     $outputString += "Description:`t$($details.Description)`r`n"
     $outputString += "Impact:`t`t$($details.Impact)`r`n"
+    $outputString += "Severity:`t$Severity`r`n"
 
     if (-NOT [string]::IsNullOrEmpty($Remediation)) {
-        if ($Remediation -ieq [array]) {
-            $outputString += "Remediation:`r`n`t- $($Remediation -join "`r`n`t - ")`r`n"
+        if ($Remediation -is [System.Collections.ICollection] -or $Remediation -is [System.Array]) {
+            $outputString += "Remediation:`r`n`t- $($Remediation -join "`r`n`t- ")`r`n"
         }
         else {
             $outputString += "Remediation:`t$Remediation`r`n"
@@ -317,8 +332,7 @@ function Write-HealthValidationInfo {
     }
 
     $outputString += "`r`n--------------------------`r`n"
-
-    $outputString | Write-Host -ForegroundColor Yellow
+    $outputString | Write-Host -ForegroundColor $foregroundColor
 }
 
 function Debug-SdnFabricInfrastructure {
@@ -516,19 +530,17 @@ function Debug-SdnFabricInfrastructure {
                 }
             }
 
-            # evaluate the results of the tests and determine if any completed with Warning or FAIL
-            # if so, we will want to set the Result of the report to reflect this
-            foreach ($test in $healthReport) {
-                if ($test.Result -ieq 'WARN') {
-                    $roleHealthReport.Result = 'WARN'
+            $roleHealthReport.RoleTest += $healthReport
+            foreach ($test in $roleHealthReport.RoleTest.HealthTest) {
+                if ($test.Result -ieq 'WARNING') {
+                    $roleHealthReport.Result = 'WARNING'
                 }
-                if ($test.Result -ieq 'FAIL') {
+                elseif ($test.Result -ieq 'FAIL') {
                     $roleHealthReport.Result = 'FAIL'
                     break
                 }
             }
 
-            $roleHealthReport.RoleTest += $healthReport
             $aggregateHealthReport += $roleHealthReport
         }
     }
@@ -538,6 +550,51 @@ function Debug-SdnFabricInfrastructure {
     }
     finally {
         if ($aggregateHealthReport) {
+
+            # Display SDN Health Validation Report Header
+            $reportHeader = @"
+
+===============================================================================
+                      SDN HEALTH VALIDATION REPORT                          
+===============================================================================
+
+"@
+            Write-Host $reportHeader -ForegroundColor Cyan
+
+            # Calculate aggregate summary
+            $allRoles = ($aggregateHealthReport | Select-Object -ExpandProperty Role) -join ', '
+            $allNodes = ($aggregateHealthReport | ForEach-Object { $_.RoleTest.ComputerName } | Sort-Object -Unique) -join ', '
+            $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss UTC"
+            
+            # Determine overall health state (worst case wins: FAIL > WARNING > PASS)
+            $overallState = 'PASS'
+            foreach ($report in $aggregateHealthReport) {
+                if ($report.Result -ieq 'FAIL') {
+                    $overallState = 'FAIL'
+                    break
+                }
+                elseif ($report.Result -ieq 'WARNING' -and $overallState -ne 'FAIL') {
+                    $overallState = 'WARNING'
+                }
+            }
+
+            # Set color based on overall state
+            $stateColor = switch ($overallState) {
+                'PASS' { 'Green' }
+                'WARNING' { 'Yellow' }
+                'FAIL' { 'Red' }
+            }
+
+            # Display summary
+            Write-Host "Report Generated: " -NoNewline -ForegroundColor Gray
+            Write-Host $timestamp -ForegroundColor White
+            Write-Host "Roles Tested:     " -NoNewline -ForegroundColor Gray
+            Write-Host $allRoles -ForegroundColor White
+            Write-Host "Nodes Tested:     " -NoNewline -ForegroundColor Gray
+            Write-Host $allNodes -ForegroundColor White
+            Write-Host "Overall State:    " -NoNewline -ForegroundColor Gray
+            Write-Host $overallState -ForegroundColor $stateColor
+            Write-Host ""
 
             # enumerate all the roles that were tested so we can determine if any completed with Warning or FAIL
             $aggregateHealthReport | ForEach-Object {
@@ -554,12 +611,22 @@ function Debug-SdnFabricInfrastructure {
                                 $remediationList = [System.Collections.ArrayList]::new()
                                 $_.Remediation | ForEach-Object { [void]$remediationList.Add($_) }
 
-                                Write-HealthValidationInfo -ComputerName $c -Name $_.Name -Remediation $remediationList
+                                Write-HealthValidationInfo -ComputerName $c -Name $_.Name -Remediation $remediationList -Severity $_.Result
                             }
                         }
                     }
                 }
             }
+
+            # Display SDN Health Validation Report Footer
+            $reportFooter = @"
+
+===============================================================================
+                    END OF SDN HEALTH VALIDATION REPORT                     
+===============================================================================
+
+"@
+            Write-Host $reportFooter -ForegroundColor Cyan
 
             # save the aggregate health report to cache so we can use it for further analysis
             $script:SdnDiagnostics_Health.Cache = $aggregateHealthReport
@@ -653,12 +720,12 @@ function Debug-SdnNetworkController {
             }
         }
 
-        # enumerate all the tests performed so we can determine if any completed with WARN or FAIL
-        # if any of the tests completed with WARN, we will set the aggregate result to WARN
+        # enumerate all the tests performed so we can determine if any completed with WARNING or FAIL
+        # if any of the tests completed with WARNING, we will set the aggregate result to WARNING
         # if any of the tests completed with FAIL, we will set the aggregate result to FAIL and then break out of the foreach loop
         # we will skip tests with PASS, as that is the default value
         foreach ($test in $healthReport.HealthTest) {
-            if ($test.Result -eq 'WARN') {
+            if ($test.Result -eq 'WARNING') {
                 $healthReport.Result = $test.Result
             }
             elseif ($test.Result -eq 'FAIL') {
@@ -721,12 +788,12 @@ function Debug-SdnServer {
             )
         }
 
-        # enumerate all the tests performed so we can determine if any completed with WARN or FAIL
-        # if any of the tests completed with WARN, we will set the aggregate result to WARN
+        # enumerate all the tests performed so we can determine if any completed with WARNING or FAIL
+        # if any of the tests completed with WARNING, we will set the aggregate result to WARNING
         # if any of the tests completed with FAIL, we will set the aggregate result to FAIL and then break out of the foreach loop
         # we will skip tests with PASS, as that is the default value
         foreach ($test in $healthReport.HealthTest) {
-            if ($test.Result -eq 'WARN') {
+            if ($test.Result -eq 'WARNING') {
                 $healthReport.Result = $test.Result
             }
             elseif ($test.Result -eq 'FAIL') {
@@ -767,12 +834,12 @@ function Debug-SdnLoadBalancerMux {
             )
         }
 
-        # enumerate all the tests performed so we can determine if any completed with WARN or FAIL
-        # if any of the tests completed with WARN, we will set the aggregate result to WARN
+        # enumerate all the tests performed so we can determine if any completed with WARNING or FAIL
+        # if any of the tests completed with WARNING, we will set the aggregate result to WARNING
         # if any of the tests completed with FAIL, we will set the aggregate result to FAIL and then break out of the foreach loop
         # we will skip tests with PASS, as that is the default value
         foreach ($test in $healthReport.HealthTest) {
-            if ($test.Result -eq 'WARN') {
+            if ($test.Result -eq 'WARNING') {
                 $healthReport.Result = $test.Result
             }
             elseif ($test.Result -eq 'FAIL') {
@@ -992,7 +1059,7 @@ function Test-SdnNetworkControllerApiNameResolution {
                     }
                     catch {
                         $_ | Trace-Exception
-                        "`t- Investigate DNS resolution failure against DNS server {0} for name {1}" -f $dnsServer, $Endpoint
+                        "Investigate DNS resolution failure against DNS server {0} for name {1}" -f $dnsServer, $Endpoint
                     }
                 }
 
@@ -1080,7 +1147,7 @@ function Test-SdnCertificateMultiple {
                 "`t- Thumbprint: {0} Subject: {1} Issuer: {2} NotAfter: {3}" -f $_.Thumbprint, $_.Subject, $_.Issuer, $_.NotAfter
             }
 
-            $sdnHealthTest.Result = 'WARN'
+            $sdnHealthTest.Result = 'WARNING'
             $sdnHealthTest.Remediation = "Examine and cleanup the certificates if no longer needed:`r`n{0}" -f ($certDetails -join "`r`n")
         }
     }
@@ -1377,7 +1444,7 @@ function Test-SdnHostAgentConnectionStateToApiService {
             if ($tcpConnection.State -ine 'Established') {
                 $serviceState = Get-Service -Name NCHostAgent -ErrorAction Stop
                 if ($serviceState.Status -ine 'Running') {
-                    $sdnHealthTest.Result = 'WARN'
+                    $sdnHealthTest.Result = 'WARNING'
                     $sdnHealthTest.Remediation += "Ensure the NCHostAgent service is running."
                 }
                 else {
@@ -1888,7 +1955,7 @@ function Test-SdnAdapterPerformanceSetting {
         if ($adaptersToRepair.Count -gt 0) {
             $sdnHealthTest.Result = 'WARNING'
             foreach ($adapter in $adaptersToRepair) {
-                $sdnHealthTest.Remediation += "Use Invoke-SdnRemediationScript -ScriptName 'ConfigureForwardOptimization.ps1' -ArgumentList @{AdapterName='$adapter'; NoRestart=`$false}"
+                $sdnHealthTest.Remediation += "Run 'Invoke-SdnRemediationScript -ScriptName 'ConfigureForwardOptimization.ps1' -ArgumentList @{AdapterName='$adapter'; NoRestart=`$false}' on the impacted node to enable Forwarding Optimization."
             }
         }
     }


### PR DESCRIPTION
This pull request updates the health reporting logic in `src/modules/SdnDiag.Health.psm1` to standardize the severity terminology from `WARN` to `WARNING`, improves the health validation output formatting, and enhances the overall health report summary for SDN diagnostics. The changes also add color-coded output and a clear report header/footer for better readability.

**Severity and terminology standardization:**
* Changed all references and logic from `WARN` to `WARNING` for health test results, including allowed values and result aggregation in all relevant functions (`New-SdnHealthTest`, `New-SdnRoleHealthReport`, `New-SdnFabricHealthReport`, and all diagnostic functions). [[1]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L226-R226) [[2]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60R242-R245) [[3]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L261-R262) [[4]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L519-L531) [[5]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L656-R728) [[6]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L724-R796) [[7]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L770-R842) [[8]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L1083-R1150) [[9]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L1380-R1447)

**Reporting and output improvements:**
* Added a severity parameter to `Write-HealthValidationInfo`, which sets the output color based on severity and displays severity in the report. Output color is now dynamically set to yellow for `WARNING` and red for `FAIL`. [[1]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L292-R308) [[2]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60R317-R320) [[3]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L320-R335) [[4]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L557-R630)
* Implemented a formatted report header and footer, and a summary section showing tested roles, nodes, timestamp, and overall health state with color coding.

**Logic enhancements:**
* Improved aggregation logic to ensure the worst-case health state is reflected (FAIL > WARNING > PASS) and summary is displayed accordingly.

**Remediation and messaging:**
* Updated remediation messages for clarity and consistency, especially in adapter performance settings and DNS resolution failures. [[1]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L995-R1062) [[2]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L1891-R1958)

These changes make the health reporting more consistent, readable, and user-friendly for diagnosing SDN environments.

<img width="1306" height="826" alt="image" src="https://github.com/user-attachments/assets/d8063554-1e29-4244-8bf3-d4cbce6ac6b8" />


# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [x] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.