### PR TITLE
Code fixes - 2026.01

### DIFF
--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -1461,7 +1461,7 @@ function Show-SdnGatewayUtilization {
                     $barLength = 40
                     $filledLength = [int][Math]::Round(($utilizationPercent / 100) * $barLength)
                     $emptyLength = $barLength - $filledLength
-                    $bar = ("█" * $filledLength) + ("░" * $emptyLength)
+                    $bar = ("=" * $filledLength) + ("." * $emptyLength)
 
                     # Determine color based on utilization thresholds
                     $barColor = if ($utilizationPercent -ge 90) { 'Red' }
@@ -1479,7 +1479,7 @@ function Show-SdnGatewayUtilization {
                     "`t`tCPU Utilization (sampled at {0}):" -f $gateway.CpuMetrics.Timestamp.ToString('yyyy-MM-dd HH:mm:ss') | Write-Host -ForegroundColor Cyan
                     
                     foreach ($cpu in $gateway.CpuMetrics.Processors | Sort-Object -Property ProcessorId) {
-                        $cpuBar = '█' * [int]($cpu.Utilization / 2.5)  # Scale to ~40 chars max
+                        $cpuBar = '=' * [int]($cpu.Utilization / 2.5)  # Scale to ~40 chars max
                         $cpuColor = if ($cpu.Utilization -ge 90) { 'Red' }
                                     elseif ($cpu.Utilization -ge 75) { 'Yellow' }
                                     else { 'Green' }
@@ -1490,7 +1490,7 @@ function Show-SdnGatewayUtilization {
                     }
                     
                     # Display average
-                    $avgBar = '█' * [int]($gateway.CpuMetrics.AverageUtilization / 2.5)
+                    $avgBar = '=' * [int]($gateway.CpuMetrics.AverageUtilization / 2.5)
                     $avgColor = if ($gateway.CpuMetrics.AverageUtilization -ge 90) { 'Red' }
                                 elseif ($gateway.CpuMetrics.AverageUtilization -ge 75) { 'Yellow' }
                                 else { 'Green' }

--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -819,7 +819,8 @@ function Start-SdnDataCollection {
         [System.IO.FileInfo]$OutputDirectory = Join-Path -Path $OutputDirectory.FullName -ChildPath $childPath
         [System.IO.FileInfo]$workingDirectory = (Get-WorkingDirectory)
         [System.IO.FileInfo]$tempDirectory = "$(Get-WorkingDirectory)\Temp"
-
+        $null = Start-Transcript -Path (Join-Path -Path $OutputDirectory.FullName -ChildPath 'DataCollection_Transcript.txt') -ErrorAction Stop
+        
         # setup the directory location where files will be saved to
         "Starting SDN Data Collection" | Trace-Output
 
@@ -1143,6 +1144,7 @@ function Start-SdnDataCollection {
         }
     }
 
+    $null = Stop-Transcript -ErrorAction Ignore
     return $dataCollectionObject
 }
 

--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -752,6 +752,17 @@ function Start-SdnDataCollection {
         [bool]$ConvertETW = $true
     )
 
+    # if we are running in a remote session, we need to do some extra validation
+    if ($PSSenderInfo) {
+        # if we are running in a remote session and CredSSP is not enabled, then we need to ensure that
+        # the user has supplied -Credential to avoid double-hop authentication issues
+        if (-not (Get-WSManCredSSPState)) {
+            if ($Credential -ieq [System.Management.Automation.PSCredential]::Empty -or $null -ieq $Credential) {
+                throw New-Object System.NotSupportedException("Start-SdnDataCollection cannot be run in a remote session without supplying -Credential.")
+            }
+        }
+    }
+
     $ErrorActionPreference = 'Continue'
     $dataCollectionNodes = [System.Collections.ArrayList]::new() # need an arrayList so we can remove objects from this list
 

--- a/src/SdnDiagnostics.psm1
+++ b/src/SdnDiagnostics.psm1
@@ -1255,7 +1255,7 @@ function Show-SdnGatewayUtilization {
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential
+        $Credential = [System.Management.Automation.PSCredential]::Empty
     )
 
     $ncRestParams = @{

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -1170,7 +1170,7 @@ function Test-SdnCertificateMultiple {
             }
 
             $sdnHealthTest.Result = 'WARNING'
-            $sdnHealthTest.Remediation = "Examine and cleanup the certificates if no longer needed:`r`n{0}" -f ($certDetails -join "`r`n")
+            $sdnHealthTest.Remediation = "Examine and cleanup the certificates if no longer needed:`r`n`t{0}" -f ($certDetails -join "`r`n`t")
         }
     }
     catch {


### PR DESCRIPTION
This pull request introduces improvements to remote session handling, logging, and output formatting in the SDN diagnostics and health validation scripts. The main changes include enforcing credential requirements for remote sessions, adding transcript logging, and standardizing output visuals.

**Remote session validation and credential handling:**
- Added checks in both `Start-SdnDataCollection` and `Debug-SdnFabricInfrastructure` to ensure that when running in a remote session without CredSSP enabled, the user must supply the `-Credential` parameter to avoid double-hop authentication issues. If not, the functions throw a `NotSupportedException`. [[1]](diffhunk://#diff-490865628c61b2e97c50f45b37d7086647c70b2444cbfb9c60cc8c682801356eR757-R767) [[2]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60R403-R416)
- Set a default value for the `$Credential` parameter in `Show-SdnGatewayUtilization` to prevent null credential issues.

**Logging and transcript improvements:**
- Introduced transcript logging at the start of data collection and health validation processes, and ensured transcripts are stopped appropriately to capture command output for troubleshooting. [[1]](diffhunk://#diff-490865628c61b2e97c50f45b37d7086647c70b2444cbfb9c60cc8c682801356eR835) [[2]](diffhunk://#diff-490865628c61b2e97c50f45b37d7086647c70b2444cbfb9c60cc8c682801356eR1160) [[3]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L411-L415)

**Output and formatting enhancements:**
- Updated bar chart characters in `Show-SdnGatewayUtilization` from Unicode blocks (`█`, `░`) to ASCII characters (`=`, `.`) for improved compatibility and readability. [[1]](diffhunk://#diff-490865628c61b2e97c50f45b37d7086647c70b2444cbfb9c60cc8c682801356eL1464-R1477) [[2]](diffhunk://#diff-490865628c61b2e97c50f45b37d7086647c70b2444cbfb9c60cc8c682801356eL1482-R1495) [[3]](diffhunk://#diff-490865628c61b2e97c50f45b37d7086647c70b2444cbfb9c60cc8c682801356eL1493-R1506)
- Improved remediation message formatting in `Test-SdnCertificateMultiple` by adding indentation for better clarity.

**Minor logic adjustments:**
- Moved the network controller confirmation check in `Debug-SdnFabricInfrastructure` to occur only after remote session validation, ensuring proper sequencing. [[1]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60R403-R416) [[2]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60L411-L415) [[3]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60R433)

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.