### PR TITLE
Add SF Network Controller Partition DB Health Test

### DIFF
--- a/src/modules/SdnDiag.Health.Config.psd1
+++ b/src/modules/SdnDiag.Health.Config.psd1
@@ -111,6 +111,12 @@
             Impact = "Policy configuration failures may be reported by Network Controller when applying policies to the Hyper-v host. Network Interfaces reporting configurationState failure will not be routable."
             PublicDocUrl = ""
         }
+        'Test-SdnServiceFabricPartitionDatabaseSize' = @{
+            FriendlyName = "SDN Service Fabric Partition Database Size"
+            Description = "Ensure that the Service Fabric partition database size is within acceptable limits."
+            Impact = "Large partition databases can lead to performance issues."
+            PublicDocUrl = ""
+        }
 
         # SERVER TESTS
 

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -1962,7 +1962,7 @@ function Test-SdnServiceFabricPartitionDatabaseSize {
     $array = @()
 
     try {
-        $ncAppWorkDir = Invoke-SdnServiceFabricCommand -ScriptBlock { 
+        $ncApp = Invoke-SdnServiceFabricCommand -ScriptBlock { 
             Get-ServiceFabricDeployedApplication -ApplicationName 'fabric:/NetworkController' 
         }
         $ncAppWorkDir = $ncApp.WorkDirectory

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -764,6 +764,7 @@ function Debug-SdnNetworkController {
                     Test-SdnServiceFabricApplicationHealth
                     Test-SdnServiceFabricClusterHealth
                     Test-SdnServiceFabricNodeStatus
+                    Test-SdnServiceFabricPartitionDatabaseSize
                 )
 
                 foreach ($service in $services_sf) {
@@ -1937,6 +1938,64 @@ function Test-SdnNetworkControllerNodeRestInterface {
         if ($null -eq $netAdapter) {
             $sdnHealthTest.Result = 'FAIL'
             $sdnHealthTest.Remediation += "Ensure that the Network Adapter $($node.RestInterface) exists. Leverage 'Set-NetworkControllerNode to update the -RestInterface if original adapter is not available."
+        }
+    }
+    catch {
+        $_ | Trace-Exception
+        $sdnHealthTest.Result = 'UNKNOWN'
+    }
+
+    return $sdnHealthTest
+}
+
+
+function Test-SdnServiceFabricPartitionDatabaseSize {
+    <#
+    .SYNOPSIS
+        Validate the Service Fabric partition size for each of the services running on Network Controller.
+    #>
+
+    [CmdletBinding()]
+    param ()
+
+    $sdnHealthTest = New-SdnHealthTest
+
+    try {
+        $ncAppWorkDir = Invoke-SdnServiceFabricCommand -ScriptBlock { 
+            Get-ServiceFabricDeployedApplication -ApplicationName 'fabric:/NetworkController' 
+        }
+        $ncAppWorkDir = $ncApp.WorkDirectory
+        if($null -eq $ncAppWorkDir){
+            throw New-Object System.NullReferenceException("Unable to retrieve working directory path")
+        }
+
+        $ncServices = Get-SdnServiceFabricService | Where-Object {$_.ServiceKind -eq "Stateful"}
+        foreach ($ncService in $ncServices){
+            $replica = Get-SdnServiceFabricReplica -ServiceName $ncService.ServiceName
+            $imosStorePath = Join-Path -Path $ncAppWorkDir -ChildPath "P_$($replica.PartitionId)\R_$($replica.ReplicaId)\ImosStore"
+            if (Test-Path -Path $imosStorePath) {
+                $imosStoreFile = (Get-Item -Path $imosStorePath)
+            }
+            else {
+                $imosStoreFile = $null
+            }
+
+            if($null -ne $imosStoreFile){
+                $formatedByteSize = Format-ByteSize -Bytes $imosStoreFile.Length
+                $imosInfo = [PSCustomObject]@{
+                    Service = $ncService.ServiceName
+                    ImosSize = $formatedByteSize.GB
+                }
+
+                $sdnHealthTest.Properties = $imosInfo
+
+                # if the imos database file exceeds 4GB, want to indicate failure as it should not grow to be larger than this size
+                # need to perform InvariantCulture to ensure that the decimal separator is a period
+                if([float]::Parse($formatedByteSize.GB, [System.Globalization.NumberStyles]::Float, [System.Globalization.CultureInfo]::InvariantCulture) -gt 4){
+                    $sdnHealthTest.Result = 'FAIL'
+                    $sdnHealthTest.Remediation = "Engage Microsoft CSS for further support"
+                }
+            }
         }
     }
     catch {

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -1959,6 +1959,7 @@ function Test-SdnServiceFabricPartitionDatabaseSize {
     param ()
 
     $sdnHealthTest = New-SdnHealthTest
+    $array = @()
 
     try {
         $ncAppWorkDir = Invoke-SdnServiceFabricCommand -ScriptBlock { 
@@ -1985,9 +1986,10 @@ function Test-SdnServiceFabricPartitionDatabaseSize {
                 $imosInfo = [PSCustomObject]@{
                     Service = $ncService.ServiceName
                     ImosSize = $formatedByteSize.GB
+                    Path = $imosStorePath
                 }
 
-                $sdnHealthTest.Properties = $imosInfo
+                $array += $imosInfo
 
                 # if the imos database file exceeds 4GB, want to indicate failure as it should not grow to be larger than this size
                 # need to perform InvariantCulture to ensure that the decimal separator is a period
@@ -1997,6 +1999,8 @@ function Test-SdnServiceFabricPartitionDatabaseSize {
                 }
             }
         }
+
+        $sdnHealthTest.Properties = $array
     }
     catch {
         $_ | Trace-Exception


### PR DESCRIPTION
# Description
This pull request introduces a new health check for monitoring the size of Service Fabric partition databases used by the Network Controller, helping to proactively detect and address performance issues. The main changes include the implementation of the new test, its integration into the existing health check workflow, and the addition of corresponding metadata.

**New Service Fabric Partition Database Size Health Check:**

* Added a new function, `Test-SdnServiceFabricPartitionDatabaseSize`, which checks the size of each stateful Service Fabric partition database for the Network Controller. If any database exceeds 4GB, it reports a failure and recommends escalation.

**Integration and Metadata:**

* Integrated the new health check into the `Debug-SdnNetworkController` workflow to ensure it runs alongside existing Service Fabric health tests.
* Updated the `src/modules/SdnDiag.Health.Config.psd1` configuration file to add metadata for the new test, including its friendly name, description, and impact.
* 
# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [] I have tested and validated my code changes.