### PR TITLE
Drop BGP learned routes from networkConnections PUT body

### DIFF
--- a/src/modules/SdnDiag.NetworkController.psm1
+++ b/src/modules/SdnDiag.NetworkController.psm1
@@ -669,6 +669,127 @@ function Invoke-SdnNetworkControllerStateDump {
     return $false
 }
 
+function Remove-BgpLearnedRoute {
+    <#
+    .SYNOPSIS
+        Returns a copy of the supplied resource with any BGP learned routes removed from the routes array.
+    .DESCRIPTION
+        The routes array of a networkConnections resource contains both the statically configured routes and the routes that have
+        been dynamically learned from the remote peer via BGP. The routes.protocol property is read-only and indicates how the route
+        was added. If a BGP learned route is included within the body of a PUT operation, Network Controller persists the route as a
+        static route, which then prevents the route from being withdrawn when the peer stops advertising it.
+
+        This function inspects the routes array of the resource, as well as the routes array of any networkConnections nested under
+        the resource, and removes any route where the protocol is reported as BGP. The object supplied by the caller is not modified.
+    .PARAMETER Object
+        The virtualGateways or networkConnections object to remove the BGP learned routes from.
+    .EXAMPLE
+        PS> $object = Get-SdnResource -NcUri $ncUri -ResourceRef '/virtualGateways/contoso-vgw01/networkConnections/contoso-nc01'
+        PS> $object = Remove-BgpLearnedRoute -Object $object
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [AllowNull()]
+        [System.Object]$Object
+    )
+
+    process {
+        if ($null -eq $Object) {
+            return $Object
+        }
+
+        $propertiesMember = $Object.PSObject.Properties['properties']
+        if ($null -eq $propertiesMember -or $null -eq $propertiesMember.Value) {
+            return $Object
+        }
+
+        $properties = $propertiesMember.Value
+        $updatedProperties = @{}
+
+        # remove any BGP learned routes that are declared directly on this resource
+        $routesMember = $properties.PSObject.Properties['routes']
+        if ($null -ne $routesMember) {
+            $staticRoutes = Select-StaticRoute -Route $routesMember.Value
+            if ($null -ne $staticRoutes) {
+                $updatedProperties['routes'] = $staticRoutes
+            }
+        }
+
+        # networkConnections are child resources of a virtualGateway and are returned inline when operating against the
+        # parent resource, so the routes array of each child connection needs to be processed as well
+        $connectionsMember = $properties.PSObject.Properties['networkConnections']
+        if ($null -ne $connectionsMember -and $null -ne $connectionsMember.Value) {
+            $updatedConnections = @()
+            $connectionUpdated = $false
+            foreach ($connection in @($connectionsMember.Value)) {
+                $updatedConnection = Remove-BgpLearnedRoute -Object $connection
+                if (-NOT [System.Object]::ReferenceEquals($updatedConnection, $connection)) {
+                    $connectionUpdated = $true
+                }
+
+                $updatedConnections += $updatedConnection
+            }
+
+            if ($connectionUpdated) {
+                $updatedProperties['networkConnections'] = $updatedConnections
+            }
+        }
+
+        # if nothing was removed, return the original object so the payload is left untouched
+        if ($updatedProperties.Count -eq 0) {
+            return $Object
+        }
+
+        $modifiedProperties = Copy-ObjectWithPropertyOverride -Object $properties -PropertyOverride $updatedProperties
+        return (Copy-ObjectWithPropertyOverride -Object $Object -PropertyOverride @{ 'properties' = $modifiedProperties })
+    }
+}
+
+function Select-StaticRoute {
+    <#
+    .SYNOPSIS
+        Removes any route that was learned via BGP from a routes array.
+    .DESCRIPTION
+        Returns $null when the array does not contain any BGP learned routes, which allows the caller to detect that no changes
+        are required and leave the original object untouched.
+    .PARAMETER Route
+        The routes array to filter.
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [System.Object]$Route
+    )
+
+    if ($null -eq $Route) {
+        return $null
+    }
+
+    $staticRoutes = @()
+    $bgpRouteCount = 0
+    foreach ($entry in @($Route)) {
+        if ($null -ne $entry -and $null -ne $entry.PSObject.Properties['protocol'] -and "$($entry.protocol)".Trim() -ieq 'bgp') {
+            $bgpRouteCount++
+            continue
+        }
+
+        $staticRoutes += $entry
+    }
+
+    if ($bgpRouteCount -eq 0) {
+        return $null
+    }
+
+    "Removed {0} BGP learned route(s) from the routes array" -f $bgpRouteCount | Trace-Output -Level:Verbose
+
+    # use the comma operator so an array is always returned, even when every route was learned via BGP
+    return ,$staticRoutes
+}
+
 function Test-NetworkControllerIsHealthy {
     try {
         $null = Get-NetworkController -ErrorAction 'Stop'
@@ -2837,7 +2958,17 @@ function Set-SdnResource {
                 }
             }
             default {
-                $modifiedObject = Remove-PropertiesFromObject -Object $Object -PropertiesToRemove @('ConfigurationState','ProvisioningState')
+                $objectToUpdate = $Object
+
+                # the routes array of a networkConnections resource contains both the statically configured routes and the routes
+                # that have been dynamically learned from the remote peer via BGP. routes.protocol is a read-only property, so if a
+                # BGP learned route is included within the PUT operation, network controller persists it as a static route.
+                # networkConnections are also returned inline when operating against the parent virtualGateways resource
+                if ($uri -imatch '/(virtualGateways|networkConnections)/') {
+                    $objectToUpdate = Remove-BgpLearnedRoute -Object $objectToUpdate
+                }
+
+                $modifiedObject = Remove-PropertiesFromObject -Object $objectToUpdate -PropertiesToRemove @('ConfigurationState','ProvisioningState')
                 $jsonBody = $modifiedObject | ConvertTo-Json -Depth 100
 
                 $putRestParams = $restParams.Clone()

--- a/src/modules/SdnDiag.Utilities.psm1
+++ b/src/modules/SdnDiag.Utilities.psm1
@@ -3124,6 +3124,50 @@ function Remove-PropertiesFromObject {
     }
 }
 
+function Copy-ObjectWithPropertyOverride {
+    <#
+    .SYNOPSIS
+        Creates a shallow copy of an object, replacing the value of the specified properties.
+    .DESCRIPTION
+        Used to avoid mutating an object supplied by the caller when only a subset of the properties need to be changed.
+        Property names are matched case-insensitively and the original property order is preserved.
+    .PARAMETER Object
+        The object to copy.
+    .PARAMETER PropertyOverride
+        A hashtable of property names and the values that should replace the value on the copied object. Property names
+        that do not exist on the object are ignored. An exception is raised when more than one key matches the same property.
+    .EXAMPLE
+        $object = Copy-ObjectWithPropertyOverride -Object $object -PropertyOverride @{ 'properties' = $modifiedProperties }
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        $Object,
+
+        [Parameter(Mandatory = $true)]
+        [System.Collections.Hashtable]$PropertyOverride
+    )
+
+    process {
+        $customObject = [PSCustomObject]@{}
+        foreach ($property in $Object.PSObject.Properties) {
+            $matchingKeys = @($PropertyOverride.Keys | Where-Object { $_ -ieq $property.Name })
+            if ($matchingKeys.Count -gt 1) {
+                throw New-Object System.ArgumentException("PropertyOverride contains multiple keys that match the property '$($property.Name)'.")
+            }
+
+            if ($matchingKeys.Count -eq 1) {
+                $customObject | Add-Member -MemberType NoteProperty -Name $property.Name -Value $PropertyOverride[$matchingKeys[0]]
+            }
+            else {
+                $customObject | Add-Member -MemberType NoteProperty -Name $property.Name -Value $property.Value
+            }
+        }
+
+        return $customObject
+    }
+}
+
 function Test-ComputerIsAccessible {
     <#
     .SYNOPSIS

--- a/tests/offline/NetworkController.Tests.ps1
+++ b/tests/offline/NetworkController.Tests.ps1
@@ -225,3 +225,274 @@ Describe 'NetworkController - Get-SdnNetworkInterfaceOutboundPublicIPAddress' {
         }
     }
 }
+
+Describe 'NetworkController - Remove-BgpLearnedRoute' {
+    Context 'networkConnections resource' {
+        It "Removes BGP learned routes and retains the statically configured routes" {
+            InModuleScope SdnDiag.NetworkController {
+                $connection = $Global:PesterOfflineTests.SdnApiResourcesByRef['/VirtualGateways/vgw-tenant-0002'].properties.networkConnections[0]
+                $result = Remove-BgpLearnedRoute -Object $connection
+                $result.properties.routes.Count | Should -Be 1
+                $result.properties.routes[0].protocol | Should -Be 'Static'
+                $result.properties.routes[0].destinationPrefix | Should -Be '172.16.10.0/24'
+            }
+        }
+
+        It "Matches the protocol value without regard to casing" {
+            InModuleScope SdnDiag.NetworkController {
+                $connection = [PSCustomObject]@{
+                    resourceRef = '/VirtualGateways/vgw-tenant-0002/networkConnections/nc-case'
+                    properties  = [PSCustomObject]@{
+                        routes = @(
+                            [PSCustomObject]@{ destinationPrefix = '10.0.0.0/24'; protocol = 'BGP' }
+                            [PSCustomObject]@{ destinationPrefix = '10.1.0.0/24'; protocol = 'bgp' }
+                            [PSCustomObject]@{ destinationPrefix = '10.2.0.0/24'; protocol = 'Bgp' }
+                            [PSCustomObject]@{ destinationPrefix = '10.3.0.0/24'; protocol = 'Static' }
+                        )
+                    }
+                }
+                $result = Remove-BgpLearnedRoute -Object $connection
+                $result.properties.routes.Count | Should -Be 1
+                $result.properties.routes[0].destinationPrefix | Should -Be '10.3.0.0/24'
+            }
+        }
+
+        It "Retains routes that do not report a protocol" {
+            InModuleScope SdnDiag.NetworkController {
+                $connection = [PSCustomObject]@{
+                    properties = [PSCustomObject]@{
+                        routes = @(
+                            [PSCustomObject]@{ destinationPrefix = '10.0.0.0/24' }
+                            [PSCustomObject]@{ destinationPrefix = '10.1.0.0/24'; protocol = 'Bgp' }
+                        )
+                    }
+                }
+                $result = Remove-BgpLearnedRoute -Object $connection
+                $result.properties.routes.Count | Should -Be 1
+                $result.properties.routes[0].destinationPrefix | Should -Be '10.0.0.0/24'
+            }
+        }
+
+        It "Serializes to an empty array when every route was learned via BGP" {
+            InModuleScope SdnDiag.NetworkController {
+                $connection = [PSCustomObject]@{
+                    properties = [PSCustomObject]@{
+                        routes = @([PSCustomObject]@{ destinationPrefix = '10.0.0.0/24'; protocol = 'Bgp' })
+                    }
+                }
+                $result = Remove-BgpLearnedRoute -Object $connection
+                $result.properties.routes.Count | Should -Be 0
+                ($result | ConvertTo-Json -Depth 10 -Compress).Contains('"routes":[]') | Should -BeTrue
+            }
+        }
+
+        It "Preserves the remaining properties of the resource" {
+            InModuleScope SdnDiag.NetworkController {
+                $connection = $Global:PesterOfflineTests.SdnApiResourcesByRef['/VirtualGateways/vgw-tenant-0002'].properties.networkConnections[0]
+                $result = Remove-BgpLearnedRoute -Object $connection
+                $result.resourceId | Should -Be 'nc-tenant-0002-ipsec'
+                $result.resourceRef | Should -Be '/VirtualGateways/vgw-tenant-0002/networkConnections/nc-tenant-0002-ipsec'
+                $result.etag | Should -Be $connection.etag
+                $result.properties.connectionType | Should -Be 'IPSec'
+                $result.properties.destinationIpAddress | Should -Be '40.40.40.10'
+            }
+        }
+
+        It "Does not modify the object supplied by the caller" {
+            InModuleScope SdnDiag.NetworkController {
+                $connection = $Global:PesterOfflineTests.SdnApiResourcesByRef['/VirtualGateways/vgw-tenant-0002'].properties.networkConnections[0]
+                $before = $connection | ConvertTo-Json -Depth 100 -Compress
+                $null = Remove-BgpLearnedRoute -Object $connection
+                ($connection | ConvertTo-Json -Depth 100 -Compress) | Should -Be $before
+            }
+        }
+
+        It "Returns the original object when there are no BGP learned routes" {
+            InModuleScope SdnDiag.NetworkController {
+                $connection = [PSCustomObject]@{
+                    properties = [PSCustomObject]@{
+                        routes = @([PSCustomObject]@{ destinationPrefix = '10.0.0.0/24'; protocol = 'Static' })
+                    }
+                }
+                $result = Remove-BgpLearnedRoute -Object $connection
+                [System.Object]::ReferenceEquals($result, $connection) | Should -BeTrue
+            }
+        }
+
+        It "Returns the original object when the resource has no routes" {
+            InModuleScope SdnDiag.NetworkController {
+                $server = $Global:PesterOfflineTests.SdnApiResourcesByRef['/servers/DVLAB-S1-N01']
+                $result = Remove-BgpLearnedRoute -Object $server
+                [System.Object]::ReferenceEquals($result, $server) | Should -BeTrue
+            }
+        }
+    }
+
+    Context 'virtualGateways resource' {
+        It "Removes BGP learned routes from networkConnections nested under the gateway" {
+            InModuleScope SdnDiag.NetworkController {
+                $gateway = $Global:PesterOfflineTests.SdnApiResourcesByRef['/VirtualGateways/vgw-tenant-0002']
+                $before = $gateway | ConvertTo-Json -Depth 100 -Compress
+                $result = Remove-BgpLearnedRoute -Object $gateway
+                $result.properties.networkConnections[0].properties.routes.Count | Should -Be 1
+                $result.properties.networkConnections[0].properties.routes[0].protocol | Should -Be 'Static'
+                ($gateway | ConvertTo-Json -Depth 100 -Compress) | Should -Be $before
+            }
+        }
+
+        It "Returns the original object when the gateway has no network connections" {
+            InModuleScope SdnDiag.NetworkController {
+                $gateway = $Global:PesterOfflineTests.SdnApiResourcesByRef['/VirtualGateways/vgw-tenant-0001']
+                $result = Remove-BgpLearnedRoute -Object $gateway
+                [System.Object]::ReferenceEquals($result, $gateway) | Should -BeTrue
+            }
+        }
+
+        It "Handles a null entry within the networkConnections array" {
+            InModuleScope SdnDiag.NetworkController {
+                $gateway = [PSCustomObject]@{
+                    resourceRef = '/VirtualGateways/vgw-tenant-0003'
+                    properties  = [PSCustomObject]@{
+                        networkConnections = @(
+                            $null
+                            [PSCustomObject]@{
+                                properties = [PSCustomObject]@{
+                                    routes = @(
+                                        [PSCustomObject]@{ destinationPrefix = '10.0.0.0/24'; protocol = 'Static' }
+                                        [PSCustomObject]@{ destinationPrefix = '10.1.0.0/24'; protocol = 'Bgp' }
+                                    )
+                                }
+                            }
+                        )
+                    }
+                }
+                $result = Remove-BgpLearnedRoute -Object $gateway
+                $result.properties.networkConnections.Count | Should -Be 2
+                $result.properties.networkConnections[0] | Should -BeNullOrEmpty
+                $result.properties.networkConnections[1].properties.routes.Count | Should -Be 1
+            }
+        }
+    }
+}
+
+Describe 'NetworkController - Set-SdnResource' {
+    It "Excludes BGP learned routes from the body of a networkConnections PUT" {
+        InModuleScope SdnDiag.NetworkController {
+            $Global:PesterPutBody = $null
+            Mock Confirm-ProvisioningStateSucceeded { return $true }
+            Mock Invoke-RestMethodWithRetry {
+                if ($null -ne $Body) {
+                    $Global:PesterPutBody = $Body
+                    return $null
+                }
+                return [PSCustomObject]@{ properties = [PSCustomObject]@{ provisioningState = 'Succeeded' } }
+            }
+
+            $connection = $Global:PesterOfflineTests.SdnApiResourcesByRef['/VirtualGateways/vgw-tenant-0002'].properties.networkConnections[0]
+            $null = Set-SdnResource -NcUri "https://dvlab-nc.dvlab.contoso.local" -ResourceRef $connection.resourceRef -Object $connection -OperationType 'Update' -Confirm:$false
+
+            # assert against the raw body so the routes array is proven to serialize as a JSON array
+            $Global:PesterPutBody.Replace(' ', '').Replace("`r", '').Replace("`n", '') | Should -BeLike '*"routes":`[`{*'
+            $body = $Global:PesterPutBody | ConvertFrom-Json
+            $body.properties.routes.Count | Should -Be 1
+            $body.properties.routes[0].protocol | Should -Be 'Static'
+            $body.properties.routes[0].destinationPrefix | Should -Be '172.16.10.0/24'
+        }
+    }
+
+    It "Sends an empty routes array when every route was learned via BGP" {
+        InModuleScope SdnDiag.NetworkController {
+            $Global:PesterPutBody = $null
+            Mock Confirm-ProvisioningStateSucceeded { return $true }
+            Mock Invoke-RestMethodWithRetry {
+                if ($null -ne $Body) {
+                    $Global:PesterPutBody = $Body
+                    return $null
+                }
+                return [PSCustomObject]@{ properties = [PSCustomObject]@{ provisioningState = 'Succeeded' } }
+            }
+
+            $connection = [PSCustomObject]@{
+                resourceId  = 'nc-tenant-0002-allbgp'
+                resourceRef = '/VirtualGateways/vgw-tenant-0002/networkConnections/nc-tenant-0002-allbgp'
+                properties  = [PSCustomObject]@{
+                    routes = @([PSCustomObject]@{ destinationPrefix = '172.16.20.0/24'; protocol = 'BGP' })
+                }
+            }
+            $null = Set-SdnResource -NcUri "https://dvlab-nc.dvlab.contoso.local" -ResourceRef $connection.resourceRef -Object $connection -OperationType 'Update' -Confirm:$false
+
+            $Global:PesterPutBody.Replace(' ', '').Replace("`r", '').Replace("`n", '').Contains('"routes":[]') | Should -BeTrue
+        }
+    }
+
+    It "Excludes BGP learned routes when the resource is targeted by name and id" {
+        InModuleScope SdnDiag.NetworkController {
+            $Global:PesterPutBody = $null
+            Mock Confirm-ProvisioningStateSucceeded { return $true }
+            Mock Invoke-RestMethodWithRetry {
+                if ($null -ne $Body) {
+                    $Global:PesterPutBody = $Body
+                    return $null
+                }
+                return [PSCustomObject]@{ properties = [PSCustomObject]@{ provisioningState = 'Succeeded' } }
+            }
+
+            $gateway = $Global:PesterOfflineTests.SdnApiResourcesByRef['/VirtualGateways/vgw-tenant-0002']
+            $null = Set-SdnResource -NcUri "https://dvlab-nc.dvlab.contoso.local" -Resource 'VirtualGateways' -ResourceId $gateway.resourceId -Object $gateway -OperationType 'Update' -Confirm:$false
+
+            $body = $Global:PesterPutBody | ConvertFrom-Json
+            $body.properties.networkConnections[0].properties.routes.Count | Should -Be 1
+            $body.properties.networkConnections[0].properties.routes[0].protocol | Should -Be 'Static'
+        }
+    }
+
+    It "Excludes BGP learned routes nested under a virtualGateways PUT" {
+        InModuleScope SdnDiag.NetworkController {
+            $Global:PesterPutBody = $null
+            Mock Confirm-ProvisioningStateSucceeded { return $true }
+            Mock Invoke-RestMethodWithRetry {
+                if ($null -ne $Body) {
+                    $Global:PesterPutBody = $Body
+                    return $null
+                }
+                return [PSCustomObject]@{ properties = [PSCustomObject]@{ provisioningState = 'Succeeded' } }
+            }
+
+            $gateway = $Global:PesterOfflineTests.SdnApiResourcesByRef['/VirtualGateways/vgw-tenant-0002']
+            $null = Set-SdnResource -NcUri "https://dvlab-nc.dvlab.contoso.local" -ResourceRef $gateway.resourceRef -Object $gateway -OperationType 'Update' -Confirm:$false
+
+            $body = $Global:PesterPutBody | ConvertFrom-Json
+            $body.properties.networkConnections[0].properties.routes.Count | Should -Be 1
+            $body.properties.networkConnections[0].properties.routes[0].protocol | Should -Be 'Static'
+        }
+    }
+
+    It "Leaves the routes array untouched for resources that are not gateway related" {
+        InModuleScope SdnDiag.NetworkController {
+            $Global:PesterPutBody = $null
+            Mock Confirm-ProvisioningStateSucceeded { return $true }
+            Mock Invoke-RestMethodWithRetry {
+                if ($null -ne $Body) {
+                    $Global:PesterPutBody = $Body
+                    return $null
+                }
+                return [PSCustomObject]@{ properties = [PSCustomObject]@{ provisioningState = 'Succeeded' } }
+            }
+
+            $routeTable = [PSCustomObject]@{
+                resourceId  = 'rt-tenant-0001'
+                resourceRef = '/routeTables/rt-tenant-0001'
+                properties  = [PSCustomObject]@{
+                    routes = @(
+                        [PSCustomObject]@{ destinationPrefix = '10.0.0.0/24'; protocol = 'Static' }
+                        [PSCustomObject]@{ destinationPrefix = '10.1.0.0/24'; protocol = 'Bgp' }
+                    )
+                }
+            }
+            $null = Set-SdnResource -NcUri "https://dvlab-nc.dvlab.contoso.local" -ResourceRef $routeTable.resourceRef -Object $routeTable -OperationType 'Update' -Confirm:$false
+
+            $body = $Global:PesterPutBody | ConvertFrom-Json
+            $body.properties.routes.Count | Should -Be 2
+        }
+    }
+}

--- a/tests/offline/Utilities.Tests.ps1
+++ b/tests/offline/Utilities.Tests.ps1
@@ -177,3 +177,68 @@ Describe 'Utilities - IP Address Validation' {
         }
     }
 }
+
+Describe 'Utilities - Object Helpers' {
+    Context 'Copy-ObjectWithPropertyOverride' {
+        It "Replaces the value of the specified property" {
+            InModuleScope SdnDiagnostics {
+                $source = [PSCustomObject]@{ name = 'original'; value = 1 }
+                $result = Copy-ObjectWithPropertyOverride -Object $source -PropertyOverride @{ 'name' = 'updated' }
+                $result.name | Should -Be 'updated'
+            }
+        }
+
+        It "Leaves the properties that were not overridden unchanged" {
+            InModuleScope SdnDiagnostics {
+                $source = [PSCustomObject]@{ name = 'original'; value = 1 }
+                $result = Copy-ObjectWithPropertyOverride -Object $source -PropertyOverride @{ 'name' = 'updated' }
+                $result.value | Should -Be 1
+            }
+        }
+
+        It "Matches property names without regard to casing" {
+            InModuleScope SdnDiagnostics {
+                $source = [PSCustomObject]@{ Name = 'original' }
+                $result = Copy-ObjectWithPropertyOverride -Object $source -PropertyOverride @{ 'NAME' = 'updated' }
+                $result.Name | Should -Be 'updated'
+            }
+        }
+
+        It "Does not modify the object supplied by the caller" {
+            InModuleScope SdnDiagnostics {
+                $source = [PSCustomObject]@{ name = 'original' }
+                $null = Copy-ObjectWithPropertyOverride -Object $source -PropertyOverride @{ 'name' = 'updated' }
+                $source.name | Should -Be 'original'
+            }
+        }
+
+        It "Ignores override entries for properties that do not exist on the object" {
+            InModuleScope SdnDiagnostics {
+                $source = [PSCustomObject]@{ name = 'original' }
+                $result = Copy-ObjectWithPropertyOverride -Object $source -PropertyOverride @{ 'missing' = 'value' }
+                $result.PSObject.Properties.Name | Should -Be 'name'
+                $result.name | Should -Be 'original'
+            }
+        }
+
+        It "Applies an override that sets the property value to null" {
+            InModuleScope SdnDiagnostics {
+                $source = [PSCustomObject]@{ name = 'original'; value = 1 }
+                $result = Copy-ObjectWithPropertyOverride -Object $source -PropertyOverride @{ 'name' = $null }
+                $result.PSObject.Properties.Name | Should -Contain 'name'
+                $result.name | Should -BeNullOrEmpty
+                $result.value | Should -Be 1
+            }
+        }
+
+        It "Throws when more than one override key matches the same property" {
+            InModuleScope SdnDiagnostics {
+                $source = [PSCustomObject]@{ name = 'original' }
+                $override = [System.Collections.Hashtable]::new()
+                $override.Add('name', 'first')
+                $override.Add('NAME', 'second')
+                { Copy-ObjectWithPropertyOverride -Object $source -PropertyOverride $override } | Should -Throw
+            }
+        }
+    }
+}

--- a/tests/offline/data/SdnApiResources/virtualGateways.json
+++ b/tests/offline/data/SdnApiResources/virtualGateways.json
@@ -13,6 +13,56 @@
       "resourceRef": "/VirtualGateways/vgw-tenant-0001",
       "etag": "W/\"vgw-etag-0001\"",
       "instanceId": "vgw-inst-0001-aaaa-bbbb-cccccccccccc"
+    },
+    {
+      "resourceId": "vgw-tenant-0002",
+      "properties": {
+        "gatewaySubnets": [],
+        "gatewayPool": {
+          "resourceRef": "/GatewayPools/default"
+        },
+        "provisioningState": "Succeeded",
+        "networkConnections": [
+          {
+            "resourceId": "nc-tenant-0002-ipsec",
+            "properties": {
+              "connectionType": "IPSec",
+              "connectionState": "Connected",
+              "connectionStatus": "Enabled",
+              "outboundKiloBitsPerSecond": 200000,
+              "inboundKiloBitsPerSecond": 200000,
+              "destinationIpAddress": "40.40.40.10",
+              "routes": [
+                {
+                  "destinationPrefix": "172.16.10.0/24",
+                  "nextHop": "172.16.10.1",
+                  "metric": 10,
+                  "protocol": "Static"
+                },
+                {
+                  "destinationPrefix": "172.16.20.0/24",
+                  "nextHop": "172.16.20.1",
+                  "metric": 10,
+                  "protocol": "BGP"
+                },
+                {
+                  "destinationPrefix": "172.16.30.0/24",
+                  "nextHop": "172.16.30.1",
+                  "metric": 10,
+                  "protocol": "bgp"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            },
+            "resourceRef": "/VirtualGateways/vgw-tenant-0002/networkConnections/nc-tenant-0002-ipsec",
+            "etag": "W/\"nc-etag-0002\"",
+            "instanceId": "nc-inst-0002-aaaa-bbbb-cccccccccccc"
+          }
+        ]
+      },
+      "resourceRef": "/VirtualGateways/vgw-tenant-0002",
+      "etag": "W/\"vgw-etag-0002\"",
+      "instanceId": "vgw-inst-0002-aaaa-bbbb-cccccccccccc"
     }
   ],
   "nextLink": ""


### PR DESCRIPTION
## Problem

The `routes` array of a `networkConnections` resource (`/virtualGateways/{id}/networkConnections/{id}`) contains **both** the statically configured routes and the routes dynamically learned from the remote peer via BGP.

Per [MS-NCNBI](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-ncnbi/41233345-496d-43e7-b58c-2d5b6a28757d), `routes.protocol` is a **read-only** property that indicates how the route was added (`Static` or `BGP`).

This creates a trap for the standard GET/modify/PUT pattern. When a caller retrieves a network connection, changes an unrelated property, and PUTs the object back, the BGP learned routes are still sitting in the `routes` array. Network Controller then persists them as **static** routes. Once static, those routes can never be withdrawn when the BGP peer stops advertising them, which leaves stale routing state on the connection.

## Fix

`Set-SdnResource` now removes any route reporting `protocol` of `bgp` from the PUT body when the target resource is a `virtualGateways` or `networkConnections` resource.

`networkConnections` are returned inline when operating against the parent `virtualGateway`, so the same conversion can happen through the parent resource. Nested connections are filtered as well.

Non-gateway resources are untouched, so there is no behavior change for any other resource type.

## Changes

**`src/modules/SdnDiag.NetworkController.psm1`**
- `Remove-BgpLearnedRoute` (private) - returns a copy of a `virtualGateways`/`networkConnections` resource with every `properties.routes` entry whose `protocol` is `bgp` removed. Matching is case-insensitive and tolerates surrounding whitespace. Recurses into `properties.networkConnections`. Returns the original object reference when nothing needed to be removed.
- `Select-StaticRoute` (private) - the array filter. Returns `$null` when no BGP routes were present so the caller can skip the copy entirely.
- `Set-SdnResource` - applies the filter on the PUT path before `Remove-PropertiesFromObject` and JSON serialization.

**`src/modules/SdnDiag.Utilities.psm1`**
- `Copy-ObjectWithPropertyOverride` (private) - shallow copy with case-insensitive property replacement, alongside the existing `Remove-PropertiesFromObject`. This is what keeps the object supplied by the caller from being mutated.

## Testing

82/82 offline Pester tests pass (21 new). New coverage:

- BGP routes dropped, static routes retained
- Mixed protocol casing (`BGP`, `bgp`, `Bgp`)
- Routes that do not report a protocol are conservatively retained
- An all-BGP array serializes to `[]`, asserted against the **raw** PUT body rather than the decoded object
- A single retained route still serializes as a JSON array, not a scalar
- The caller's object is never mutated, verified by comparing full before/after serialization
- `null` entries within a `networkConnections` array
- Both the `-ResourceRef` and `-Resource`/`-ResourceId` parameter sets
- Non-gateway resources are left alone

Mock data adds `vgw-tenant-0002` with a network connection carrying both static and BGP learned routes. The existing `vgw-tenant-0001` is unchanged so the empty-connections case stays covered.

The changed code paths were also validated directly on **Windows PowerShell 5.1** and **PowerShell 7** to confirm identical array and JSON serialization semantics, since the manifest declares `PowerShellVersion = '5.1'`.

## Notes for reviewers

Two defects were caught during review of this change and are already fixed here:

1. `Remove-BgpLearnedRoute -Object` was `Mandatory` without `[AllowNull()]`, so a `$null` element inside a `networkConnections` array would have thrown at parameter binding instead of reaching the null guard. A regression test covers this.
2. `Copy-ObjectWithPropertyOverride` silently picked an arbitrary value when a case-sensitive hashtable contained both `name` and `NAME`, and picked *differently* on 5.1 than on 7. It now throws on ambiguous keys.
