### PR TITLE
Check ps remoteaccess class present

### DIFF
--- a/src/modules/SdnDiag.Health.Config.psd1
+++ b/src/modules/SdnDiag.Health.Config.psd1
@@ -51,6 +51,12 @@
             Impact = "You may not achieve optimal performance for network traffic flowing through the SDN Node(s)."
             PublicDocUrl = ""
         }
+        'Test-SdnGatewayRemoteAccessCimClass' = @{
+            FriendlyName = "Gateway RemoteAccess CIM Class"
+            Description = "Ensure that the PS_RemoteAccess CIM class is accessible in the root/microsoft/windows/remoteaccess namespace on Gateway node(s)."
+            Impact = "Gateway functionality may be impacted if the RemoteAccess WMI provider is not installed or operational."
+            PublicDocUrl = ""
+        }
 
         # LOAD BALANCER MUX TESTS
 

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -2096,7 +2096,7 @@ function Test-SdnGatewayRemoteAccessCimClass {
         catch {
             $_ | Trace-Exception
             $sdnHealthTest.Result = 'FAIL'
-            $sdnHealthTest.Remediation += "Ensure the RemoteAccess role and required WMI providers are installed and functional on this Gateway node."
+            $sdnHealthTest.Remediation += "Ensure the RemoteAccess role is installed. Run 'Install-WindowsFeature -Name RSAT-RemoteAccess-PowerShell' to install missing WMI class"
         }
     }
     catch {

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -2091,7 +2091,7 @@ function Test-SdnGatewayRemoteAccessCimClass {
     $sdnHealthTest = New-SdnHealthTest
     try {
         try {
-            Get-CimClass -Namespace 'root/microsoft/windows/remoteaccess' -ClassName 'PS_RemoteAccess' -ErrorAction Stop | Out-Null
+            $null = Get-CimClass -Namespace 'root/microsoft/windows/remoteaccess' -ClassName 'PS_RemoteAccess' -ErrorAction Stop
         }
         catch {
             $_ | Trace-Exception

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -924,6 +924,7 @@ function Debug-SdnGateway {
             Test-SdnNonSelfSignedCertificateInTrustedRootStore @PSBoundParameters
             Test-SdnDiagnosticsCleanupTaskEnabled -TaskName 'SDN Diagnostics Task' @PSBoundParameters
             Test-SdnAdapterPerformanceSetting @PSBoundParameters
+            Test-SdnGatewayRemoteAccessCimClass @PSBoundParameters
         )
 
         foreach ($service in $services) {
@@ -2076,4 +2077,32 @@ function Test-SdnAdapterPerformanceSetting {
     }
 
     return $sdnHealthTest
-} 
+}
+
+function Test-SdnGatewayRemoteAccessCimClass {
+    <#
+        .SYNOPSIS
+            Validates that the RemoteAccess CIM class is accessible on the Gateway node.
+    #>
+
+    [CmdletBinding()]
+    param ()
+
+    $sdnHealthTest = New-SdnHealthTest
+    try {
+        try {
+            Get-CimClass -Namespace 'root/microsoft/windows/remoteaccess' -ClassName 'PS_RemoteAccess' -ErrorAction Stop | Out-Null
+        }
+        catch {
+            $_ | Trace-Exception
+            $sdnHealthTest.Result = 'FAIL'
+            $sdnHealthTest.Remediation += "Ensure the RemoteAccess role and required WMI providers are installed and functional on this Gateway node."
+        }
+    }
+    catch {
+        $_ | Trace-Exception
+        $sdnHealthTest.Result = 'UNKNOWN'
+    }
+
+    return $sdnHealthTest
+}

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -1123,7 +1123,7 @@ function Test-SdnNetworkControllerApiNameResolution {
                     }
                     catch {
                         $_ | Trace-Exception
-                        "Investigate DNS resolution failure against DNS server {0} for name {1}" -f $dnsServer, $Endpoint
+                        "Failed to resolve {0} from {1}. Exception: {2}" -f $Endpoint, $dnsServer, $_.Exception.Message
                     }
                 }
 


### PR DESCRIPTION
# Description
This pull request introduces a new health check for SDN Gateway nodes to ensure the RemoteAccess CIM class is available, which helps verify that the necessary WMI providers for gateway functionality are installed and operational. The new test is integrated into the gateway diagnostics workflow and its metadata is added to the configuration.

**New Gateway Health Check:**

* Added `Test-SdnGatewayRemoteAccessCimClass` function to validate that the `PS_RemoteAccess` CIM class is accessible in the `root/microsoft/windows/remoteaccess` namespace, ensuring the RemoteAccess role is installed and functional on Gateway nodes.
* Integrated the new health check into the `Debug-SdnGateway` diagnostic workflow, so it runs automatically with other gateway tests.
* Registered the new test and its metadata (friendly name, description, impact) in the `SdnDiag.Health.Config.psd1` configuration file for reporting and documentation purposes.

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [ ] My code follows the style and contribution guidelines of this project.
- [ ] I have tested and validated my code changes.