### PR TITLE
Add certificate FriendlyName to result output

### DIFF
--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -977,11 +977,12 @@ function Test-SdnNonSelfSignedCertificateInTrustedRootStore {
 
             $rootCerts | ForEach-Object {
                 $array += [PSCustomObject]@{
-                    Thumbprint = $_.Thumbprint
-                    Subject    = $_.Subject
-                    Issuer     = $_.Issuer
-                    NotAfter   = $_.NotAfter
-                    NotBefore  = $_.NotBefore
+                    Thumbprint      = $_.Thumbprint
+                    Subject         = $_.Subject
+                    FriendlyName    = $_.FriendlyName
+                    Issuer          = $_.Issuer
+                    NotAfter        = $_.NotAfter
+                    NotBefore       = $_.NotBefore
                 }
             }
 
@@ -1168,11 +1169,12 @@ function Test-SdnCertificateExpired {
 
                 $certificate | ForEach-Object {
                     $array += [PSCustomObject]@{
-                        Thumbprint = $_.Thumbprint
-                        Subject    = $_.Subject
-                        NotAfter   = $_.NotAfter
-                        NotBefore  = $_.NotBefore
-                        Issuer     = $_.Issuer
+                        Thumbprint      = $_.Thumbprint
+                        Subject         = $_.Subject
+                        FriendlyName    = $_.FriendlyName
+                        Issuer          = $_.Issuer
+                        NotAfter        = $_.NotAfter
+                        NotBefore       = $_.NotBefore
                     }
                 }
             }
@@ -1220,11 +1222,12 @@ function Test-SdnCertificateMultiple {
 
             $certificate | ForEach-Object {
                 $array += [PSCustomObject]@{
-                    Thumbprint = $_.Thumbprint
-                    Subject    = $_.Subject
-                    Issuer     = $_.Issuer
-                    NotAfter   = $_.NotAfter
-                    NotBefore  = $_.NotBefore
+                    Thumbprint      = $_.Thumbprint
+                    Subject         = $_.Subject
+                    FriendlyName    = $_.FriendlyName
+                    Issuer          = $_.Issuer
+                    NotAfter        = $_.NotAfter
+                    NotBefore       = $_.NotBefore
                 }
             }
 


### PR DESCRIPTION
# Description
This pull request makes minor improvements to the certificate-related PowerShell functions by ensuring that the `FriendlyName` property is included in the output objects. Additionally, it corrects the ordering of the `Issuer` property in one function for consistency.

Certificate object output improvements:

* Added the `FriendlyName` property to the output objects in the `Test-SdnNonSelfSignedCertificateInTrustedRootStore`, `Test-SdnCertificateExpired`, and `Test-SdnCertificateMultiple` functions to provide more descriptive information about each certificate. [[1]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60R982) [[2]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60R1174-L1175) [[3]](diffhunk://#diff-15898640fc68e07afa836ad8d93af4f22a4442978d9c233f39d48d44d85cfb60R1227)

Code consistency:

* Moved the `Issuer` property to a consistent position in the output object for the `Test-SdnCertificateExpired` function.

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [x] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.