### PR TITLE
Enable ability for force override disabling SF node

### DIFF
--- a/src/modules/SdnDiag.NetworkController.SF.psm1
+++ b/src/modules/SdnDiag.NetworkController.SF.psm1
@@ -2986,6 +2986,8 @@ function Disable-SdnServiceFabricNode {
         Specifies the name of a Service Fabric node. The cmdlet disables the node that you specify.
     .PARAMETER Credential
         Specifies a user account that has permission to perform this action. The default is the current user.
+    .PARAMETER Force
+        Specifies that the cmdlet should override any restrictions that would prevent the action from completing.
     .EXAMPLE
         PS> Disable-SdnServiceFabricNode -NetworkController 'NC01' -Credential (Get-Credential) -NodeName 'Node01'
     #>
@@ -3001,7 +3003,10 @@ function Disable-SdnServiceFabricNode {
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
-        $Credential = [System.Management.Automation.PSCredential]::Empty
+        $Credential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.SwitchParameter]$Force
     )
 
     $stopWatch = [System.Diagnostics.Stopwatch]::StartNew()
@@ -3034,8 +3039,8 @@ function Disable-SdnServiceFabricNode {
     # check to see if the service fabric cluster is healthy before we disable the node
     # if the cluster is not healthy, then we cannot disable the node
     $isClusterHealthy = Confirm-SdnServiceFabricHealthy -NetworkController $NetworkController -Credential $Credential -ErrorAction Stop
-    if (-NOT $isClusterHealthy) {
-        "Service Fabric Cluster is not healthy, cannot disable $($fabricNode.NodeName)" | Trace-Output -Level:Warning
+    if (-NOT $isClusterHealthy -and -NOT $Force) {
+        "Service Fabric Cluster is not healthy, cannot disable $($fabricNode.NodeName). Use -Force to override" | Trace-Output -Level:Warning
         return
     }
 


### PR DESCRIPTION
# Description
This pull request adds a new `-Force` parameter to the `Disable-SdnServiceFabricNode` function, allowing users to override the health check restriction when disabling a Service Fabric node. If the cluster is not healthy, the operation can now proceed if `-Force` is specified.

**Enhancement to node disabling command:**

* Added a `Force` switch parameter to `Disable-SdnServiceFabricNode`, enabling users to override restrictions that would otherwise prevent disabling a node if the Service Fabric cluster is unhealthy. [[1]](diffhunk://#diff-990bb440c859f26a7bb2db20db61323daa2a690ea91d1b81d4447023e1ef4e1bR2989-R2990) [[2]](diffhunk://#diff-990bb440c859f26a7bb2db20db61323daa2a690ea91d1b81d4447023e1ef4e1bL3004-R3009) [[3]](diffhunk://#diff-990bb440c859f26a7bb2db20db61323daa2a690ea91d1b81d4447023e1ef4e1bL3037-R3043)
* Updated the logic to check for the `Force` parameter: if the cluster is unhealthy and `-Force` is not specified, the command will not proceed and will prompt the user to use `-Force` to override.

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.