### PR TITLE
Fix issue with empty credentials passed to Invoke-Command

### DIFF
--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -2802,7 +2802,16 @@ function Install-SdnDiagnostics {
                     # use Invoke-Command here, as we do not want to create a cached session for the remote computers
                     # as it will impact scenarios where we need to import the module on the remote computer for remote sessions
                     try {
-                        $remoteModuleVersion = Invoke-Command -ComputerName $computer -Credential $Credential -ScriptBlock $getModuleVersionSB -ArgumentList @($moduleName) -ErrorAction Stop
+                        $invokeParams = @{
+                            ComputerName = $computer
+                            ScriptBlock = $getModuleVersionSB
+                            ArgumentList = @($moduleName)
+                            ErrorAction = 'Stop'
+                        }
+                        if ($Credential -ne [System.Management.Automation.PSCredential]::Empty -and $null -ne $Credential) {
+                            $invokeParams.Add('Credential', $Credential)
+                        }
+                        $remoteModuleVersion = Invoke-Command @invokeParams
                     }
                     catch {
                         # if we are unable to connect to the remote computer, we will skip the operation


### PR DESCRIPTION
# Description
This pull request refactors how credentials are passed to `Invoke-Command` in the `Install-SdnDiagnostics` function to improve reliability and avoid passing empty credentials. The change ensures that the `Credential` parameter is only added when a valid credential is provided.

**Improvements to remote command invocation:**

* Refactored the parameters for `Invoke-Command` to use a hashtable (`$invokeParams`) and only add the `Credential` key if a non-empty credential is provided, preventing issues with empty credentials being passed.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.