### PR TITLE
fix how to extract property from vfp port state

### DIFF
--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -2272,7 +2272,7 @@ function Get-SdnVfpPortState {
                     "Inner MAC VMQ Enabled" { $object.OffloadState.InnerMacVmqEnabled = $true }
                     
                     default {
-                        # this may just be random lines that do not map to a property, so we will just log it and continue
+                        # this may just be random lines that do not map to a property, so we will just skip them
                         continue
                     }
                 }


### PR DESCRIPTION
This pull request updates the logic for parsing VFP port state properties in `Get-SdnVfpPortState` to better handle properties that are output without explicit key/value pairs, and adds support for the `SriovEnabled` property in the `VfpPortState` class. The main changes focus on improving how enabled features are detected and mapped to the state object.

**Enhancements to VFP Port State Parsing:**

* Updated the parsing logic in `Get-SdnVfpPortState` to handle lines that only contain a property name (without a value), assuming these properties are enabled by default when present in the output. This ensures properties like "SR-IOV Enabled" and various offload features are correctly set to `$true` when detected.

* Moved the mapping of several port state and offload properties (such as "DTLS Offload Enabled", "GFT Offload Enabled", and various NVGRE/VXLAN offload features) from the key/value parsing block to the new single-property-line parsing block, improving robustness and accuracy. [[1]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL2231-L2250) [[2]](diffhunk://#diff-11217f20b55d3b4ea34c8c217794c81d65acc4852dff9bf4295e5cc4d6dfaeedL2265-R2280)

**VfpPortState Class Update:**

* Added a new `[boolean]$SriovEnabled` property to the `VfpPortState` class to track the SR-IOV enablement state.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.