### PR TITLE
Fix remediation output for health tests for certs

### DIFF
--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -1179,8 +1179,15 @@ function Test-SdnCertificateMultiple {
             }
         }
 
+        # exclude any Azure Stack certificates from the results as these are managed on their own lifecycle
+        # could be edge scenarios where we have an outdate certificate, but we will take caution regardless to not delete these certificates
+        if ($null -ne $certificate) {
+            $certificate = $certificate | Where-Object { $_.Issuer -ine "CN=AzureStackCertificationAuthority"}
+        }
+
+        # if we still have multiple certificates after filtering, we need to flag this as a warning
+        # we will exclude the most current certificate from the warning as that is the one in use
         if ($null -ne $certificate -and $certificate.Count -gt 1) {
-            # eliminate the most current certificate from the array as we do not want to flag that one
             $latestCert = $certificate | Sort-Object -Property NotAfter -Descending | Select-Object -First 1
             $certificate = $certificate | Where-Object { $_.Thumbprint -ne $latestCert.Thumbprint }
             $certDetails = $certificate | ForEach-Object {

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -952,8 +952,11 @@ function Test-SdnNonSelfSignedCertificateInTrustedRootStore {
         $rootCerts = Get-ChildItem -Path 'Cert:LocalMachine\Root' | Where-Object { $_.Issuer -ne $_.Subject }
         if ($rootCerts -or $rootCerts.Count -gt 0) {
             $sdnHealthTest.Result = 'FAIL'
-            $rootCerts | ForEach-Object {
+            $certDetails = $rootCerts | ForEach-Object {
                 "`t- Thumbprint: {0} Subject: {1} Issuer: {2} NotAfter: {3}" -f $_.Thumbprint, $_.Subject, $_.Issuer, $_.NotAfter
+            }
+
+            $rootCerts | ForEach-Object {
                 $array += [PSCustomObject]@{
                     Thumbprint = $_.Thumbprint
                     Subject    = $_.Subject
@@ -1116,6 +1119,7 @@ function Test-SdnCertificateExpired {
 
     $role = $Global:SdnDiagnostics.Config.Role
     $sdnHealthTest = New-SdnHealthTest
+    $array = @()
 
     try {
         foreach ($r in $role) {
@@ -1134,8 +1138,9 @@ function Test-SdnCertificateExpired {
             if ($certificate -or $certificate.Count -gt 0) {
                 $sdnHealthTest.Result = 'FAIL'
                 $sdnHealthTest.Remediation = "Renew the certificate(s) used for SDN components."
+
                 $certificate | ForEach-Object {
-                    $sdnHealthTest.Properties += [PSCustomObject]@{
+                    $array += [PSCustomObject]@{
                         Thumbprint = $_.Thumbprint
                         Subject    = $_.Subject
                         NotAfter   = $_.NotAfter
@@ -1145,6 +1150,8 @@ function Test-SdnCertificateExpired {
                 }
             }
         }
+
+        $sdnHealthTest.Properties = $array
     }
     catch {
         $_ | Trace-Exception
@@ -1158,6 +1165,7 @@ function Test-SdnCertificateMultiple {
 
     $role = $Global:SdnDiagnostics.Config.Role
     $sdnHealthTest = New-SdnHealthTest
+    $array = @()
 
     try {
         foreach ($r in $role) {
@@ -1179,9 +1187,21 @@ function Test-SdnCertificateMultiple {
                 "`t- Thumbprint: {0} Subject: {1} Issuer: {2} NotAfter: {3}" -f $_.Thumbprint, $_.Subject, $_.Issuer, $_.NotAfter
             }
 
+            $certificate | ForEach-Object {
+                $array += [PSCustomObject]@{
+                    Thumbprint = $_.Thumbprint
+                    Subject    = $_.Subject
+                    Issuer     = $_.Issuer
+                    NotAfter   = $_.NotAfter
+                    NotBefore  = $_.NotBefore
+                }
+            }
+
             $sdnHealthTest.Result = 'WARNING'
-            $sdnHealthTest.Remediation = "Examine and cleanup the certificates if no longer needed:`r`n`t{0}" -f ($certDetails -join "`r`n`t")
+            $sdnHealthTest.Remediation = "Examine and cleanup the certificates if no longer needed:`r`n{0}" -f ($certDetails -join "`r`n")
         }
+
+        $sdnHealthTest.Properties = $array
     }
     catch {
         $_ | Trace-Exception


### PR DESCRIPTION
This pull request enhances the certificate validation logic in the SDN diagnostic health module by improving how certificate details are collected and reported in several health test functions. The main improvements include standardizing the way certificate properties are gathered and ensuring that results are consistently stored for reporting.

**Certificate details collection and reporting:**

* Refactored `Test-SdnCertificateExpired` and `Test-SdnCertificateMultiple` to accumulate certificate details into an array and assign them to `Properties` at the end of execution, ensuring consistent and structured reporting of affected certificates. [[1]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60R1122) [[2]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60R1141-R1143) [[3]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60R1153-R1154) [[4]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60R1168) [[5]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60R1182-R1211)
* In `Test-SdnNonSelfSignedCertificateInTrustedRootStore`, introduced a variable to collect certificate details and improved the process of adding certificate information to the result array.

**Certificate selection logic:**

* Enhanced logic in `Test-SdnCertificateMultiple` to prioritize certificates issued by `AzureStackCertificationAuthority` when determining which certificate to keep, and improved the remediation message formatting.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.