### PR TITLE
add check for missing encryption cert

### DIFF
--- a/src/modules/SdnDiag.Health.Config.psd1
+++ b/src/modules/SdnDiag.Health.Config.psd1
@@ -117,6 +117,12 @@
             Impact = "Policy configuration failures may be reported by Network Controller when applying policies to the Hyper-v host. Network Interfaces reporting configurationState failure will not be routable."
             PublicDocUrl = ""
         }
+        'Test-SdnEncryptionCertificateIsPresent' = @{
+            FriendlyName = "SDN Encryption Certificate Is Present"
+            Description = "Ensure that the encryption certificate is present on the network controller node."
+            Impact = "The encryption certificate is missing from the LocalMachine\My store. It is used to decrypt the SDN database and may result in failures when accessing SDN resources."
+            PublicDocUrl = ""
+        }
 
         # SERVER TESTS
 

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -746,6 +746,7 @@ function Debug-SdnNetworkController {
         # execute tests for network controller, regardless of the cluster type
         $healthReport.HealthTest += @(
             Test-SdnNonSelfSignedCertificateInTrustedRootStore
+            Test-SdnRestCertificateIsPresent
         )
 
         # execute tests based on the cluster type
@@ -1938,6 +1939,44 @@ function Test-SdnNetworkControllerNodeRestInterface {
         if ($null -eq $netAdapter) {
             $sdnHealthTest.Result = 'FAIL'
             $sdnHealthTest.Remediation += "Ensure that the Network Adapter $($node.RestInterface) exists. Leverage 'Set-NetworkControllerNode to update the -RestInterface if original adapter is not available."
+        }
+    }
+    catch {
+        $_ | Trace-Exception
+        $sdnHealthTest.Result = 'UNKNOWN'
+    }
+
+    return $sdnHealthTest
+}
+
+function Test-SdnEncryptionCertificateIsPresent {
+    <#
+        .SYNOPSIS
+            Validates that the encryption certificate is present on the network controller node.
+    #>
+
+    [CmdletBinding()]
+    param()
+
+    Confirm-IsNetworkController
+    $sdnHealthTest = New-SdnHealthTest
+
+    try {
+        switch ($Global:SdnDiagnostics.EnvironmentInfo.ClusterConfigType) {
+            'FailoverCluster' {
+                $ncResult = Get-SdnNetworkController -ErrorAction Stop
+                $certThumbprint = $ncResult.RestCertificateThumbPrint
+            }
+            'ServiceFabric' {
+                $ncClusterSettings = Get-NetworkControllerCluster -ErrorAction Stop
+                $certThumbprint = $ncClusterSettings.CredentialEncryptionCertificate.Thumbprint
+            }
+        }
+
+        $cert = Get-SdnCertificate -Thumbprint $certThumbprint -Path 'Cert:\localmachine\My'
+        if ($null -eq $cert) {
+            $sdnHealthTest.Result = 'FAIL'
+            $sdnHealthTest.Remediation += "Ensure that the encryption certificate $($certThumbprint) for SDN is present in the LocalMachine\My store."
         }
     }
     catch {

--- a/src/modules/SdnDiag.Health.psm1
+++ b/src/modules/SdnDiag.Health.psm1
@@ -746,7 +746,7 @@ function Debug-SdnNetworkController {
         # execute tests for network controller, regardless of the cluster type
         $healthReport.HealthTest += @(
             Test-SdnNonSelfSignedCertificateInTrustedRootStore
-            Test-SdnRestCertificateIsPresent
+            Test-SdnEncryptionCertificateIsPresent 
         )
 
         # execute tests based on the cluster type


### PR DESCRIPTION
# Description
This pull request adds a new health test to ensure the presence of the SDN encryption certificate on the network controller node. It introduces the `Test-SdnEncryptionCertificateIsPresent` function, updates the module manifest with its metadata, and adds a related test to the network controller health check sequence.

**New SDN Encryption Certificate Health Check:**

* Added the `Test-SdnEncryptionCertificateIsPresent` function to validate that the required encryption certificate is present in the `LocalMachine\My` store on the network controller node. This helps prevent failures when accessing SDN resources if the certificate is missing.
* Registered the new test in the module manifest (`SdnDiag.Health.Config.psd1`) with a friendly name, description, and impact statement.

**Health Check Workflow Updates:**

* Included the new `Test-SdnEncryptionCertificateIsPresent` in the list of tests executed for network controller health validation.

# Change type
- [ ] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [x] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.