### PR TITLE
Remove conflicting VLAN configuration in Repair-SdnVMNetworkAdapterPortProfile

### DIFF
--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -3611,24 +3611,52 @@ function Repair-SdnVMNetworkAdapterPortProfile {
 
         # VLAN configured directly on the VM network adapter conflicts with the isolation settings that VFP
         # programs once the port profile has been applied, so any VLAN configuration must be removed.
-        # Get-VMNetworkAdapterVlan always returns an object for an adapter, so we determine whether a VLAN is
-        # actually configured based on the OperationMode being something other than Untagged.
+        # Get-VMNetworkAdapterVlan always returns a Microsoft.HyperV.PowerShell.VMNetworkAdapterVlanSetting object
+        # for an adapter, so we determine whether a VLAN is actually configured based on the OperationMode being
+        # something other than Untagged.
         foreach ($vlanConfiguration in $currentVlanConfiguration) {
             if ($null -eq $vlanConfiguration) {
                 continue
             }
 
-            if ($vlanConfiguration.OperationMode -ine 'Untagged') {
-                $vlanDetails = switch ($vlanConfiguration.OperationMode) {
-                    'Access' { "AccessVlanId [{0}]" -f $vlanConfiguration.AccessVlanId }
-                    'Trunk' { "NativeVlanId [{0}] AllowedVlanIdList [{1}]" -f $vlanConfiguration.NativeVlanId, ($vlanConfiguration.AllowedVlanIdList -join ',') }
-                    default { "PrimaryVlanId [{0}] SecondaryVlanId [{1}]" -f $vlanConfiguration.PrimaryVlanId, $vlanConfiguration.SecondaryVlanId }
-                }
-
-                "Detected VLAN OperationMode [{0}] {1} on VM {2} with MAC Address {3}, which conflicts with the isolation settings leveraged by VFP." `
-                    -f $vlanConfiguration.OperationMode, $vlanDetails, $VMName, $formattedMacAddress | Trace-Output -Level:Warning
-                $vlanRepairRequired = $true
+            # OperationMode and PrivateVlanMode are enums locally, however they are deserialized as their underlying
+            # integer value when returned from a remote session, so cast to string to ensure we compare against the
+            # enum name consistently regardless of whether the Hyper-V host is local or remote.
+            $operationMode = [string]$vlanConfiguration.OperationMode
+            if ([string]::IsNullOrEmpty($operationMode) -or $operationMode -ieq 'Untagged') {
+                continue
             }
+
+            # only a subset of the properties are populated on the object, based on the OperationMode that has
+            # been configured, so we only report on the properties that are relevant for the current mode.
+            $vlanDetails = switch ($operationMode) {
+                'Access' {
+                    "AccessVlanId [{0}]" -f $vlanConfiguration.AccessVlanId
+                }
+                'Trunk' {
+                    "NativeVlanId [{0}] AllowedVlanIdList [{1}]" -f $vlanConfiguration.NativeVlanId, $vlanConfiguration.AllowedVlanIdListString
+                }
+                'Private' {
+                    # SecondaryVlanId is only populated when PrivateVlanMode is Isolated or Community, whereas
+                    # SecondaryVlanIdList is only populated when PrivateVlanMode is Promiscuous.
+                    $privateVlanMode = [string]$vlanConfiguration.PrivateVlanMode
+                    $secondaryVlanDetails = if ($privateVlanMode -ieq 'Promiscuous') {
+                        "SecondaryVlanIdList [{0}]" -f $vlanConfiguration.SecondaryVlanIdListString
+                    }
+                    else {
+                        "SecondaryVlanId [{0}]" -f $vlanConfiguration.SecondaryVlanId
+                    }
+
+                    "PrivateVlanMode [{0}] PrimaryVlanId [{1}] {2}" -f $privateVlanMode, $vlanConfiguration.PrimaryVlanId, $secondaryVlanDetails
+                }
+                default {
+                    '(no additional details available)'
+                }
+            }
+
+            "Detected VLAN OperationMode [{0}] {1} on VM {2} with MAC Address {3}, which conflicts with the isolation settings leveraged by VFP." `
+                -f $operationMode, $vlanDetails, $VMName, $formattedMacAddress | Trace-Output -Level:Warning
+            $vlanRepairRequired = $true
         }
 
         # remove the VLAN configuration before applying the port profile, to ensure the conflicting

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -3452,6 +3452,7 @@ function Repair-SdnVMNetworkAdapterPortProfile {
         Repairs the port profile applied to the virtual machine network interfaces.
     .DESCRIPTION
         This cmdlet repairs the port profile applied to the virtual machine network interfaces by retrieving the network interface from Network Controller and applying the port profile to the VM network adapter.
+        Any VLAN configuration detected on the VM network adapter is also removed, as it conflicts with the isolation settings that VFP programs once the port profile has been applied.
     .PARAMETER VMName
         Specifies the name of the virtual machine.
     .PARAMETER MacAddress
@@ -3509,6 +3510,7 @@ function Repair-SdnVMNetworkAdapterPortProfile {
     }
 
     $repairRequired = $false
+    $vlanRepairRequired = $false
     $ncRestParams = @{
         NcUri    = $NcUri
         Resource = 'NetworkInterfaces'
@@ -3565,9 +3567,12 @@ function Repair-SdnVMNetworkAdapterPortProfile {
         $repairPortProfileParams.ProfileId = $networkInterface.InstanceId
 
         # check to see if the Hyper-V host is local or remote host
-        if (Test-ComputerNameIsLocal -ComputerName $HyperVHost) {
+        $isLocalHost = Test-ComputerNameIsLocal -ComputerName $HyperVHost
+        if ($isLocalHost) {
             $vmNetworkAdapters = Get-SdnVMNetworkAdapterPortProfile -VMName $VMName -ErrorAction Stop
             $currentPortProfileSettings = $vmNetworkAdapters | Where-Object {$_.MacAddress -eq $formattedMacAddress}
+
+            $currentVlanConfiguration = Get-SdnVMNetworkAdapter -VMName $VMName -MacAddress $formattedMacAddress -ErrorAction Stop | Get-VMNetworkAdapterVlan -ErrorAction Stop
         }
         else {
             $repairPortProfileParams.Add('HyperVHost', $HyperVHost)
@@ -3578,6 +3583,12 @@ function Repair-SdnVMNetworkAdapterPortProfile {
 
                 $vmNetworkAdapters = Get-SdnVMNetworkAdapterPortProfile -VMName $vmName
                 return ($vmNetworkAdapters | Where-Object {$_.MacAddress -eq $macAddress})
+            } -ArgumentList @($VMName, $formattedMacAddress) -ErrorAction Stop
+
+            $currentVlanConfiguration = Invoke-SdnCommand -ComputerName $HyperVHost -Credential $Credential -ScriptBlock {
+                param($vmName, $macAddress)
+
+                return (Get-SdnVMNetworkAdapter -VMName $vmName -MacAddress $macAddress | Get-VMNetworkAdapterVlan)
             } -ArgumentList @($VMName, $formattedMacAddress) -ErrorAction Stop
         }
         if ($null -ieq $currentPortProfileSettings) {
@@ -3598,11 +3609,50 @@ function Repair-SdnVMNetworkAdapterPortProfile {
             $repairRequired = $true
         }
 
+        # VLAN configured directly on the VM network adapter conflicts with the isolation settings that VFP
+        # programs once the port profile has been applied, so any VLAN configuration must be removed.
+        # Get-VMNetworkAdapterVlan always returns an object for an adapter, so we determine whether a VLAN is
+        # actually configured based on the OperationMode being something other than Untagged.
+        foreach ($vlanConfiguration in $currentVlanConfiguration) {
+            if ($null -eq $vlanConfiguration) {
+                continue
+            }
+
+            if ($vlanConfiguration.OperationMode -ine 'Untagged') {
+                $vlanDetails = switch ($vlanConfiguration.OperationMode) {
+                    'Access' { "AccessVlanId [{0}]" -f $vlanConfiguration.AccessVlanId }
+                    'Trunk' { "NativeVlanId [{0}] AllowedVlanIdList [{1}]" -f $vlanConfiguration.NativeVlanId, ($vlanConfiguration.AllowedVlanIdList -join ',') }
+                    default { "PrimaryVlanId [{0}] SecondaryVlanId [{1}]" -f $vlanConfiguration.PrimaryVlanId, $vlanConfiguration.SecondaryVlanId }
+                }
+
+                "Detected VLAN OperationMode [{0}] {1} on VM {2} with MAC Address {3}, which conflicts with the isolation settings leveraged by VFP." `
+                    -f $vlanConfiguration.OperationMode, $vlanDetails, $VMName, $formattedMacAddress | Trace-Output -Level:Warning
+                $vlanRepairRequired = $true
+            }
+        }
+
+        # remove the VLAN configuration before applying the port profile, to ensure the conflicting
+        # configuration is cleared prior to VFP programming the isolation settings
+        if ($vlanRepairRequired) {
+            "Removing VLAN configuration from VM $VMName with MAC Address $formattedMacAddress." | Trace-Output
+            if ($isLocalHost) {
+                Get-SdnVMNetworkAdapter -VMName $VMName -MacAddress $formattedMacAddress -ErrorAction Stop | Set-VMNetworkAdapterVlan -Untagged -ErrorAction Stop
+            }
+            else {
+                Invoke-SdnCommand -ComputerName $HyperVHost -Credential $Credential -ScriptBlock {
+                    param($vmName, $macAddress)
+
+                    Get-SdnVMNetworkAdapter -VMName $vmName -MacAddress $macAddress | Set-VMNetworkAdapterVlan -Untagged
+                } -ArgumentList @($VMName, $formattedMacAddress) -ErrorAction Stop
+            }
+        }
+
         if ($repairRequired) {
             "Repairing Port Profile for VM $VMName with MAC Address $formattedMacAddress." | Trace-Output
             Set-SdnVMNetworkAdapterPortProfile @repairPortProfileParams
         }
-        else {
+
+        if (-NOT $repairRequired -and -NOT $vlanRepairRequired) {
             "Port Profile for VM $VMName with MAC Address $formattedMacAddress is already in the correct state." | Trace-Output -Level:Information
         }
     }

--- a/src/modules/SdnDiag.Server.psm1
+++ b/src/modules/SdnDiag.Server.psm1
@@ -3581,14 +3581,14 @@ function Repair-SdnVMNetworkAdapterPortProfile {
             $currentPortProfileSettings = Invoke-SdnCommand -ComputerName $HyperVHost -Credential $Credential -ScriptBlock {
                 param($vmName, $macAddress)
 
-                $vmNetworkAdapters = Get-SdnVMNetworkAdapterPortProfile -VMName $vmName
+                $vmNetworkAdapters = Get-SdnVMNetworkAdapterPortProfile -VMName $vmName -ErrorAction Stop
                 return ($vmNetworkAdapters | Where-Object {$_.MacAddress -eq $macAddress})
             } -ArgumentList @($VMName, $formattedMacAddress) -ErrorAction Stop
 
             $currentVlanConfiguration = Invoke-SdnCommand -ComputerName $HyperVHost -Credential $Credential -ScriptBlock {
                 param($vmName, $macAddress)
 
-                return (Get-SdnVMNetworkAdapter -VMName $vmName -MacAddress $macAddress | Get-VMNetworkAdapterVlan)
+                return (Get-SdnVMNetworkAdapter -VMName $vmName -MacAddress $macAddress -ErrorAction Stop | Get-VMNetworkAdapterVlan -ErrorAction Stop)
             } -ArgumentList @($VMName, $formattedMacAddress) -ErrorAction Stop
         }
         if ($null -ieq $currentPortProfileSettings) {
@@ -3670,7 +3670,7 @@ function Repair-SdnVMNetworkAdapterPortProfile {
                 Invoke-SdnCommand -ComputerName $HyperVHost -Credential $Credential -ScriptBlock {
                     param($vmName, $macAddress)
 
-                    Get-SdnVMNetworkAdapter -VMName $vmName -MacAddress $macAddress | Set-VMNetworkAdapterVlan -Untagged
+                    Get-SdnVMNetworkAdapter -VMName $vmName -MacAddress $macAddress -ErrorAction Stop | Set-VMNetworkAdapterVlan -Untagged -ErrorAction Stop
                 } -ArgumentList @($VMName, $formattedMacAddress) -ErrorAction Stop
             }
         }

--- a/tests/offline/Server.Tests.ps1
+++ b/tests/offline/Server.Tests.ps1
@@ -1,0 +1,268 @@
+Describe 'Server - Repair-SdnVMNetworkAdapterPortProfile' {
+
+    BeforeAll {
+        # network interface returned from Network Controller that the VM network adapter should be aligned to.
+        # instanceId is a valid GUID so that it can be compared against the profileId returned from the hypervisor.
+        $Global:PesterOfflineTests.RepairPortProfile = @{
+            InstanceId = '11111111-2222-3333-4444-555555555555'
+            MacAddress = '001DD8070001'
+            NcUri      = 'https://dvlab-nc.dvlab.contoso.local'
+            HyperVHost = 'DVLAB-S1-N01'
+            VMName     = 'DVLAB-VM01'
+        }
+    }
+
+    It "Removes the VLAN configuration when the VM network adapter is configured with an access VLAN" {
+        InModuleScope SdnDiag.Server {
+            $testData = $Global:PesterOfflineTests.RepairPortProfile
+
+            Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith {
+                return [PSCustomObject]@{
+                    resourceRef = '/networkInterfaces/DVLAB-VM01-NIC01'
+                    instanceId  = $Global:PesterOfflineTests.RepairPortProfile.InstanceId
+                    properties  = [PSCustomObject]@{
+                        privateMacAddress = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                        ipConfigurations  = @(
+                            [PSCustomObject]@{
+                                properties = [PSCustomObject]@{
+                                    privateIPAllocationMethod = 'Static'
+                                    subnet                    = [PSCustomObject]@{ resourceRef = '/virtualNetworks/vnet-0001/subnets/subnet-0001' }
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+
+            Mock Test-ComputerNameIsLocal { return $false }
+            Mock Set-SdnVMNetworkAdapterPortProfile { }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
+                return [PSCustomObject]@{
+                    VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                    MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                    ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
+                    ProfileData = 1
+                }
+            }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
+                return [PSCustomObject]@{
+                    OperationMode = 'Access'
+                    AccessVlanId  = 101
+                }
+            }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
+
+            Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
+                -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost -WarningAction SilentlyContinue
+
+            Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 1 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
+        }
+    }
+
+    It "Removes the VLAN configuration when the VM network adapter is configured in trunk mode" {
+        InModuleScope SdnDiag.Server {
+            $testData = $Global:PesterOfflineTests.RepairPortProfile
+
+            Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith {
+                return [PSCustomObject]@{
+                    resourceRef = '/networkInterfaces/DVLAB-VM01-NIC01'
+                    instanceId  = $Global:PesterOfflineTests.RepairPortProfile.InstanceId
+                    properties  = [PSCustomObject]@{
+                        privateMacAddress = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                        ipConfigurations  = @(
+                            [PSCustomObject]@{
+                                properties = [PSCustomObject]@{
+                                    privateIPAllocationMethod = 'Static'
+                                    subnet                    = [PSCustomObject]@{ resourceRef = '/virtualNetworks/vnet-0001/subnets/subnet-0001' }
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+
+            Mock Test-ComputerNameIsLocal { return $false }
+            Mock Set-SdnVMNetworkAdapterPortProfile { }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
+                return [PSCustomObject]@{
+                    VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                    MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                    ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
+                    ProfileData = 1
+                }
+            }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
+                return [PSCustomObject]@{
+                    OperationMode     = 'Trunk'
+                    NativeVlanId      = 0
+                    AllowedVlanIdList = '1-100'
+                }
+            }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
+
+            Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
+                -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost -WarningAction SilentlyContinue
+
+            Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 1 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
+        }
+    }
+
+    It "Does not modify the VLAN configuration when the VM network adapter is untagged" {
+        InModuleScope SdnDiag.Server {
+            $testData = $Global:PesterOfflineTests.RepairPortProfile
+
+            Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith {
+                return [PSCustomObject]@{
+                    resourceRef = '/networkInterfaces/DVLAB-VM01-NIC01'
+                    instanceId  = $Global:PesterOfflineTests.RepairPortProfile.InstanceId
+                    properties  = [PSCustomObject]@{
+                        privateMacAddress = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                        ipConfigurations  = @(
+                            [PSCustomObject]@{
+                                properties = [PSCustomObject]@{
+                                    privateIPAllocationMethod = 'Static'
+                                    subnet                    = [PSCustomObject]@{ resourceRef = '/virtualNetworks/vnet-0001/subnets/subnet-0001' }
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+
+            Mock Test-ComputerNameIsLocal { return $false }
+            Mock Set-SdnVMNetworkAdapterPortProfile { }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
+                return [PSCustomObject]@{
+                    VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                    MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                    ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
+                    ProfileData = 1
+                }
+            }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
+                return [PSCustomObject]@{
+                    OperationMode = 'Untagged'
+                    AccessVlanId  = 0
+                }
+            }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
+
+            Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
+                -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost
+
+            Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 0 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
+            Should -Invoke -CommandName Set-SdnVMNetworkAdapterPortProfile -Exactly -Times 0
+        }
+    }
+
+    It "Repairs the port profile when the profile data does not match and the adapter is untagged" {
+        InModuleScope SdnDiag.Server {
+            $testData = $Global:PesterOfflineTests.RepairPortProfile
+
+            Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith {
+                return [PSCustomObject]@{
+                    resourceRef = '/networkInterfaces/DVLAB-VM01-NIC01'
+                    instanceId  = $Global:PesterOfflineTests.RepairPortProfile.InstanceId
+                    properties  = [PSCustomObject]@{
+                        privateMacAddress = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                        ipConfigurations  = @(
+                            [PSCustomObject]@{
+                                properties = [PSCustomObject]@{
+                                    privateIPAllocationMethod = 'Static'
+                                    subnet                    = [PSCustomObject]@{ resourceRef = '/virtualNetworks/vnet-0001/subnets/subnet-0001' }
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+
+            Mock Test-ComputerNameIsLocal { return $false }
+            Mock Set-SdnVMNetworkAdapterPortProfile { }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
+                return [PSCustomObject]@{
+                    VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                    MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                    ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
+                    ProfileData = 2
+                }
+            }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
+                return [PSCustomObject]@{
+                    OperationMode = 'Untagged'
+                    AccessVlanId  = 0
+                }
+            }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
+
+            Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
+                -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost
+
+            Should -Invoke -CommandName Set-SdnVMNetworkAdapterPortProfile -Exactly -Times 1
+            Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 0 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
+        }
+    }
+
+    It "Removes the VLAN configuration and repairs the port profile when both are misconfigured" {
+        InModuleScope SdnDiag.Server {
+            $testData = $Global:PesterOfflineTests.RepairPortProfile
+
+            Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith {
+                return [PSCustomObject]@{
+                    resourceRef = '/networkInterfaces/DVLAB-VM01-NIC01'
+                    instanceId  = $Global:PesterOfflineTests.RepairPortProfile.InstanceId
+                    properties  = [PSCustomObject]@{
+                        privateMacAddress = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                        ipConfigurations  = @(
+                            [PSCustomObject]@{
+                                properties = [PSCustomObject]@{
+                                    privateIPAllocationMethod = 'Static'
+                                    subnet                    = [PSCustomObject]@{ resourceRef = '/virtualNetworks/vnet-0001/subnets/subnet-0001' }
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+
+            Mock Test-ComputerNameIsLocal { return $false }
+            Mock Set-SdnVMNetworkAdapterPortProfile { }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
+                return [PSCustomObject]@{
+                    VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                    MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                    ProfileId   = '{00000000-0000-0000-0000-000000000000}'
+                    ProfileData = 2
+                }
+            }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
+                return [PSCustomObject]@{
+                    OperationMode = 'Access'
+                    AccessVlanId  = 200
+                }
+            }
+
+            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
+
+            Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
+                -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost -WarningAction SilentlyContinue
+
+            Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 1 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
+            Should -Invoke -CommandName Set-SdnVMNetworkAdapterPortProfile -Exactly -Times 1
+        }
+    }
+}

--- a/tests/offline/Server.Tests.ps1
+++ b/tests/offline/Server.Tests.ps1
@@ -1,268 +1,317 @@
 Describe 'Server - Repair-SdnVMNetworkAdapterPortProfile' {
 
     BeforeAll {
+        # the Hyper-V PowerShell module is not guaranteed to be present on the machine running the offline tests,
+        # so we define test-only stubs for the Hyper-V cmdlets used by the local host code path. these are defined
+        # in the global scope so that the mocks Pester injects into the SdnDiag.Server module scope take precedence.
+        function global:Get-VMNetworkAdapterVlan {
+            [CmdletBinding()]
+            param (
+                [Parameter(ValueFromPipeline = $true)]
+                $VMNetworkAdapter
+            )
+        }
+
+        function global:Set-VMNetworkAdapterVlan {
+            [CmdletBinding()]
+            param (
+                [Parameter(ValueFromPipeline = $true)]
+                $VMNetworkAdapter,
+
+                [Parameter(Mandatory = $false)]
+                [switch]$Untagged
+            )
+        }
+
         # network interface returned from Network Controller that the VM network adapter should be aligned to.
         # instanceId is a valid GUID so that it can be compared against the profileId returned from the hypervisor.
         $Global:PesterOfflineTests.RepairPortProfile = @{
-            InstanceId = '11111111-2222-3333-4444-555555555555'
-            MacAddress = '001DD8070001'
-            NcUri      = 'https://dvlab-nc.dvlab.contoso.local'
-            HyperVHost = 'DVLAB-S1-N01'
-            VMName     = 'DVLAB-VM01'
+            InstanceId       = '11111111-2222-3333-4444-555555555555'
+            MacAddress       = '001DD8070001'
+            NcUri            = 'https://dvlab-nc.dvlab.contoso.local'
+            HyperVHost       = 'DVLAB-S1-N01'
+            VMName           = 'DVLAB-VM01'
+            NetworkInterface = [PSCustomObject]@{
+                resourceRef = '/networkInterfaces/DVLAB-VM01-NIC01'
+                instanceId  = '11111111-2222-3333-4444-555555555555'
+                properties  = [PSCustomObject]@{
+                    privateMacAddress = '001DD8070001'
+                    ipConfigurations  = @(
+                        [PSCustomObject]@{
+                            properties = [PSCustomObject]@{
+                                privateIPAllocationMethod = 'Static'
+                                subnet                    = [PSCustomObject]@{ resourceRef = '/virtualNetworks/vnet-0001/subnets/subnet-0001' }
+                            }
+                        }
+                    )
+                }
+            }
         }
     }
 
-    It "Removes the VLAN configuration when the VM network adapter is configured with an access VLAN" {
-        InModuleScope SdnDiag.Server {
-            $testData = $Global:PesterOfflineTests.RepairPortProfile
+    AfterAll {
+        Remove-Item -Path 'function:\global:Get-VMNetworkAdapterVlan' -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path 'function:\global:Set-VMNetworkAdapterVlan' -Force -ErrorAction SilentlyContinue
+    }
 
-            Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith {
-                return [PSCustomObject]@{
-                    resourceRef = '/networkInterfaces/DVLAB-VM01-NIC01'
-                    instanceId  = $Global:PesterOfflineTests.RepairPortProfile.InstanceId
-                    properties  = [PSCustomObject]@{
-                        privateMacAddress = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
-                        ipConfigurations  = @(
-                            [PSCustomObject]@{
-                                properties = [PSCustomObject]@{
-                                    privateIPAllocationMethod = 'Static'
-                                    subnet                    = [PSCustomObject]@{ resourceRef = '/virtualNetworks/vnet-0001/subnets/subnet-0001' }
-                                }
-                            }
-                        )
+    Context 'Remote Hyper-V host' {
+
+        It "Removes the VLAN configuration when the VM network adapter is configured with an access VLAN" {
+            InModuleScope SdnDiag.Server {
+                $testData = $Global:PesterOfflineTests.RepairPortProfile
+
+                Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith { return $Global:PesterOfflineTests.RepairPortProfile.NetworkInterface }
+                Mock Test-ComputerNameIsLocal { return $false }
+                Mock Set-SdnVMNetworkAdapterPortProfile { }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
+                    return [PSCustomObject]@{
+                        VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                        MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                        ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
+                        ProfileData = 1
                     }
                 }
-            }
 
-            Mock Test-ComputerNameIsLocal { return $false }
-            Mock Set-SdnVMNetworkAdapterPortProfile { }
-
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
-                return [PSCustomObject]@{
-                    VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
-                    MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
-                    ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
-                    ProfileData = 1
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
+                    return [PSCustomObject]@{
+                        OperationMode = 'Access'
+                        AccessVlanId  = 101
+                    }
                 }
-            }
 
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
-                return [PSCustomObject]@{
-                    OperationMode = 'Access'
-                    AccessVlanId  = 101
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
+
+                Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
+                    -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost -WarningAction SilentlyContinue
+
+                Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 1 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
+            }
+        }
+
+        It "Removes the VLAN configuration when the VM network adapter is configured in trunk mode" {
+            InModuleScope SdnDiag.Server {
+                $testData = $Global:PesterOfflineTests.RepairPortProfile
+
+                Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith { return $Global:PesterOfflineTests.RepairPortProfile.NetworkInterface }
+                Mock Test-ComputerNameIsLocal { return $false }
+                Mock Set-SdnVMNetworkAdapterPortProfile { }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
+                    return [PSCustomObject]@{
+                        VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                        MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                        ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
+                        ProfileData = 1
+                    }
                 }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
+                    return [PSCustomObject]@{
+                        OperationMode     = 'Trunk'
+                        NativeVlanId      = 0
+                        AllowedVlanIdList = '1-100'
+                    }
+                }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
+
+                Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
+                    -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost -WarningAction SilentlyContinue
+
+                Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 1 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
             }
+        }
 
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
+        It "Does not modify the VLAN configuration when the VM network adapter is untagged" {
+            InModuleScope SdnDiag.Server {
+                $testData = $Global:PesterOfflineTests.RepairPortProfile
 
-            Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
-                -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost -WarningAction SilentlyContinue
+                Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith { return $Global:PesterOfflineTests.RepairPortProfile.NetworkInterface }
+                Mock Test-ComputerNameIsLocal { return $false }
+                Mock Set-SdnVMNetworkAdapterPortProfile { }
 
-            Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 1 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
+                    return [PSCustomObject]@{
+                        VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                        MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                        ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
+                        ProfileData = 1
+                    }
+                }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
+                    return [PSCustomObject]@{
+                        OperationMode = 'Untagged'
+                        AccessVlanId  = 0
+                    }
+                }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
+
+                Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
+                    -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost
+
+                Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 0 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
+                Should -Invoke -CommandName Set-SdnVMNetworkAdapterPortProfile -Exactly -Times 0
+            }
+        }
+
+        It "Repairs the port profile when the profile data does not match and the adapter is untagged" {
+            InModuleScope SdnDiag.Server {
+                $testData = $Global:PesterOfflineTests.RepairPortProfile
+
+                Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith { return $Global:PesterOfflineTests.RepairPortProfile.NetworkInterface }
+                Mock Test-ComputerNameIsLocal { return $false }
+                Mock Set-SdnVMNetworkAdapterPortProfile { }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
+                    return [PSCustomObject]@{
+                        VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                        MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                        ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
+                        ProfileData = 2
+                    }
+                }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
+                    return [PSCustomObject]@{
+                        OperationMode = 'Untagged'
+                        AccessVlanId  = 0
+                    }
+                }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
+
+                Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
+                    -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost
+
+                Should -Invoke -CommandName Set-SdnVMNetworkAdapterPortProfile -Exactly -Times 1
+                Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 0 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
+            }
+        }
+
+        It "Removes the VLAN configuration and repairs the port profile when both are misconfigured" {
+            InModuleScope SdnDiag.Server {
+                $testData = $Global:PesterOfflineTests.RepairPortProfile
+
+                Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith { return $Global:PesterOfflineTests.RepairPortProfile.NetworkInterface }
+                Mock Test-ComputerNameIsLocal { return $false }
+                Mock Set-SdnVMNetworkAdapterPortProfile { }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
+                    return [PSCustomObject]@{
+                        VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                        MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                        ProfileId   = '{00000000-0000-0000-0000-000000000000}'
+                        ProfileData = 2
+                    }
+                }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
+                    return [PSCustomObject]@{
+                        OperationMode = 'Access'
+                        AccessVlanId  = 200
+                    }
+                }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
+
+                Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
+                    -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost -WarningAction SilentlyContinue
+
+                Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 1 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
+                Should -Invoke -CommandName Set-SdnVMNetworkAdapterPortProfile -Exactly -Times 1
+            }
         }
     }
 
-    It "Removes the VLAN configuration when the VM network adapter is configured in trunk mode" {
-        InModuleScope SdnDiag.Server {
-            $testData = $Global:PesterOfflineTests.RepairPortProfile
+    Context 'Local Hyper-V host' {
 
-            Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith {
-                return [PSCustomObject]@{
-                    resourceRef = '/networkInterfaces/DVLAB-VM01-NIC01'
-                    instanceId  = $Global:PesterOfflineTests.RepairPortProfile.InstanceId
-                    properties  = [PSCustomObject]@{
-                        privateMacAddress = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
-                        ipConfigurations  = @(
-                            [PSCustomObject]@{
-                                properties = [PSCustomObject]@{
-                                    privateIPAllocationMethod = 'Static'
-                                    subnet                    = [PSCustomObject]@{ resourceRef = '/virtualNetworks/vnet-0001/subnets/subnet-0001' }
-                                }
-                            }
-                        )
+        It "Removes the VLAN configuration when the VM network adapter is configured with an access VLAN" {
+            InModuleScope SdnDiag.Server {
+                $testData = $Global:PesterOfflineTests.RepairPortProfile
+
+                Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith { return $Global:PesterOfflineTests.RepairPortProfile.NetworkInterface }
+                Mock Test-ComputerNameIsLocal { return $true }
+                Mock Set-SdnVMNetworkAdapterPortProfile { }
+                Mock Invoke-SdnCommand { }
+
+                Mock Get-SdnVMNetworkAdapterPortProfile {
+                    return [PSCustomObject]@{
+                        VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                        MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                        ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
+                        ProfileData = 1
                     }
                 }
-            }
 
-            Mock Test-ComputerNameIsLocal { return $false }
-            Mock Set-SdnVMNetworkAdapterPortProfile { }
-
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
-                return [PSCustomObject]@{
-                    VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
-                    MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
-                    ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
-                    ProfileData = 1
+                Mock Get-SdnVMNetworkAdapter {
+                    return [PSCustomObject]@{
+                        Name       = 'Network Adapter'
+                        VMName     = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                        MacAddress = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                    }
                 }
-            }
 
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
-                return [PSCustomObject]@{
-                    OperationMode     = 'Trunk'
-                    NativeVlanId      = 0
-                    AllowedVlanIdList = '1-100'
+                Mock Get-VMNetworkAdapterVlan {
+                    return [PSCustomObject]@{
+                        OperationMode = 'Access'
+                        AccessVlanId  = 101
+                    }
                 }
+
+                Mock Set-VMNetworkAdapterVlan { }
+
+                Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
+                    -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost -WarningAction SilentlyContinue
+
+                Should -Invoke -CommandName Set-VMNetworkAdapterVlan -Exactly -Times 1 -ParameterFilter { $Untagged -eq $true }
+                Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 0
             }
-
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
-
-            Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
-                -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost -WarningAction SilentlyContinue
-
-            Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 1 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
         }
-    }
 
-    It "Does not modify the VLAN configuration when the VM network adapter is untagged" {
-        InModuleScope SdnDiag.Server {
-            $testData = $Global:PesterOfflineTests.RepairPortProfile
+        It "Does not modify the VLAN configuration when the VM network adapter is untagged" {
+            InModuleScope SdnDiag.Server {
+                $testData = $Global:PesterOfflineTests.RepairPortProfile
 
-            Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith {
-                return [PSCustomObject]@{
-                    resourceRef = '/networkInterfaces/DVLAB-VM01-NIC01'
-                    instanceId  = $Global:PesterOfflineTests.RepairPortProfile.InstanceId
-                    properties  = [PSCustomObject]@{
-                        privateMacAddress = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
-                        ipConfigurations  = @(
-                            [PSCustomObject]@{
-                                properties = [PSCustomObject]@{
-                                    privateIPAllocationMethod = 'Static'
-                                    subnet                    = [PSCustomObject]@{ resourceRef = '/virtualNetworks/vnet-0001/subnets/subnet-0001' }
-                                }
-                            }
-                        )
+                Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith { return $Global:PesterOfflineTests.RepairPortProfile.NetworkInterface }
+                Mock Test-ComputerNameIsLocal { return $true }
+                Mock Set-SdnVMNetworkAdapterPortProfile { }
+                Mock Invoke-SdnCommand { }
+
+                Mock Get-SdnVMNetworkAdapterPortProfile {
+                    return [PSCustomObject]@{
+                        VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                        MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                        ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
+                        ProfileData = 1
                     }
                 }
-            }
 
-            Mock Test-ComputerNameIsLocal { return $false }
-            Mock Set-SdnVMNetworkAdapterPortProfile { }
-
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
-                return [PSCustomObject]@{
-                    VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
-                    MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
-                    ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
-                    ProfileData = 1
-                }
-            }
-
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
-                return [PSCustomObject]@{
-                    OperationMode = 'Untagged'
-                    AccessVlanId  = 0
-                }
-            }
-
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
-
-            Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
-                -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost
-
-            Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 0 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
-            Should -Invoke -CommandName Set-SdnVMNetworkAdapterPortProfile -Exactly -Times 0
-        }
-    }
-
-    It "Repairs the port profile when the profile data does not match and the adapter is untagged" {
-        InModuleScope SdnDiag.Server {
-            $testData = $Global:PesterOfflineTests.RepairPortProfile
-
-            Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith {
-                return [PSCustomObject]@{
-                    resourceRef = '/networkInterfaces/DVLAB-VM01-NIC01'
-                    instanceId  = $Global:PesterOfflineTests.RepairPortProfile.InstanceId
-                    properties  = [PSCustomObject]@{
-                        privateMacAddress = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
-                        ipConfigurations  = @(
-                            [PSCustomObject]@{
-                                properties = [PSCustomObject]@{
-                                    privateIPAllocationMethod = 'Static'
-                                    subnet                    = [PSCustomObject]@{ resourceRef = '/virtualNetworks/vnet-0001/subnets/subnet-0001' }
-                                }
-                            }
-                        )
+                Mock Get-SdnVMNetworkAdapter {
+                    return [PSCustomObject]@{
+                        Name       = 'Network Adapter'
+                        VMName     = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                        MacAddress = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
                     }
                 }
-            }
 
-            Mock Test-ComputerNameIsLocal { return $false }
-            Mock Set-SdnVMNetworkAdapterPortProfile { }
-
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
-                return [PSCustomObject]@{
-                    VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
-                    MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
-                    ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
-                    ProfileData = 2
-                }
-            }
-
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
-                return [PSCustomObject]@{
-                    OperationMode = 'Untagged'
-                    AccessVlanId  = 0
-                }
-            }
-
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
-
-            Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
-                -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost
-
-            Should -Invoke -CommandName Set-SdnVMNetworkAdapterPortProfile -Exactly -Times 1
-            Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 0 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
-        }
-    }
-
-    It "Removes the VLAN configuration and repairs the port profile when both are misconfigured" {
-        InModuleScope SdnDiag.Server {
-            $testData = $Global:PesterOfflineTests.RepairPortProfile
-
-            Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith {
-                return [PSCustomObject]@{
-                    resourceRef = '/networkInterfaces/DVLAB-VM01-NIC01'
-                    instanceId  = $Global:PesterOfflineTests.RepairPortProfile.InstanceId
-                    properties  = [PSCustomObject]@{
-                        privateMacAddress = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
-                        ipConfigurations  = @(
-                            [PSCustomObject]@{
-                                properties = [PSCustomObject]@{
-                                    privateIPAllocationMethod = 'Static'
-                                    subnet                    = [PSCustomObject]@{ resourceRef = '/virtualNetworks/vnet-0001/subnets/subnet-0001' }
-                                }
-                            }
-                        )
+                Mock Get-VMNetworkAdapterVlan {
+                    return [PSCustomObject]@{
+                        OperationMode = 'Untagged'
+                        AccessVlanId  = 0
                     }
                 }
+
+                Mock Set-VMNetworkAdapterVlan { }
+
+                Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
+                    -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost
+
+                Should -Invoke -CommandName Set-VMNetworkAdapterVlan -Exactly -Times 0
+                Should -Invoke -CommandName Set-SdnVMNetworkAdapterPortProfile -Exactly -Times 0
             }
-
-            Mock Test-ComputerNameIsLocal { return $false }
-            Mock Set-SdnVMNetworkAdapterPortProfile { }
-
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
-                return [PSCustomObject]@{
-                    VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
-                    MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
-                    ProfileId   = '{00000000-0000-0000-0000-000000000000}'
-                    ProfileData = 2
-                }
-            }
-
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
-                return [PSCustomObject]@{
-                    OperationMode = 'Access'
-                    AccessVlanId  = 200
-                }
-            }
-
-            Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
-
-            Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
-                -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost -WarningAction SilentlyContinue
-
-            Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 1 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
-            Should -Invoke -CommandName Set-SdnVMNetworkAdapterPortProfile -Exactly -Times 1
         }
     }
 }

--- a/tests/offline/Server.Tests.ps1
+++ b/tests/offline/Server.Tests.ps1
@@ -2,6 +2,37 @@ Describe 'Server - Repair-SdnVMNetworkAdapterPortProfile' {
 
     BeforeAll {
         # the Hyper-V PowerShell module is not guaranteed to be present on the machine running the offline tests,
+        # so we define stand-in enums that mirror Microsoft.HyperV.PowerShell.VMNetworkAdapterVlanMode and
+        # Microsoft.HyperV.PowerShell.VMNetworkAdapterPrivateVlanMode. these are added to the AppDomain so that
+        # they resolve from within the SdnDiag.Server module scope where the tests execute.
+        if (-NOT ('SdnDiagnostics.PesterOffline.VMNetworkAdapterVlanMode' -as [type])) {
+            Add-Type -TypeDefinition @'
+namespace SdnDiagnostics.PesterOffline {
+    public enum VMNetworkAdapterVlanMode { Untagged = 0, Access = 1, Trunk = 2, Private = 3 }
+    public enum VMNetworkAdapterPrivateVlanMode { Isolated = 1, Community = 2, Promiscuous = 3 }
+}
+'@
+        }
+
+        # objects returned from a remote session are serialized and rehydrated by PSRemoting, which causes enum
+        # properties such as OperationMode and PrivateVlanMode to be deserialized as their underlying integer
+        # value rather than the enum itself. this helper round trips a mock object through the same serializer
+        # that Invoke-Command uses, so that the remote host tests exercise the exact shape the function receives.
+        function global:ConvertTo-PesterRemoteObject {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+                $InputObject
+            )
+
+            process {
+                return [System.Management.Automation.PSSerializer]::Deserialize(
+                    [System.Management.Automation.PSSerializer]::Serialize($InputObject, 1)
+                )
+            }
+        }
+
+        # the Hyper-V PowerShell module is not guaranteed to be present on the machine running the offline tests,
         # so we define test-only stubs for the Hyper-V cmdlets used by the local host code path. these are defined
         # in the global scope so that the mocks Pester injects into the SdnDiag.Server module scope take precedence.
         function global:Get-VMNetworkAdapterVlan {
@@ -52,6 +83,7 @@ Describe 'Server - Repair-SdnVMNetworkAdapterPortProfile' {
     AfterAll {
         Remove-Item -Path 'function:\global:Get-VMNetworkAdapterVlan' -Force -ErrorAction SilentlyContinue
         Remove-Item -Path 'function:\global:Set-VMNetworkAdapterVlan' -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path 'function:\global:ConvertTo-PesterRemoteObject' -Force -ErrorAction SilentlyContinue
     }
 
     Context 'Remote Hyper-V host' {
@@ -74,10 +106,10 @@ Describe 'Server - Repair-SdnVMNetworkAdapterPortProfile' {
                 }
 
                 Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
-                    return [PSCustomObject]@{
-                        OperationMode = 'Access'
+                    return ([PSCustomObject]@{
+                        OperationMode = [SdnDiagnostics.PesterOffline.VMNetworkAdapterVlanMode]::Access
                         AccessVlanId  = 101
-                    }
+                    } | ConvertTo-PesterRemoteObject)
                 }
 
                 Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
@@ -107,11 +139,89 @@ Describe 'Server - Repair-SdnVMNetworkAdapterPortProfile' {
                 }
 
                 Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
+                    return ([PSCustomObject]@{
+                        OperationMode           = [SdnDiagnostics.PesterOffline.VMNetworkAdapterVlanMode]::Trunk
+                        NativeVlanId            = 0
+                        AllowedVlanIdList       = @(1..100)
+                        AllowedVlanIdListString = '1-100'
+                    } | ConvertTo-PesterRemoteObject)
+                }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
+
+                Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
+                    -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost -WarningAction SilentlyContinue
+
+                Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 1 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
+            }
+        }
+
+        It "Removes the VLAN configuration when the VM network adapter is configured in private VLAN promiscuous mode" {
+            InModuleScope SdnDiag.Server {
+                $testData = $Global:PesterOfflineTests.RepairPortProfile
+
+                Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith { return $Global:PesterOfflineTests.RepairPortProfile.NetworkInterface }
+                Mock Test-ComputerNameIsLocal { return $false }
+                Mock Set-SdnVMNetworkAdapterPortProfile { }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
                     return [PSCustomObject]@{
-                        OperationMode     = 'Trunk'
-                        NativeVlanId      = 0
-                        AllowedVlanIdList = '1-100'
+                        VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                        MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                        ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
+                        ProfileData = 1
                     }
+                }
+
+                # when PrivateVlanMode is Promiscuous, SecondaryVlanId is not populated and the configured VLANs
+                # are exposed via SecondaryVlanIdList / SecondaryVlanIdListString instead.
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
+                    return ([PSCustomObject]@{
+                        OperationMode             = [SdnDiagnostics.PesterOffline.VMNetworkAdapterVlanMode]::Private
+                        PrivateVlanMode           = [SdnDiagnostics.PesterOffline.VMNetworkAdapterPrivateVlanMode]::Promiscuous
+                        PrimaryVlanId             = 10
+                        SecondaryVlanId           = 0
+                        SecondaryVlanIdList       = @(11, 12)
+                        SecondaryVlanIdListString = '11-12'
+                    } | ConvertTo-PesterRemoteObject)
+                }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
+
+                Repair-SdnVMNetworkAdapterPortProfile -VMName $testData.VMName -MacAddress $testData.MacAddress `
+                    -NcUri $testData.NcUri -HyperVHost $testData.HyperVHost -WarningAction SilentlyContinue
+
+                Should -Invoke -CommandName Invoke-SdnCommand -Exactly -Times 1 -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' }
+            }
+        }
+
+        It "Removes the VLAN configuration when the VM network adapter is configured in private VLAN isolated mode" {
+            InModuleScope SdnDiag.Server {
+                $testData = $Global:PesterOfflineTests.RepairPortProfile
+
+                Mock Get-SdnResource -RemoveParameterType 'Resource' -MockWith { return $Global:PesterOfflineTests.RepairPortProfile.NetworkInterface }
+                Mock Test-ComputerNameIsLocal { return $false }
+                Mock Set-SdnVMNetworkAdapterPortProfile { }
+
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-SdnVMNetworkAdapterPortProfile' } -MockWith {
+                    return [PSCustomObject]@{
+                        VMName      = $Global:PesterOfflineTests.RepairPortProfile.VMName
+                        MacAddress  = $Global:PesterOfflineTests.RepairPortProfile.MacAddress
+                        ProfileId   = "{$($Global:PesterOfflineTests.RepairPortProfile.InstanceId)}"
+                        ProfileData = 1
+                    }
+                }
+
+                # when PrivateVlanMode is Isolated, SecondaryVlanId is populated and SecondaryVlanIdList is null.
+                Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
+                    return ([PSCustomObject]@{
+                        OperationMode             = [SdnDiagnostics.PesterOffline.VMNetworkAdapterVlanMode]::Private
+                        PrivateVlanMode           = [SdnDiagnostics.PesterOffline.VMNetworkAdapterPrivateVlanMode]::Isolated
+                        PrimaryVlanId             = 10
+                        SecondaryVlanId           = 11
+                        SecondaryVlanIdList       = $null
+                        SecondaryVlanIdListString = $null
+                    } | ConvertTo-PesterRemoteObject)
                 }
 
                 Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
@@ -141,10 +251,10 @@ Describe 'Server - Repair-SdnVMNetworkAdapterPortProfile' {
                 }
 
                 Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
-                    return [PSCustomObject]@{
-                        OperationMode = 'Untagged'
+                    return ([PSCustomObject]@{
+                        OperationMode = [SdnDiagnostics.PesterOffline.VMNetworkAdapterVlanMode]::Untagged
                         AccessVlanId  = 0
-                    }
+                    } | ConvertTo-PesterRemoteObject)
                 }
 
                 Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
@@ -175,10 +285,10 @@ Describe 'Server - Repair-SdnVMNetworkAdapterPortProfile' {
                 }
 
                 Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
-                    return [PSCustomObject]@{
-                        OperationMode = 'Untagged'
+                    return ([PSCustomObject]@{
+                        OperationMode = [SdnDiagnostics.PesterOffline.VMNetworkAdapterVlanMode]::Untagged
                         AccessVlanId  = 0
-                    }
+                    } | ConvertTo-PesterRemoteObject)
                 }
 
                 Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
@@ -209,10 +319,10 @@ Describe 'Server - Repair-SdnVMNetworkAdapterPortProfile' {
                 }
 
                 Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Get-VMNetworkAdapterVlan' } -MockWith {
-                    return [PSCustomObject]@{
-                        OperationMode = 'Access'
+                    return ([PSCustomObject]@{
+                        OperationMode = [SdnDiagnostics.PesterOffline.VMNetworkAdapterVlanMode]::Access
                         AccessVlanId  = 200
-                    }
+                    } | ConvertTo-PesterRemoteObject)
                 }
 
                 Mock Invoke-SdnCommand -ParameterFilter { $ScriptBlock.ToString() -match 'Set-VMNetworkAdapterVlan' } -MockWith { }
@@ -254,9 +364,11 @@ Describe 'Server - Repair-SdnVMNetworkAdapterPortProfile' {
                     }
                 }
 
+                # the local host code path receives the live object from Get-VMNetworkAdapterVlan, so the enum
+                # is returned as-is rather than being deserialized as its underlying integer value.
                 Mock Get-VMNetworkAdapterVlan {
                     return [PSCustomObject]@{
-                        OperationMode = 'Access'
+                        OperationMode = [SdnDiagnostics.PesterOffline.VMNetworkAdapterVlanMode]::Access
                         AccessVlanId  = 101
                     }
                 }
@@ -299,7 +411,7 @@ Describe 'Server - Repair-SdnVMNetworkAdapterPortProfile' {
 
                 Mock Get-VMNetworkAdapterVlan {
                     return [PSCustomObject]@{
-                        OperationMode = 'Untagged'
+                        OperationMode = [SdnDiagnostics.PesterOffline.VMNetworkAdapterVlanMode]::Untagged
                         AccessVlanId  = 0
                     }
                 }


### PR DESCRIPTION
# Description
VLAN configured directly on a VM network adapter conflicts with the isolation settings that VFP programs once the SDN port profile has been applied. `Repair-SdnVMNetworkAdapterPortProfile` previously fixed up the port profile but left any stale VLAN configuration in place, so the adapter could end up in a broken state even after a successful "repair".

Summary of changes:
- `Repair-SdnVMNetworkAdapterPortProfile` now retrieves the VM network adapter VLAN configuration alongside the port profile, honoring the existing local vs. remote Hyper-V host branching (the `Test-ComputerNameIsLocal` result is captured in `$isLocalHost` so it can be reused for the removal path).
- When VLAN configuration is detected, the adapter is reset with `Set-VMNetworkAdapterVlan -Untagged` **before** the port profile is applied, so the conflicting configuration is cleared prior to VFP programming the isolation settings.
- The "already in the correct state" message now only emits when neither the port profile nor the VLAN required repair.
- Adds `tests/offline/Server.Tests.ps1` with coverage for access VLAN, trunk mode, untagged (no-op), port-profile-only repair, and the combined repair path.

Worth calling out for review: `Get-VMNetworkAdapterVlan` always returns an object for a VM network adapter (`OperationMode = 'Untagged'` when nothing is configured), so a literal null check would fire on every adapter. The detection therefore keys off `OperationMode -ine 'Untagged'`. The warning message is mode-aware so trunk and isolated adapters report the relevant VLAN IDs instead of an empty `AccessVlanId`.

The new tests exercise the remote code path (`Test-ComputerNameIsLocal` mocked to `$false`) so the GitHub `windows-latest` runners do not need the Hyper-V PowerShell module for `Mock` resolution. The `Get-SdnResource` mock uses `-RemoveParameterType 'Resource'` because the `[SdnApiResource]` enum is defined in `SdnDiag.NetworkController` and is not resolvable from `SdnDiag.Server`'s scope.

# Change type
- [x] Bug fix (non-breaking change)
- [ ] Code style update (formatting, local variables)
- [ ] New Feature (non-breaking change that adds new functionality without impacting existing)
- [ ] Breaking change (fix or feature that may cause functionality impact)
- [ ] Other

# Checklist:
- [x] My code follows the style and contribution guidelines of this project.
- [x] I have tested and validated my code changes.

Validated with `.\build.ps1` followed by `tests\offline\RunTests.ps1`: 55/55 offline tests passing, including the 5 new cases.